### PR TITLE
Add helper methods for using StripeMock

### DIFF
--- a/spec/api/houdini/nonprofit_spec.rb
+++ b/spec/api/houdini/nonprofit_spec.rb
@@ -132,7 +132,7 @@ describe Houdini::V1::Nonprofit, :type => :request do
     end
 
     it "succeeds" do
-      StripeMock.start
+      StripeMockHelper.start
       force_create(:nonprofit, slug: "n", state_code_slug: "wi", city_slug: "appleton")
       input = {
           nonprofit: {name: "n", state_code: "WI", city: "appleton", zip_code: 54915, url: 'www.cs.c', website: 'www.cs.c'},
@@ -182,7 +182,7 @@ describe Houdini::V1::Nonprofit, :type => :request do
       expect(our_np.roles.nonprofit_admins.count).to eq 1
       expect(our_np.roles.nonprofit_admins.first.user.attributes).to eq expected_user
 
-      StripeMock.stop
+      StripeMockHelper.stop
     end
 
 

--- a/spec/lib/cancel_billing_subscriptions_spec.rb
+++ b/spec/lib/cancel_billing_subscriptions_spec.rb
@@ -3,16 +3,12 @@ require 'rails_helper'
 require 'stripe_mock'
 
 describe CancelBillingSubscription do
-  let(:stripe_helper) { StripeMock.create_test_helper }
-  before(:each) {
-    StripeMock.start
-    @card_token = StripeMock.generate_card_token(last4: '9191', exp_year:2011)
-    @np = force_create(:nonprofit)
-
-
-
-  }
-  after {StripeMock.stop}
+  around(:each) do |example|
+    StripeMockHelper.mock do
+      @card_token = StripeMock.generate_card_token(last4: '9191', exp_year:2011)
+      @np = force_create(:nonprofit)
+    end
+  end
 
   describe 'parameter validation' do
     it 'without db' do
@@ -58,7 +54,7 @@ describe CancelBillingSubscription do
     before(:each){
       bp = create(:billing_plan, amount: 133333, percentage_fee: 0.33, tier: 1, name: "fake plan")
       @stripe_customer = Stripe::Customer.create(currency:'usd')
-      @plan = stripe_helper.create_plan(id: 'test_str_plan', amount:0, currency: 'usd', interval: 'year', name: 'test PLan')
+      @plan = StripeMockHelper.stripe_helper.create_plan(id: 'test_str_plan', amount:0, currency: 'usd', interval: 'year', name: 'test PLan')
 
       @original_str_subscription = @stripe_customer.subscriptions.create(:plan => @plan.id)
 

--- a/spec/lib/insert/insert_bank_account_spec.rb
+++ b/spec/lib/insert/insert_bank_account_spec.rb
@@ -2,15 +2,15 @@
 require 'rails_helper'
 
 describe InsertBankAccount do
-  let(:stripe_helper) { StripeMock.create_test_helper }
-  before(:each) {
-    Timecop.freeze(2020,5,4)
-    StripeMock.start
-  }
-  after(:each) {
-    StripeMock.stop
-    Timecop.return
-  }
+  
+  around(:each) do |example|
+    Timecop.freeze(2020,5,4) do
+      StripeMockHelper.mock do
+        example.run
+      end
+    end
+    
+  end
 
   let(:nonprofit) {force_create(:nonprofit) }
   let(:user) { force_create(:user, :email => 'x@example.com')}

--- a/spec/lib/insert/insert_card_spec.rb
+++ b/spec/lib/insert/insert_card_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe InsertCard do
   describe'.with_stripe' do
 
-  let(:stripe_helper) { StripeMock.create_test_helper }
 
   let(:stripe_card_token) { StripeMock.generate_card_token(last4: '9191', exp_year:2011)}
   let(:default_card_attribs) {
@@ -31,9 +30,9 @@ describe InsertCard do
 
   around(:each) {|example|
     Timecop.freeze(2020, 5, 4) do
-      StripeMock.start
+      StripeMockHelper.mock do
         example.run
-      StripeMock.stop
+      end
     end
   }
 

--- a/spec/lib/insert/insert_payout_spec.rb
+++ b/spec/lib/insert/insert_payout_spec.rb
@@ -55,13 +55,12 @@ describe InsertPayout do
     end
 
     context 'when valid' do
-      let(:stripe_helper) {StripeMock.create_test_helper}
 
       around(:each) do |example|
         Timecop.freeze(2020, 5, 5) do 
-          StripeMock.start
-          example.run
-          StripeMock.stop
+          StripeMockHelper.mock do 
+            example.run
+          end
         end
       end
 

--- a/spec/lib/pay_recurring_donation_spec.rb
+++ b/spec/lib/pay_recurring_donation_spec.rb
@@ -10,13 +10,12 @@ describe PayRecurringDonation  do
 
   describe '.with_donation' do
     include_context :shared_donation_charge_context
-    let(:stripe_helper) { StripeMock.create_test_helper }
     
     around (:each)  do |example|
       Timecop.freeze( 2020, 5,4) do 
-        StripeMock.start
+        StripeMockHelper.mock do 
           example.run
-        StripeMock.stop
+        end
       end
     end
 

--- a/spec/lib/stripe_account_utils_spec.rb
+++ b/spec/lib/stripe_account_utils_spec.rb
@@ -4,9 +4,12 @@ require 'stripe'
 require 'stripe_mock'
 
 describe StripeAccountUtils do
-  let(:stripe_helper) { StripeMock.create_test_helper }
-  before(:each) { StripeMock.start}
-  after(:each) { StripeMock.stop}
+  around(:each) do |example|
+    StripeMockHelper.mock do
+      example.run
+    end
+  end
+
   let(:nonprofit) { force_create(:nonprofit)}
   let(:nonprofit_with_bad_values) { force_create(:nonprofit, state_code: "invalid", zip_code: 'not valid', website: 'invalid_url', email: 'penelope@email.email')}
 

--- a/spec/mailers/dispute_mailer_spec.rb
+++ b/spec/mailers/dispute_mailer_spec.rb
@@ -2,8 +2,10 @@
 require "rails_helper"
 
 RSpec.describe DisputeMailer, :type => :mailer do
-  before(:each) do
-    StripeMock.start
+  around(:each) do |example|
+    StripeMockHelper.mock do
+      example.run
+    end
   end
   
 
@@ -71,8 +73,10 @@ RSpec.describe DisputeMailer, :type => :mailer do
   end
 
   describe "update" do
-    before(:each) do
-      StripeMock.start
+    around(:each) do |example|
+      StripeMockHelper.mock do
+        example.run
+      end
     end
     let(:nonprofit) { force_create(:nonprofit, name: "spec_nonprofit_full")}
     let(:json) do

--- a/spec/models/stripe_account_spec.rb
+++ b/spec/models/stripe_account_spec.rb
@@ -2,8 +2,10 @@
 require 'rails_helper'
 
 RSpec.describe StripeAccount, :type => :model do
-  before(:each) do
-    StripeMock.start
+  around(:each) do |example|
+    StripeMockHelper.mock do
+      example.run
+    end
   end
   describe "account should be pending" do
     let(:sa) do 

--- a/spec/models/stripe_event-charge.dispute_spec.rb
+++ b/spec/models/stripe_event-charge.dispute_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 
 RSpec.describe StripeEvent, :type => :model do
   around(:each) do |example|
-    StripeMock.start
     Timecop.freeze(Date.new(2021, 5, 4)) do
-      example.run
+      StripeMockHelper.mock do 
+        example.run
+      end
     end
-    StripeMock.stop
   end
-  let(:stripe_helper) { StripeMock.create_test_helper }
+
 
 
   describe 'charge.dispute.*' do 

--- a/spec/models/stripe_event_spec.rb
+++ b/spec/models/stripe_event_spec.rb
@@ -3,13 +3,12 @@ require 'rails_helper'
 
 RSpec.describe StripeEvent, :type => :model do
   around(:each) do |example|
-    StripeMock.start
     Timecop.freeze(Date.new(2021, 5, 4)) do
-      example.run
+      StripeMockHelper.mock do 
+        example.run
+      end
     end
-    StripeMock.stop
   end
-  let(:stripe_helper) { StripeMock.create_test_helper }
 
   describe "stripe_account.updated" do 
     let(:nonprofit_verification_process_status) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,7 @@ require 'devise'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'support/factory_bot'
 require 'support/date_time'
+require 'support/stripe_mock_helper'
 require 'timecop'
 require 'delayed_job'
 require 'support/contexts'
@@ -87,6 +88,10 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation, reset_ids: true)
     Rails.cache.clear
+  end
+
+  config.after(:each) do
+    StripeMockHelper.stop
   end
 
   config.around(:each) do |example|

--- a/spec/support/contexts/charge_context.rb
+++ b/spec/support/contexts/charge_context.rb
@@ -1,11 +1,10 @@
 RSpec.shared_context :charge_context do
   around(:each) do |example|
-    StripeMock.start
+    StripeMockHelper.mock do
       example.run
-    StripeMock.stop
+    end
   end
 
-  let(:stripe_helper) { StripeMock.create_test_helper }
   let(:json) do
     event_json['data']['object']
   end

--- a/spec/support/contexts/disputes_context.rb
+++ b/spec/support/contexts/disputes_context.rb
@@ -1,11 +1,10 @@
 RSpec.shared_context :disputes_context do
   around(:each) do |example|
-    StripeMock.start
+    StripeMockHelper.mock do
       example.run
-    StripeMock.stop
+    end
   end
 
-  let(:stripe_helper) { StripeMock.create_test_helper }
   let(:nonprofit) { force_create(:nonprofit)}
   let(:supporter) { force_create(:supporter, nonprofit: nonprofit)}
   let(:json) do
@@ -94,7 +93,7 @@ RSpec.shared_context :dispute_created_context do
 
     let(:event_json) do 
       event_json = StripeMock.mock_webhook_event('charge.dispute.created')
-      stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
+      StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
       event_json
     end
 
@@ -176,7 +175,7 @@ RSpec.shared_context :dispute_funds_withdrawn_context do
 
     let(:event_json) do 
       event_json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
-      stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
+      StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
       event_json
     end
 
@@ -268,7 +267,7 @@ RSpec.shared_context :dispute_funds_reinstated_context do
   include_context :disputes_context
   let(:event_json) do
     event_json =StripeMock.mock_webhook_event('charge.dispute.funds_reinstated')
-    stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
     event_json
   end
   let!(:charge) { force_create(:charge, supporter: supporter, 
@@ -379,7 +378,7 @@ RSpec.shared_context :dispute_lost_context do
   include_context :disputes_context
   let(:event_json) do
     event_json =StripeMock.mock_webhook_event('charge.dispute.closed-lost')
-    stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
     event_json
   end
   let!(:charge) { force_create(:charge, supporter: supporter, 
@@ -470,7 +469,7 @@ RSpec.shared_context :dispute_won_context do
   include_context :disputes_context
   let(:event_json) do
     event_json =StripeMock.mock_webhook_event('charge.dispute.closed-won')
-    stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
     event_json
   end
   let!(:charge) { force_create(:charge, supporter: supporter, 
@@ -589,7 +588,7 @@ RSpec.shared_context :dispute_created_and_withdrawn_at_same_time_context do
 
   let(:event_json_funds_withdrawn) do
     json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
 
@@ -690,7 +689,7 @@ RSpec.shared_context :dispute_created_and_withdrawn_in_order_context do
   include_context :dispute_created_and_withdrawn_at_same_time_context
   let(:event_json_created) do
     json = StripeMock.mock_webhook_event('charge.dispute.created')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
 
@@ -700,7 +699,7 @@ RSpec.shared_context :dispute_created_and_withdrawn_in_order_context do
 
   let(:event_json_funds_withdrawn) do
     json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
 
@@ -801,7 +800,7 @@ RSpec.shared_context :dispute_created_withdrawn_and_lost_in_order_context do
   include_context :disputes_context
   let(:event_json_created) do
     json = StripeMock.mock_webhook_event('charge.dispute.created')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
 
@@ -809,7 +808,7 @@ RSpec.shared_context :dispute_created_withdrawn_and_lost_in_order_context do
 
   let(:event_json_funds_withdrawn) do
     json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
 
@@ -817,7 +816,7 @@ RSpec.shared_context :dispute_created_withdrawn_and_lost_in_order_context do
 
   let(:event_json_lost) do
     json = StripeMock.mock_webhook_event('charge.dispute.closed-lost')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
   
@@ -917,7 +916,7 @@ RSpec.shared_context :dispute_created_with_withdrawn_and_lost_in_order_context d
 
   let(:event_json_created) do
     json = StripeMock.mock_webhook_event('charge.dispute.created-with-one-withdrawn')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
 end
@@ -1020,7 +1019,7 @@ RSpec.shared_context :dispute_lost_created_and_funds_withdrawn_at_same_time_cont
 
   let(:event_json_lost) do
     json = StripeMock.mock_webhook_event('charge.dispute.closed-lost')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
   
@@ -1123,7 +1122,7 @@ RSpec.shared_context :__dispute_with_two_partial_disputes_withdrawn_at_same_time
   include_context :disputes_context
   let(:event_json_dispute_partial1) do
     json = StripeMock.mock_webhook_event('charge.dispute.created-with-one-withdrawn--partial1')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
 
@@ -1131,7 +1130,7 @@ RSpec.shared_context :__dispute_with_two_partial_disputes_withdrawn_at_same_time
 
   let(:event_json_dispute_partial2) do
     json = StripeMock.mock_webhook_event('charge.dispute.created-with-one-withdrawn--partial2')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
 
@@ -1330,7 +1329,7 @@ RSpec.shared_context :legacy_dispute_context do
 
   let(:event_json) do
     json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
-    stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
+    StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
 end

--- a/spec/support/contexts/shared_donation_charge_context.rb
+++ b/spec/support/contexts/shared_donation_charge_context.rb
@@ -40,7 +40,6 @@ RSpec.shared_context :shared_donation_charge_context do
   let!(:previous_fee_era) { create(:fee_era_with_no_start)}
   let!(:future_fee_era) { create(:fee_era_with_no_end)}
 
-  let(:stripe_helper) { StripeMock.create_test_helper }
 
   def generate_card_token(brand="Visa", country='US')
     StripeMock.generate_card_token({brand: brand, country: country})
@@ -48,9 +47,9 @@ RSpec.shared_context :shared_donation_charge_context do
 
   around(:each){|example|
     Timecop.freeze(2020, 5, 4) do
-      StripeMock.start
-      example.run
-      StripeMock.stop
+      StripeMockHelper.mock do 
+        example.run
+      end
     end
   }
 end

--- a/spec/support/stripe_mock_helper.rb
+++ b/spec/support/stripe_mock_helper.rb
@@ -1,0 +1,57 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+
+
+# StripeMockHelper adds some helper methods to RSpec. Additionally, it builds on
+# the features in StripeMock by creating
+
+module StripeMockHelper
+
+  # Creates a default test helper for the current StripeMock session
+  def self.create_default_helper
+    @@default_helper ||= StripeMock.create_test_helper
+  end
+
+  # Most StripeMock sessions only need a single test helper so you can get it here
+  # @return a Stripe test helper or nil if none is set
+  def self.default_helper
+    if defined? @@default_helper
+      @@default_helper 
+    else
+      nil
+    end
+  end
+
+  # Clears the default test helper for the current StripeMock session
+  def self.clear_default_helper
+    remove_class_variable :@@default_helper if defined? @@default_helper
+  end
+
+  
+  # sets up a StripeMock session and sets up StripeMock::default_helper
+  # note: Rspec is set up to autostop a StripeMock session when an example finishes
+  def self.start
+    StripeMock.start
+    create_default_helper
+  end
+
+  # stosp a StripeMock session and clears StripeMock::default_helper
+  def self.stop
+    clear_default_helper
+    StripeMock.stop
+  end
+
+  # helper to get StripeMock::default_helper
+  def self.stripe_helper
+    default_helper
+  end
+
+  # wraps a block in a StripeMock session and sets up StripeMock::default_helper
+  def self.mock(&block)
+    start
+
+    block.call
+    
+    stop
+  end
+end
+    

--- a/spec/support/stripe_mock_helper.rb
+++ b/spec/support/stripe_mock_helper.rb
@@ -30,8 +30,10 @@ module StripeMockHelper
   # sets up a StripeMock session and sets up StripeMock::default_helper
   # note: Rspec is set up to autostop a StripeMock session when an example finishes
   def self.start
-    StripeMock.start
-    create_default_helper
+    unless default_helper
+      StripeMock.start
+      create_default_helper
+    end
   end
 
   # stosp a StripeMock session and clears StripeMock::default_helper

--- a/spec/support/test/stripe_mock_helper_spec.rb
+++ b/spec/support/test/stripe_mock_helper_spec.rb
@@ -14,4 +14,16 @@ describe StripeMockHelper do
     end
     expect(StripeMockHelper.stripe_helper).to be_falsy
   end
+
+  describe "#start" do
+    it 'is safely reentrant' do
+      StripeMockHelper.mock do
+        # create a plan 
+        StripeMockHelper.stripe_helper.create_plan(id: 'test_str_plan', amount:0, currency: 'usd', interval: 'year', name: 'test PLan')
+        StripeMockHelper.start
+        expect { Stripe::Plan.retrieve('test_str_plan')}.to_not(raise_error, "If this object is not available, \
+          then the StripeMockHelper.start is incorrectly creating a new StripeMock session")
+      end
+    end
+  end
 end

--- a/spec/support/test/stripe_mock_helper_spec.rb
+++ b/spec/support/test/stripe_mock_helper_spec.rb
@@ -1,0 +1,17 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require 'rails_helper'
+
+describe StripeMockHelper do  
+  it 'sets stripe_helper' do
+    expect(StripeMockHelper.stripe_helper).to be_falsy
+    StripeMockHelper.mock do
+      expect(StripeMockHelper.stripe_helper).to be_truthy
+    end
+  end
+
+  it 'clears stripe_helper when finished' do
+    StripeMockHelper.mock do
+    end
+    expect(StripeMockHelper.stripe_helper).to be_falsy
+  end
+end


### PR DESCRIPTION
This changes how we use StripeMock to make it a little cleaner. It adds a StripeMockHelper module to all tests. `StripeMockHelper` has the following methods:

* `start`: starts a StripeMock session (using `StripeMock.start`) and sets a default test helper at `StripeMockHelper.default_helper﻿`
* `stop`: stops a StripeMock session (using `StripeMock.stop`) and clears the default test helper at `StripeMockHelper.default_helper`
* `default_helper`: a default test helper which can be used for a StripeMock session
* `stripe_helper`: an alias for `default_helper`
* `mock`: wraps a block in a StripeMock session
*  `create_default_helper`: creates a `default_helper` for the current StripeMock session
*  `clear_default_helper: clears the `default_helper` for the current StripeMock session

I've also used this code and applied it to all of our tests.
