### PR TITLE
Correct the name of a spec file and then fix the spec

### DIFF
--- a/spec/factories/nonprofits.rb
+++ b/spec/factories/nonprofits.rb
@@ -95,6 +95,7 @@ FactoryBot.define do
         end
         association :billing_subscription, 
         :with_associated_stripe_subscription,
+        nonprofit: @instance,
         **attributes
         }
     end

--- a/spec/factory_specs/nonprofits_spec.rb
+++ b/spec/factory_specs/nonprofits_spec.rb
@@ -1,0 +1,27 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+describe 'nonprofits factory' do
+
+  describe :with_billing_subscription_on_stripe do
+
+    it 'creates one Nonprofit' do
+      create(:nonprofit_base, :with_billing_subscription_on_stripe)
+      expect(Nonprofit.count).to eq 1
+    end
+
+    it 'creates one BillingSubscription' do 
+      create(:nonprofit_base, :with_billing_subscription_on_stripe)
+      expect(BillingSubscription.count).to eq 1
+    end
+ 
+    it 'creates 1 BillingPlan' do
+      create(:nonprofit_base, :with_billing_subscription_on_stripe)
+      expect(BillingPlan.count).to eq 1
+    end
+
+    it 'creates 1 Card' do
+      create(:nonprofit_base, :with_billing_subscription_on_stripe)
+      expect(Card.count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
One of the spec files was improperly named so it never ran. It also didn't work. This corrects both.﻿
