### PR TITLE
Adding recaptcha to every page?

### DIFF
--- a/app/views/layouts/_meta_tags.html.erb
+++ b/app/views/layouts/_meta_tags.html.erb
@@ -61,6 +61,13 @@ g.type='text/javascript'; g.async=true; g.src='https://cdn.matomo.cloud/commitch
 <% end %>
 <% end %>
 <%= yield :recaptcha_js %>
+<script src="https://www.recaptcha.net/recaptcha/enterprise.js?render=<%= ENV['RECAPTCHA_SITE_KEY'] %>"></script>
+<script>
+
+  grecaptcha.enterprise.ready(() => {
+      grecaptcha.enterprise.execute("<%=ENV['RECAPTCHA_SITE_KEY']%>", {action:'page_load'})
+  })
+</script>
 
 
 <%= csrf_meta_tags %>


### PR DESCRIPTION
A recommendation for improving the Recaptcha algorithm on your site to have [recaptcha execute on every page load](https://cloud.google.com/recaptcha-enterprise/docs/faq#id_like_to_use_the_score_from_to_show_a_challenge_checkbox_widget_how_can_i_do_this). I'm not a huge fan of this but if it reduces our false rejections, we may want to consider it. This draft PR begins the work of doing this but I have no idea if we ever really want to merge this.