### PR TITLE
Add spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,8 @@ group :development, :ci, :test do
   gem 'simplecov', '~> 0.16.1', require: false
   gem 'byebug'
   gem 'shoulda-matchers'
+  gem 'spring'
+  gem 'spring-commands-rspec'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,9 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     sixarm_ruby_unaccent (1.2.0)
+    spring (2.1.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -558,6 +561,8 @@ DEPENDENCIES
   securerandom
   shoulda-matchers
   simplecov (~> 0.16.1)
+  spring
+  spring-commands-rspec
   stripe (~> 4)
   stripe-ruby-mock (~> 2.5.1)
   table_print

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/rspec
+++ b/bin/rspec
@@ -4,6 +4,5 @@ begin
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
-APP_PATH = File.expand_path('../../config/application', __FILE__)
-require_relative '../config/boot'
-require 'rails/commands'
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/setup
+++ b/bin/setup
@@ -38,7 +38,7 @@ FileUtils.chdir APP_ROOT do
   end
 
   puts "\n== Preparing database =="
-  system "bin/rake db:setup"
+  system "bin/rake db:create db:setup"
 
   puts "\n== Removing old logs and tempfiles =="
   system "rm -f log/*"

--- a/bin/setup
+++ b/bin/setup
@@ -38,8 +38,7 @@ FileUtils.chdir APP_ROOT do
   end
 
   puts "\n== Preparing database =="
-  system "bin/rake db:create RAILS_ENV=test"
-  system "bin/rake db:create db:setup"
+  system "bundle exec rake db:setup"
 
   puts "\n== Removing old logs and tempfiles =="
   system "rm -f log/*"

--- a/bin/setup
+++ b/bin/setup
@@ -38,6 +38,7 @@ FileUtils.chdir APP_ROOT do
   end
 
   puts "\n== Preparing database =="
+  system "bin/rake db:create RAILS_ENV=test"
   system "bin/rake db:create db:setup"
 
   puts "\n== Removing old logs and tempfiles =="

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# This file loads Spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
+  end
+end


### PR DESCRIPTION
Consistent with the recommendations in Testing Rails, we can add spring to speed up loading for tests and local development. Spring keeps some of the initially loaded Rails code in memory so there's a shorter startup time on a test suite.

To use, call rails, rake and rspec as `bin/rails`, `bin/rake` and `bin/rspec`. In some rare cases, you might have to run `bin/spring` with one it's options to do cleanup if it gets confused on changes.
