### PR TITLE
Added some early base factories so we can use factories as intended

### DIFF
--- a/app/models/billing_subscription.rb
+++ b/app/models/billing_subscription.rb
@@ -26,6 +26,10 @@ class BillingSubscription < ActiveRecord::Base
 		h
 	end
 
+	def stripe_subscription
+		Stripe::Subscription.retrieve(stripe_subscription_id)
+	end
+
 	def self.create_with_stripe(np, params)
 		bp = BillingPlan.find_by_stripe_plan_id params[:stripe_plan_id]
 		h =  ConstructBillingSubscription.with_stripe np, bp

--- a/lib/cancel_billing_subscription.rb
+++ b/lib/cancel_billing_subscription.rb
@@ -11,6 +11,7 @@ module CancelBillingSubscription
     rescue ParamValidation::ValidationError => e
       return {json: {error: "Validation error\n #{e.message}", errors: e.data}, status: :unprocessable_entity}
     end
+
 		np_card = nonprofit.active_card
 		billing_subscription = nonprofit.billing_subscription
 		return {json:{error: 'We don\'t have a subscription for your non-profit. Please contact support.'}, status: :unprocessable_entity} if np_card.nil? || billing_subscription.nil? # stripe_customer_id on Card object

--- a/spec/api/houdini/nonprofit_spec.rb
+++ b/spec/api/houdini/nonprofit_spec.rb
@@ -2,9 +2,6 @@
 require 'rails_helper'
 
 describe Houdini::V1::Nonprofit, :type => :request do
-  describe 'get' do
-
-  end
 
   describe 'post' do
     around {|e|
@@ -132,8 +129,9 @@ describe Houdini::V1::Nonprofit, :type => :request do
     end
 
     it "succeeds" do
-      StripeMockHelper.start
-      force_create(:nonprofit, slug: "n", state_code_slug: "wi", city_slug: "appleton")
+      StripeMockHelper.start      
+      create(:nonprofit_base, slug: "n", state_code_slug: "wi", city_slug: "appleton")
+
       input = {
           nonprofit: {name: "n", state_code: "WI", city: "appleton", zip_code: 54915, url: 'www.cs.c', website: 'www.cs.c'},
           user: {name: "Name", email: "em@em.com", password: "12345678", password_confirmation: "12345678"}

--- a/spec/factories/billing_plans.rb
+++ b/spec/factories/billing_plans.rb
@@ -8,9 +8,24 @@ FactoryBot.define do
     end
   end
 
-  factory :billing_plan_percentage_fee_of_2_5_percent_and_5_cents_flat, parent: :billing_plan do 
+  factory :billing_plan_percentage_fee_of_2_5_percent_and_5_cents_flat, aliases: [:billing_plan_base], parent: :billing_plan do 
     percentage_fee { 0.025 }
     flat_fee { 5 }
+    trait :with_monthly_fee do
+      amount {500}
+    end
+
+    trait :with_associated_stripe_plan do
+      transient do 
+        stripe_plan { create(:stripe_plan_base, amount: amount || 0)}
+      end
+
+      stripe_plan_id { stripe_plan.id}
+    end
+  end
+
+  factory :default_billing_plan do
+
   end
 
   factory :billing_plan_percentage_fee_of_1_8_percent, parent: :billing_plan do 

--- a/spec/factories/billing_subscriptions.rb
+++ b/spec/factories/billing_subscriptions.rb
@@ -1,6 +1,16 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 FactoryBot.define do
-  factory :billing_subscription do
+  factory :billing_subscription, aliases: [:billing_subscription_base] do
+    nonprofit {association :nonprofit_base }
+    billing_plan { association :billing_plan_base }
+    trait :with_associated_stripe_subscription do
+      transient do 
+        stripe_subscription {association :stripe_subscription_base, stripe_customer: stripe_customer}
+        stripe_customer { association :stripe_customer_base}
+      end
+      billing_plan {association :billing_plan_base,  :with_associated_stripe_plan}
+      stripe_subscription_id { stripe_subscription.id}
 
+    end
   end
 end

--- a/spec/factories/cards.rb
+++ b/spec/factories/cards.rb
@@ -1,15 +1,17 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 FactoryBot.define do
-  factory :card do
-      factory :active_card_1 do
-        name {'card 1'}
+  factory :card, aliases: [:active_card_1, :active_card_2, :card_base] do
+    name {'card 1'} 
+    factory :inactive_card do
+      inactive {true}
+    end
+    trait :with_created_stripe_customer_and_card do
+      transient do
+        stripe_card { create(:stripe_card_base) }
       end
-      factory :active_card_2 do
-        name { 'card 1'}
-      end
-      factory :inactive_card do
-        name {'card 1'}
-        inactive {true}
-      end
+
+      stripe_card_id {stripe_card.id}
+      stripe_customer_id { stripe_card.customer}
+    end
   end
 end

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -3,4 +3,10 @@ FactoryBot.define do
   factory :charge do
     stripe_charge_id {"ch_test_id"}
   end
+
+  factory :charge_base, class: 'Charge' do
+    stripe_charge_id {"ch_test_id"}
+    nonprofit {supporter.nonprofit}
+    supporter {association :supporter_base}
+  end
 end

--- a/spec/factories/stripe/stripe_cards.rb
+++ b/spec/factories/stripe/stripe_cards.rb
@@ -1,0 +1,16 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+FactoryBot.define do
+  factory :stripe_card, aliases: [:stripe_card_base], class: 'Stripe::Card' do
+    transient do 
+      stripe_customer { association  :stripe_customer_base }
+      stripe_token { association :stripe_token_base}
+      currency {'usd'}
+    end
+  
+    to_create do |instance, evaluator|
+      StripeMockHelper.start
+      source = Stripe::Customer.create_source(evaluator.stripe_customer.id, {tok: evaluator.stripe_token.id})
+      instance.update_attributes(source)
+    end
+  end
+end

--- a/spec/factories/stripe/stripe_customers.rb
+++ b/spec/factories/stripe/stripe_customers.rb
@@ -1,0 +1,13 @@
+
+FactoryBot.define do
+  factory :stripe_customer, aliases: [:stripe_customer_base], class: 'Stripe::Customer' do
+  initialize_with { 
+    new(**attributes)
+  }
+    currency {'usd'}
+    to_create do |instance|
+      StripeMockHelper.start
+      instance.save
+    end
+  end
+end

--- a/spec/factories/stripe/stripe_plans.rb
+++ b/spec/factories/stripe/stripe_plans.rb
@@ -1,0 +1,16 @@
+
+FactoryBot.define do
+  factory :stripe_plan, aliases: [:stripe_plan_base], class: 'Stripe::Plan' do
+    transient do 
+      sequence(:id) {|i| "test_str_plan#{i}"}
+    end
+    currency {'usd'}
+    amount { 0 }
+
+    to_create do |instance, evaluator|
+      StripeMockHelper.start
+      plan = StripeMockHelper.stripe_helper.create_plan(**instance, id: evaluator.id)
+      instance.update_attributes(**plan)
+    end
+  end
+end

--- a/spec/factories/stripe/stripe_subscriptions.rb
+++ b/spec/factories/stripe/stripe_subscriptions.rb
@@ -1,0 +1,16 @@
+
+FactoryBot.define do
+  factory :stripe_subscription, aliases: [:stripe_subscription_base], class: 'Stripe::Subscription' do
+    transient do
+      stripe_customer { association :stripe_customer_base}
+      stripe_plan {association :stripe_plan_base} 
+    end
+    plan { stripe_plan.id }
+    customer { stripe_customer.id}
+
+    to_create do |instance|
+      StripeMockHelper.start
+      instance.save
+    end
+  end
+end

--- a/spec/factories/stripe/stripe_token.rb
+++ b/spec/factories/stripe/stripe_token.rb
@@ -1,0 +1,10 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+FactoryBot.define do
+  factory :stripe_token, aliases: [:stripe_token_base], class: 'Stripe::Token' do
+    to_create do |instance|
+      StripeMockHelper.start
+      new_token = StripeMockHelper.stripe_helper.generate_card_token(**instance)
+      instance.update_attributes(Stripe::Token.retrieve(new_token))
+    end
+  end
+end

--- a/spec/factories/supporters.rb
+++ b/spec/factories/supporters.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     primary_address { addresses.first}
   end
 
-  factory :supporter_with_fv_poverty, class: 'Supporter' do
+  factory :supporter_with_fv_poverty, aliases: [:supporter_base], class: 'Supporter' do
     name { 'Fake Supporter Name' }
     nonprofit { association :fv_poverty}
   end

--- a/spec/factory_specs/cards_spec.rb
+++ b/spec/factory_specs/cards_spec.rb
@@ -1,0 +1,19 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+describe 'cards factory' do
+  describe :cards_base do
+    context :with_created_stripe_customer_and_card do
+      it {
+        card = create(:card_base, :with_created_stripe_customer_and_card)
+        expect(card.stripe_card).to_not be_nil
+        
+      }
+
+      it {
+        card = create(:card_base, :with_created_stripe_customer_and_card)
+        expect(card.stripe_customer).to_not be_nil
+        
+      }
+    end
+  end
+end

--- a/spec/factory_specs/nonprofits_specs.rb
+++ b/spec/factory_specs/nonprofits_specs.rb
@@ -1,0 +1,12 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+describe 'nonprofits factory' do
+
+  describe :with_billing_subscription_on_stripe do
+
+    it {
+      nonprofit = create(:nonprofit_base, :with_billing_subscription_on_stripe)
+      expect(nonprofit).to have_attributes(attributes_for(:nonprofit_base, :with_billing_subscription_on_stripe))
+    }
+  end
+end

--- a/spec/factory_specs/stripe/stripe_cards_spec.rb
+++ b/spec/factory_specs/stripe/stripe_cards_spec.rb
@@ -1,0 +1,14 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+describe :stripe_card do
+  it 'provides a Stripe::Card' do
+    card = create(:stripe_card)
+    expect(card).to be_a Stripe::Card
+  end
+
+  it 'can be retrieved if requested' do
+    card = create(:stripe_card)
+    server_card = Stripe::Customer.retrieve_source(card.customer, card.id)
+    expect(card).to eq server_card
+  end
+end

--- a/spec/factory_specs/stripe/stripe_customers_spec.rb
+++ b/spec/factory_specs/stripe/stripe_customers_spec.rb
@@ -1,0 +1,14 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+describe :stripe_customer do
+  it 'provides a Stripe::Customer' do
+    customer = create(:stripe_customer)
+    expect(customer).to be_a Stripe::Customer
+  end
+
+  it 'can be retrieved if requested' do
+    customer = create(:stripe_customer)
+    server_customer = Stripe::Customer.retrieve(customer.id)
+    expect(customer).to eq server_customer
+  end
+end

--- a/spec/factory_specs/stripe/stripe_plans_spec.rb
+++ b/spec/factory_specs/stripe/stripe_plans_spec.rb
@@ -1,0 +1,14 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+describe :stripe_plan do
+  it 'provides a Stripe::Plan' do
+    plan = create(:stripe_plan)
+    expect(plan).to be_a Stripe::Plan
+  end
+
+  it 'can be retrieved if requested' do
+    plan = create(:stripe_plan)
+    server_plan = Stripe::Plan.retrieve(plan.id)
+    expect(plan).to eq server_plan
+  end
+end

--- a/spec/factory_specs/stripe/stripe_subscriptions_spec.rb
+++ b/spec/factory_specs/stripe/stripe_subscriptions_spec.rb
@@ -1,0 +1,26 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+describe :stripe_subscription do
+  it 'creates a plan if none provided' do
+    subscription = create(:stripe_subscription)
+    expect {Stripe::Plan.retrieve(subscription.plan.id)}.to_not raise_error
+  end
+
+  it 'creates a customer if none provided' do
+    subscription = create(:stripe_subscription)
+    expect {Stripe::Customer.retrieve(subscription.customer)}.to_not raise_error
+  end
+
+  it 'uses a custom plan if provided' do
+    provided_plan = create(:stripe_plan_base)
+    subscription = create(:stripe_subscription, stripe_plan: provided_plan)
+    expect(subscription.plan).to eq provided_plan
+    
+  end
+
+  it 'uses a custom customer if provided' do
+    provided_customer = create(:stripe_customer_base)
+    subscription = create(:stripe_subscription, stripe_customer: provided_customer)
+    expect(subscription.customer).to eq provided_customer.id
+  end
+end

--- a/spec/factory_specs/stripe/stripe_tokens_spec.rb
+++ b/spec/factory_specs/stripe/stripe_tokens_spec.rb
@@ -1,0 +1,14 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+describe :stripe_token do
+  it 'provides a Stripe::Token' do
+    token = create(:stripe_token)
+    expect(token).to be_a Stripe::Token
+  end
+
+  it 'can be retrieved if requested' do
+    token = create(:stripe_token)
+    server_token = Stripe::Token.retrieve(token.id)
+    expect(token).to eq server_token
+  end
+end

--- a/spec/lib/cancel_billing_subscriptions_spec.rb
+++ b/spec/lib/cancel_billing_subscriptions_spec.rb
@@ -1,45 +1,72 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 require 'rails_helper'
-require 'stripe_mock'
 
 describe CancelBillingSubscription do
+  
   around(:each) do |example|
     StripeMockHelper.mock do
-      @card_token = StripeMock.generate_card_token(last4: '9191', exp_year:2011)
-      @np = force_create(:nonprofit)
+      example.run
     end
   end
+  
 
   describe 'parameter validation' do
-    it 'without db' do
-      result = CancelBillingSubscription.with_stripe(nil)
-      errors = result[:json][:errors]
-      expect(errors.length).to eq(2)
-      expect(result[:status]).to eq :unprocessable_entity
-      expect_validation_errors(errors, [
-          {key: :nonprofit, name: :required},
-          {key: :nonprofit, name: :is_a}
-      ])
+    describe 'with no parameters' do
+      it "has unprocessable status" do 
+
+
+        result = CancelBillingSubscription.with_stripe(nil)
+        
+
+        
+        expect(result[:status]).to eq :unprocessable_entity
+          
+
+      end
+
+      it "has 2 validation errors" do
+        # with_stripe_mock do
+
+          result = CancelBillingSubscription.with_stripe(nil)
+          errors = result[:json][:errors]
+            expect(errors.length).to eq(2)
+            expect_validation_errors(errors, [
+                {key: :nonprofit, name: :required},
+                {key: :nonprofit, name: :is_a}
+            ])
+        
+      end
     end
 
-    context 'with db' do
-      before(:each) {
-        @np = create(:nonprofit_with_no_billing_subscription)
-      }
+    context 'with nonprofit' do
+     
+      def create_nonprofit_with_billing_subscription
+        create(:nonprofit_base, :with_default_billing_subscription)
+      end
+
+      def create_nonprofit_without_billing_subscription
+        create(:nonprofit_base)
+      end
+
+      def create_nonprofit_with_billing_subscription_and_active_card
+        create(:nonprofit_base, :with_default_billing_subscription, :with_active_card_on_stripe)
+      end
 
       it 'nonprofit valid but no card or billing_subscription' do
-        result = CancelBillingSubscription.with_stripe(@np)
+        nonprofit = create_nonprofit_without_billing_subscription
+        result = CancelBillingSubscription.with_stripe(nonprofit)
         expect_proper_failure(result)
       end
+      
       it 'nonprofit valid but no card' do
-        force_create(:billing_subscription,  :nonprofit => @np )
-        result = CancelBillingSubscription.with_stripe(@np)
+        nonprofit = create_nonprofit_with_billing_subscription
+        result = CancelBillingSubscription.with_stripe(nonprofit)
         expect_proper_failure(result)
       end
 
       it 'nonprofit valid but no billings subscription' do
-        @np.active_card = build(:card)
-        result = CancelBillingSubscription.with_stripe(@np)
+        nonprofit =  create(:nonprofit_base, :with_active_card_on_stripe)
+        result = CancelBillingSubscription.with_stripe(nonprofit)
         expect_proper_failure(result)
       end
 
@@ -51,48 +78,101 @@ describe CancelBillingSubscription do
 
   end
   context 'processing the billing subscription' do
-    before(:each){
-      bp = create(:billing_plan, amount: 133333, percentage_fee: 0.33, tier: 1, name: "fake plan")
-      @stripe_customer = Stripe::Customer.create(currency:'usd')
-      @plan = StripeMockHelper.stripe_helper.create_plan(id: 'test_str_plan', amount:0, currency: 'usd', interval: 'year', name: 'test PLan')
-
-      @original_str_subscription = @stripe_customer.subscriptions.create(:plan => @plan.id)
-
-      create(:card, holder: @np, stripe_customer_id:@stripe_customer.id)
-      @np.billing_subscription = build(:billing_subscription, billing_plan: bp, stripe_subscription_id: @original_str_subscription.id)
-      @default_plan = create(:billing_plan, :id => Settings.default_bp.id)
-    }
-
-    it 'handles failure of stripe properly' do
-
-      StripeMock.prepare_error(Stripe::StripeError.new('some failure'), :retrieve_customer_subscription)
-      original_bs = @np.billing_subscription
-
-      result = CancelBillingSubscription::with_stripe(@np)
-
-      expect(result[:status]).to eq :unprocessable_entity
-      expect(result[:json][:error]).to start_with("Oops")
-
-      expect(@np.billing_subscription).to eq(original_bs)
-
-      str_customer_reloaded = Stripe::Customer.retrieve(@stripe_customer.id)
-      expect(str_customer_reloaded.subscriptions.data).to eq([@original_str_subscription ])
+    def create_nonprofit
+      create(:nonprofit_base, :with_old_billing_plan_on_stripe)
     end
 
-    it 'should succeed' do
-
-      result = CancelBillingSubscription::with_stripe(@np)
-
-      expect(result[:status]).to eq :ok
-      expect(result[:json]).to eq Hash.new
-
-      expect(@np.billing_subscription.status).to eq 'active'
-      expect(@np.billing_subscription.billing_plan).to eq @default_plan
-      str_customer_reloaded = Stripe::Customer.retrieve(@stripe_customer.id)
-      expect(str_customer_reloaded.subscriptions.data.length).to eq 0
-
+    def create_default_plan
+      create(:billing_plan_base, :with_associated_stripe_plan, :id => Settings.default_bp.id)
     end
+
+    describe 'with a failure' do
+      def prepare_stripe_error
+        StripeMock.prepare_error(Stripe::StripeError.new('some failure'), :retrieve_customer_subscription)
+      end
+
+      it 'has a status of :unprocessable entity' do
+        np = create_nonprofit
+        prepare_stripe_error
+
+        result = CancelBillingSubscription::with_stripe(np)
+
+        expect(result[:status]).to eq :unprocessable_entity
+      end
+
+      it 'has the correct error message ' do
+        np = create_nonprofit
+        prepare_stripe_error
+        
+        result = CancelBillingSubscription::with_stripe(np)
+
+        expect(result[:json][:error]).to start_with("Oops")
+      end
+
+      it 'hasnt changed the nonprofit\'s billing_subscription' do
+        np = create_nonprofit
+        prepare_stripe_error
+        
+        expect {CancelBillingSubscription::with_stripe(np) }.to_not change { np.reload.billing_subscription.reload}
+      end
+
+      it 'hasn\'t changed the nonprofit Stripe customer subscription' do
+        np = create_nonprofit
+        prepare_stripe_error
+        expect {CancelBillingSubscription::with_stripe(np) }.to_not change { Stripe::Customer.retrieve(np.active_card.stripe_customer_id)}
+      end
+    end
+
+    describe 'successfully' do
+
+      it 'has status :ok' do
+        np = create_nonprofit
+        create_default_plan
+        result = CancelBillingSubscription::with_stripe(np)
+        expect(result[:status]).to eq :ok
+      end
+
+      it 'has empty json' do
+        np = create_nonprofit
+        create_default_plan
+        result = CancelBillingSubscription::with_stripe(np)
+        expect(result[:json]).to eq Hash.new
+      end
+
+      it 'has an active billing_subscription' do
+        np = create_nonprofit
+        create_default_plan
+        result = CancelBillingSubscription::with_stripe(np)
+        
+        expect(np.billing_subscription.status).to eq 'active'
+      end
+
+      it 'changed billing_subscription to default' do
+        np = create_nonprofit
+        default_plan = create_default_plan
+        expect {CancelBillingSubscription::with_stripe(np)}.to change{ np.billing_subscription.billing_plan }.to default_plan
+      end
+
+      it 'removed nonprofit\'s stripe customer subscriptions' do
+        np = create_nonprofit
+        default_plan = create_default_plan
+        expect {CancelBillingSubscription::with_stripe(np)}.to change { Stripe::Customer.retrieve(np.active_card.stripe_customer_id).subscriptions.data }.to []
+      end
+    end
+
+
+
+    # it 'should succeed' do
+    #   prepare
+    #   result = CancelBillingSubscription::with_stripe(@np)
+    #   expect(result[:status]).to eq :ok
+    #   expect(result[:json]).to eq Hash.new
+
+    #   expect 
+    #   expect(@np.billing_subscription.status).to eq 'active'
+    #   expect(@np.billing_subscription.billing_plan).to eq @default_plan
+    #   str_customer_reloaded = Stripe::Customer.retrieve(@np.active_card.stripe_customer_id)
+    #   expect(str_customer_reloaded.subscriptions.data.length).to eq 0
+    # end
   end
-
-
 end

--- a/spec/lib/insert/insert_custom_field_joins_spec.rb
+++ b/spec/lib/insert/insert_custom_field_joins_spec.rb
@@ -104,9 +104,9 @@ describe InsertCustomFieldJoins do
             @bad_nonprofit = force_create(:nonprofit, :id => 50)
         }
         it 'nonprofit must be valid' do
-          response = InsertCustomFieldJoins::in_bulk(@nonprofit.id+1, [], [])
+          response = InsertCustomFieldJoins::in_bulk(124571590, [], [])
           expect(response[:status]).to eq (:unprocessable_entity)
-          expect(response[:json][:error]).to include("Nonprofit #{@nonprofit.id+1} is not valid")
+          expect(response[:json][:error]).to include("Nonprofit #{124571590} is not valid")
         end
 
         it 'supporters if empty should do nothing' do

--- a/spec/lib/insert/insert_payout_spec.rb
+++ b/spec/lib/insert/insert_payout_spec.rb
@@ -67,6 +67,7 @@ describe InsertPayout do
       context 'no charges to payout' do 
         include_context 'payments for a payout' do
           let(:nonprofit) {force_create(:nonprofit, :stripe_account_id => Stripe::Account.create()['id'], vetted: true)}
+          let(:supporter) {force_create(:supporter, nonprofit: nonprofit)}
         end
         
         let!(:ba) do
@@ -108,6 +109,7 @@ describe InsertPayout do
       context 'no date provided' do
         include_context 'payments for a payout' do
           let(:nonprofit) {force_create(:nonprofit, :stripe_account_id => Stripe::Account.create()['id'], vetted: true)}
+          let(:supporter) {force_create(:supporter, nonprofit: nonprofit)}
         end
         let!(:ba) do
           ba = InsertBankAccount.with_stripe(nonprofit, user, {stripe_bank_account_token: StripeMock.generate_bank_token(), name: bank_name})

--- a/spec/lib/query/query_payments_spec.rb
+++ b/spec/lib/query/query_payments_spec.rb
@@ -11,7 +11,7 @@ describe QueryPayments do
 
     @payments = [force_create(:payment, gross_amount: 1000, fee_total: 99, net_amount: 901, supporter: @supporters[0], nonprofit:@nonprofit),
                  force_create(:payment, gross_amount: 2000, fee_total: 22, net_amount: 1978, supporter: @supporters[1], nonprofit:@nonprofit)]
-    @bank_account = force_create(:bank_account, name: 'bank1', nonprofit: @nonprofit)
+    @bank_account = force_create(:bank_account, name: 'baids_for_payoutnk1', nonprofit: @nonprofit)
   end
  
 

--- a/spec/models/nonprofit_deactivations_spec.rb
+++ b/spec/models/nonprofit_deactivations_spec.rb
@@ -2,40 +2,30 @@
 require 'rails_helper'
 
 RSpec.describe NonprofitDeactivation, type: :model do
-  let(:nonprofit) { force_create(:nonprofit, name: 'np1')}
-  let(:nonprofit_has_deactivation_but_deactivated_is_null) do 
-    np = force_create(:nonprofit, name: 'np2')
-    force_create(:nonprofit_deactivation, nonprofit: np)
-    np
+
+  def create_activated_and_unactivated_nps
+    OpenStruct.new activated: [
+      create(:nonprofit_base),
+      create(:nonprofit_base, :activated_deactivation_record)
+    ],
+    deactivated: [
+      create(:nonprofit_base, :deactivate_nonprofit)
+    ]
   end
 
-  let(:nonprofit_has_deactivation_but_deactivated_is_false) do 
-    np = force_create(:nonprofit, name: 'np3')
-    force_create(:nonprofit_deactivation, nonprofit: np, deactivated: false)
-    np
+  describe '.activated' do
+    it 'has all of the nps in activated except last one' do
+      nps = create_activated_and_unactivated_nps
+  
+      expect(Nonprofit.activated.all).to match_array(nps.activated)
+    end
   end
 
-  let(:nonprofit_has_deactivation_and_is_deactivated) do 
-    np = force_create(:nonprofit, name: 'np4')
-    force_create(:nonprofit_deactivation, nonprofit: np, deactivated: true)
-    np
-  end
-
-  it 'has all of the nps in activated except last one' do
-    result = [nonprofit,
-    nonprofit_has_deactivation_but_deactivated_is_false,
-    nonprofit_has_deactivation_but_deactivated_is_null]
-    nonprofit_has_deactivation_and_is_deactivated
-
-    expect(Nonprofit.activated.all).to match_array(result)
-  end
+  
 
   it 'has only nps in deactivated' do
-    nonprofit
-    nonprofit_has_deactivation_but_deactivated_is_false
-    nonprofit_has_deactivation_but_deactivated_is_null
-    result = [nonprofit_has_deactivation_and_is_deactivated]
-
-    expect(Nonprofit.deactivated.all).to match_array(result)
+    
+    nps = create_activated_and_unactivated_nps
+    expect(Nonprofit.deactivated.all).to match_array(nps.deactivated)
   end
 end

--- a/spec/support/mock_stripe_helper.rb
+++ b/spec/support/mock_stripe_helper.rb
@@ -1,0 +1,11 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+module MockStripeHelper
+  # wraps Stripe mocking for tests as well as creates stripe_test_helper 
+  def with_mock_stripe(&block)
+    stub_const("STRIPE_TEST_HELPER", StripeMock.create_test_helper)
+    StripeMock.start
+    block.call
+    StripeMock.stop
+  end
+end
+    


### PR DESCRIPTION
We didn't use factories properly because, well, I didn't do a good job. This is an early attempt to start using base factories properly. While I don't have time to setup base factories for everything, I converted a few specs to use them to experiment and illustrate their use.

One tweak from FactoryBot recommendations: Normally, it's considered good practice to make the default factory definition for a class as the least specific one possible. For example, the factory in `spec/factories/nonprofits.rb` should have a factory named `nonprofit` which is the least specific possible, i.e. has the minimum number of attributes to pass a test. We'd then add traits or nested factories to describe more specific situations. Unfortunately, we're already using that factory for something else and we do similar for many factories. To work around this, we're creating new "base" factories which meet this minimization standard by and naming them `<factory name>_base`, i.e. `:nonprofit_base`, `:user_base`, etc. Eventually, once we clean stuff up, we can rename all of those and remove the `_base` postfix but for now, this works well.
