### PR TITLE
Use has_scope for the ObjectEventsController queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -175,3 +175,5 @@ gem 'ruby2_keywords' # needed because we're backporting code from Rails 6.2
 gem 'securerandom' # needed becuase we're on a pre-2.5 Ruby version
 
 gem 'fx',  git: 'https://github.com/teoljungberg/fx.git', ref: '946cdccbd12333deb8f4566c9852b49c0231a618'
+
+gem 'has_scope'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,9 @@ GEM
       grape (>= 0.12.0)
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
+    has_scope (0.7.2)
+      actionpack (>= 4.1)
+      activesupport (>= 4.1)
     hashie (4.0.0)
     heroku_rails_deflate (1.0.3)
       actionpack (>= 3.2.13)
@@ -528,6 +531,7 @@ DEPENDENCIES
   grape_logging
   grape_url_validator
   hamster
+  has_scope
   hashie
   heroku_rails_deflate
   hiredis (~> 0.6.0)

--- a/app/controllers/api_new/object_events_controller.rb
+++ b/app/controllers/api_new/object_events_controller.rb
@@ -10,11 +10,13 @@ module ApiNew
 		include Controllers::Nonprofit::Authorization
 		before_action :authenticate_nonprofit_user!
 
+		has_scope :event_entity
+		has_scope :event_types, type: :array
 		# Gets the nonprofits supporters
 		# If not logged in, causes a 401 error
 		def index
-			@object_events = current_nonprofit
-				.associated_object_events.query(params.slice(:event_entity, :event_types))
+			@object_events = apply_scopes(current_nonprofit
+				.associated_object_events)
 				.order('created_at DESC').page(params[:page]).per(params[:per])
 		end
 	end

--- a/app/models/object_event.rb
+++ b/app/models/object_event.rb
@@ -9,23 +9,13 @@ class ObjectEvent < ApplicationRecord
   belongs_to :nonprofit
 
   concerning :Query do
+
     class_methods do 
-      def query(params={})
-        result = where("TRUE") # just return everything you were previously going to return
-        if (params[:event_entity])
-          result = result.event_entity(params[:event_entity])
-        elsif (params[:event_types])
-          result = result.event_types(*params[:event_types])
-        end
-
-        result
-      end
-
       def event_entity(event_entity_houid)
         where(event_entity_houid:event_entity_houid)
       end
 
-      def event_types(*types)
+      def event_types(types)
         where('event_type IN (?)', types)
       end
     end

--- a/spec/requests/api_new/object_events_controller_request_spec.rb
+++ b/spec/requests/api_new/object_events_controller_request_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+require 'rails_helper'
+
+RSpec.describe ApiNew::ObjectEventsController, type: :request do
+  let(:user) { create(:user) }
+  let(:simple_object_with_parent) { create(:simple_object_with_parent)}
+    before(:each) { 
+      simple_object_with_parent.publish_created
+      simple_object_with_parent.publish_updated
+    }
+	
+
+	def index_base_path(nonprofit_id)
+		"/api_new/nonprofits/#{nonprofit_id}/object_events"
+	end
+
+	def index_base_url(nonprofit_id, _event_id)
+		"http://www.example.com#{index_base_path(nonprofit_id)}"
+	end
+
+  let(:nonprofit) { simple_object_with_parent.nonprofit}
+
+	describe 'GET /' do
+		context 'with nonprofit user' do
+			subject(:json) do
+				JSON::parse(response.body)
+			end
+
+			before(:each) do
+				user.roles.create(name: 'nonprofit_associate', host: nonprofit)
+				sign_in user
+			end
+  
+         
+    
+      context 'empty query' do
+        before(:each) do
+          get index_base_path(nonprofit.houid)
+        end
+
+
+        it {
+          expect(json['total_count']).to eq 2
+        }
+      end
+    
+      context 'with event_entity' do
+        context 'and entity doesnt exist' do
+          before(:each) do
+            get index_base_path(nonprofit.houid), event_entity: 'fake_entity'
+          end
+          
+          it {
+            expect(json['total_count']).to eq 0
+          }
+        end
+
+        context 'and entity does exist' do 
+          before(:each) do
+            get index_base_path(nonprofit.houid), event_entity: simple_object_with_parent.houid
+          end
+          
+          it {
+            expect(json['total_count']).to eq 2
+          }
+        end
+        
+      end
+    
+      context 'with event_types' do
+        context 'and event_types doesnt exist' do
+          before(:each) do
+            get index_base_path(nonprofit.houid), event_types: ['soennoet.come']
+          end
+          
+          it {
+            expect(json['total_count']).to eq 0
+          }
+        end
+
+        context 'and event_types does exist' do
+          before(:each) do
+            get index_base_path(nonprofit.houid), event_types: ['simple_object.created']
+          end
+      
+          it {
+            expect(json['total_count']).to eq 1
+          }
+        end
+
+        context 'and multiple event_types do exist' do
+          before(:each) do
+            get index_base_path(nonprofit.houid), event_entity: ['simple_object.created', 'simple_object.updated']
+          end
+      
+          it {
+            expect(json['total_count']).to eq 2
+          }
+        end
+        
+      end
+    
+      
+      
+		end
+
+		context 'with no user' do
+			it 'returns unauthorized' do
+				get index_base_path(nonprofit.houid)
+				expect(response).to have_http_status(:unauthorized)
+			end
+		end
+	end
+end


### PR DESCRIPTION
Added [has_scope](https://github.com/heartcombo/has_scope) to assist with parsing the queries used by ObjectEventController. I'm not sure I LOVE the code, it's not bad.﻿ 
