### PR TITLE
Card#stripe_card works even if Card#stripe_customer wasn't called first

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -58,7 +58,7 @@ class Card < ActiveRecord::Base
 	end
 
 	def stripe_card
-		@stripe_card ||= @stripe_customer.sources.retrieve(stripe_card_id)
+		@stripe_card ||= stripe_customer.sources.retrieve(stripe_card_id)
 	end
 
 


### PR DESCRIPTION
There was a bug in Card that required `#stripe_customer` to be called first if you ever wanted `#stripe_card` to work. This corrects it so either calling order is fine.
