### PR TITLE
Simplify dispute specs by using using a common amount

### DIFF
--- a/spec/fixtures/stripe_webhooks/charge.dispute.closed-won.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.closed-won.json
@@ -7,13 +7,13 @@
     "object": {
       "id": "dp_15RsQX2eZvKYlo2C0ERTYUIA",
       "object": "dispute",
-      "amount": 22500,
+      "amount": 80000,
       "balance_transaction": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
       "balance_transactions": [
         {
           "id": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
           "object": "balance_transaction",
-          "amount": -22500,
+          "amount": -80000,
           "available_on": 1565008160,
           "created": 1565008160,
           "currency": "usd",
@@ -29,7 +29,7 @@
               "type": "stripe_fee"
             }
           ],
-          "net": -24000,
+          "net": -81500,
           "source": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
           "sourced_transfers": {
             "object": "list",
@@ -44,7 +44,7 @@
         {
           "id": "txn_1Y71X0BCJIIhvMWmMmtTY4m1",
           "object": "balance_transaction",
-          "amount": 22500,
+          "amount": 80000,
           "available_on": 1572381790,
           "created": 1572381790,
           "currency": "usd",

--- a/spec/fixtures/stripe_webhooks/charge.dispute.funds_reinstated.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.funds_reinstated.json
@@ -7,13 +7,13 @@
     "object": {
       "id": "dp_15RsQX2eZvKYlo2C0ERTYUIA",
       "object": "dispute",
-      "amount": 22500,
+      "amount": 80000,
       "balance_transaction": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
       "balance_transactions": [
         {
           "id": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
           "object": "balance_transaction",
-          "amount": -22500,
+          "amount": -80000,
           "available_on": 1567603760,
           "created": 1567603760,
           "currency": "usd",
@@ -29,7 +29,7 @@
               "type": "stripe_fee"
             }
           ],
-          "net": -24000,
+          "net": -81500,
           "source": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
           "sourced_transfers": {
             "object": "list",
@@ -44,7 +44,7 @@
         {
           "id": "txn_1Y71X0BCJIIhvMWmMmtTY4m1",
           "object": "balance_transaction",
-          "amount": 22500,
+          "amount": 80000,
           "available_on": 1574977390,
           "created": 1574977390,
           "currency": "usd",

--- a/spec/fixtures/stripe_webhooks/charge.dispute.updated.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.updated.json
@@ -7,13 +7,13 @@
     "object": {
       "id": "dp_15RsQX2eZvKYlo2C0ERTYUIA",
       "object": "dispute",
-      "amount": 22500,
+      "amount": 80000,
       "balance_transaction": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
       "balance_transactions": [
         {
           "id": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
           "object": "balance_transaction",
-          "amount": -22500,
+          "amount": -80000,
           "available_on": 1567603760,
           "created": 1567603760,
           "currency": "usd",
@@ -29,7 +29,7 @@
               "type": "stripe_fee"
             }
           ],
-          "net": -24000,
+          "net": -81500,
           "source": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
           "sourced_transfers": {
             "object": "list",
@@ -44,7 +44,7 @@
         {
           "id": "txn_1Y71X0BCJIIhvMWmMmtTY4m1",
           "object": "balance_transaction",
-          "amount": 22500,
+          "amount": 80000,
           "available_on": 1574977390,
           "created": 1574977390,
           "currency": "usd",

--- a/spec/mailers/dispute_mailer_spec.rb
+++ b/spec/mailers/dispute_mailer_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe DisputeMailer, :type => :mailer do
       stripe_charge_id: 'ch_1Y7vFYBCJIIhvMWmsdRJWSw5', nonprofit: nonprofit, payment:force_create(:payment,
          supporter:supporter,
         nonprofit: nonprofit,
-        gross_amount: 22500))}
+        gross_amount: 80000))}
   
     let(:obj) { StripeDispute.create(object:json) }
     let(:dispute) { obj.dispute }

--- a/spec/support/contexts/disputes_context.rb
+++ b/spec/support/contexts/disputes_context.rb
@@ -275,7 +275,7 @@ RSpec.shared_context :dispute_funds_reinstated_context do
     stripe_charge_id: 'ch_1Y7vFYBCJIIhvMWmsdRJWSw5', nonprofit: nonprofit, payment:force_create(:payment,
        supporter:supporter,
       nonprofit: nonprofit,
-      gross_amount: 22500))}
+      gross_amount: 80000))}
 end
 
 RSpec.shared_context :dispute_funds_reinstated_specs do
@@ -298,8 +298,8 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
     expect(obj.net_change).to eq 0
   end
 
-  it 'has an amount of 22500' do
-    expect(obj.amount).to eq 22500
+  it 'has an amount of 80000' do
+    expect(obj.amount).to eq 80000
   end
 
   it 'has a correct charge id ' do 
@@ -317,7 +317,7 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   describe "dispute" do
     subject { dispute }
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq 22500 }
+    specify { expect(subject.gross_amount).to eq 80000 }
     specify { expect(subject.status).to eq "under_review" }
     specify { expect(subject.reason).to eq 'credit_not_processed' }
     specify { expect(subject.started_at).to eq Time.at(1567603760)}
@@ -330,7 +330,7 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   describe 'has a withdrawal_transaction' do
     subject{ withdrawal_transaction }
     specify {  expect(subject).to be_persisted }
-    specify {  expect(subject.gross_amount).to eq -22500 }
+    specify {  expect(subject.gross_amount).to eq -80000 }
     specify {  expect(subject.fee_total).to eq -1500 }
     specify {  expect(subject.stripe_transaction_id).to eq 'txn_1Y75JVBCJIIhvMWmsnGK1JLD' }
     specify { expect(subject.date).to eq DateTime.new(2019,9,4,13,29,20)}
@@ -340,9 +340,9 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   describe 'has a withdrawal_payment' do
     subject { withdrawal_payment}
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq -22500}
+    specify { expect(subject.gross_amount).to eq -80000}
     specify { expect(subject.fee_total).to eq -1500}
-    specify { expect(subject.net_amount).to eq -24000}
+    specify { expect(subject.net_amount).to eq -81500}
     specify { expect(subject.kind).to eq 'Dispute'}
     specify { expect(subject.nonprofit).to eq supporter.nonprofit}
     specify { expect(subject.date).to eq DateTime.new(2019,9,4,13,29,20)}
@@ -352,7 +352,7 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   describe 'has a reinstated_transaction' do
     subject{ reinstated_transaction }
     specify {  expect(subject).to be_persisted }
-    specify {  expect(subject.gross_amount).to eq 22500 }
+    specify {  expect(subject.gross_amount).to eq 80000 }
     specify {  expect(subject.fee_total).to eq 1500 }
     specify { expect(subject.net_amount).to eq 24000}
     specify {  expect(subject.stripe_transaction_id).to eq 'txn_1Y71X0BCJIIhvMWmMmtTY4m1' }
@@ -363,7 +363,7 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   describe 'has a reinstated_payment' do
     subject { reinstated_payment}
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq 22500}
+    specify { expect(subject.gross_amount).to eq 80000}
     specify { expect(subject.fee_total).to eq 1500}
     specify { expect(subject.kind).to eq 'DisputeReversed'}
     specify { expect(subject.nonprofit).to eq supporter.nonprofit}
@@ -477,7 +477,7 @@ RSpec.shared_context :dispute_won_context do
     stripe_charge_id: 'ch_1Y7vFYBCJIIhvMWmsdRJWSw5', nonprofit: nonprofit, payment:force_create(:payment,
        supporter:supporter,
       nonprofit: nonprofit,
-      gross_amount: 22500))}
+      gross_amount: 80000))}
 end
 
 RSpec.shared_context :dispute_won_specs do
@@ -500,8 +500,8 @@ RSpec.shared_context :dispute_won_specs do
     expect(obj.net_change).to eq 0
   end
 
-  it 'has an amount of 22500' do
-    expect(obj.amount).to eq 22500
+  it 'has an amount of 80000' do
+    expect(obj.amount).to eq 80000
   end
 
   it 'has a correct charge id ' do 
@@ -519,7 +519,7 @@ RSpec.shared_context :dispute_won_specs do
   describe "dispute" do
     subject { dispute }
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq 22500 }
+    specify { expect(subject.gross_amount).to eq 80000 }
     specify { expect(subject.status).to eq "won" }
     specify { expect(subject.reason).to eq 'credit_not_processed' }
     specify { expect(subject.started_at).to eq Time.at(1565008160) }
@@ -532,7 +532,7 @@ RSpec.shared_context :dispute_won_specs do
   describe 'has a withdrawal_transaction' do
     subject{ withdrawal_transaction }
     specify {  expect(subject).to be_persisted }
-    specify {  expect(subject.gross_amount).to eq -22500 }
+    specify {  expect(subject.gross_amount).to eq -80000 }
     specify {  expect(subject.fee_total).to eq -1500 }
     specify {  expect(subject.stripe_transaction_id).to eq 'txn_1Y75JVBCJIIhvMWmsnGK1JLD' }
     specify { expect(subject.date).to eq DateTime.new(2019,8,5,12,29,20)}
@@ -542,9 +542,9 @@ RSpec.shared_context :dispute_won_specs do
   describe 'has a withdrawal_payment' do
     subject { withdrawal_payment}
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq -22500}
+    specify { expect(subject.gross_amount).to eq -80000}
     specify { expect(subject.fee_total).to eq -1500}
-    specify { expect(subject.net_amount).to eq -24000 }
+    specify { expect(subject.net_amount).to eq -81500 }
     specify { expect(subject.kind).to eq 'Dispute'}
     specify { expect(subject.nonprofit).to eq supporter.nonprofit}
     specify { expect(subject.date).to eq DateTime.new(2019,8,5,12,29,20)}
@@ -554,7 +554,7 @@ RSpec.shared_context :dispute_won_specs do
   describe 'has a reinstated_transaction' do
     subject{ reinstated_transaction }
     specify {  expect(subject).to be_persisted }
-    specify {  expect(subject.gross_amount).to eq 22500 }
+    specify {  expect(subject.gross_amount).to eq 80000 }
     specify {  expect(subject.fee_total).to eq 1500 }
     specify {  expect(subject.stripe_transaction_id).to eq 'txn_1Y71X0BCJIIhvMWmMmtTY4m1' }
     specify { expect(subject.date).to eq DateTime.new(2019,10,29,20,43,10)}
@@ -564,7 +564,7 @@ RSpec.shared_context :dispute_won_specs do
   describe 'has a reinstated_payment' do
     subject { reinstated_payment}
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq 22500}
+    specify { expect(subject.gross_amount).to eq 80000}
     specify { expect(subject.fee_total).to eq 1500}
     specify { expect(subject.net_amount).to eq 24000 }
     specify { expect(subject.kind).to eq 'DisputeReversed'}


### PR DESCRIPTION
Previously, some of our disputes examples had different amounts. This makes testing﻿ kind of difficult becuase we have to remember which disputes had which amounts for different situations. This change normalizes all of the dispute amounts.
