### PR TITLE
Add PaymentsExtensions#ordered

### DIFF
--- a/app/models/model_extensions/payments_extension.rb
+++ b/app/models/model_extensions/payments_extension.rb
@@ -22,6 +22,12 @@ module ModelExtensions
       map(&:fee_total).sum
     end
 
+    # orders payments without using SQL. Use this if you need them ordered
+    # but the payments haven't been saved yet.
+    def ordered
+      sort_by {|i| [i.legacy_payment.date, i.updated_at]}.reverse
+    end
+
     def owner
       proxy_association.owner
     end

--- a/app/models/subtransaction.rb
+++ b/app/models/subtransaction.rb
@@ -16,7 +16,7 @@ class Subtransaction < ApplicationRecord
 
 	# get payments in reverse chronological order
 	def ordered_payments
-		subtransaction_payments.ordered_query
+		subtransaction_payments.ordered
 	end
 
 	delegated_type :subtransactable, types: %w[OfflineTransaction, StripeTransaction]

--- a/app/models/subtransaction_payment.rb
+++ b/app/models/subtransaction_payment.rb
@@ -6,7 +6,7 @@ class SubtransactionPayment < ApplicationRecord
 	include Model::CreatedTimeable
 
 
-	# get payments in reverse chronological order
+	# get payments in reverse chronological order using SQL
 	scope :ordered_query, -> {
 		includes(:legacy_payment).references(:legacy_payments).order("payments.date DESC").order("subtransaction_payments.updated_at DESC") 
 	}

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -27,7 +27,7 @@ class Transaction < ApplicationRecord
 
 	# get payments in reverse chronological order
 	def ordered_payments
-		payments.ordered_query
+		payments.ordered
 	end
 
 	# def designation
@@ -68,7 +68,7 @@ class Transaction < ApplicationRecord
 			
 			subtransaction.publish_updated
 			# we want to publish that every payment has other than the new refund been updated
-			ordered_payments.select{|i| i != new_refund}.each(&:publish_updated)
+			payments.ordered.select{|i| i != new_refund}.each(&:publish_updated)
 			# publish that the new_refund has been created
 			new_refund.publish_created
 

--- a/app/views/api_new/subtransactions/_subtransaction.json.jbuilder
+++ b/app/views/api_new/subtransactions/_subtransaction.json.jbuilder
@@ -12,7 +12,7 @@ handle_expansion(:supporter, subtransaction.supporter, {json: json, __expand: __
 handle_expansion(:nonprofit, subtransaction.nonprofit,  {json: json, __expand: __expand})
 handle_expansion(:transaction, subtransaction.trx, {json: json, __expand: __expand})
 
-handle_array_expansion(:payments, subtransaction.ordered_payments, {json:json, __expand: __expand, item_as: :subtransaction_payment}) do |py, opts|
+handle_array_expansion(:payments, subtransaction.subtransaction_payments.ordered, {json:json, __expand: __expand, item_as: :subtransaction_payment}) do |py, opts|
 	handle_item_expansion(py, opts)
 end
 

--- a/app/views/api_new/transactions/_transaction.json.jbuilder
+++ b/app/views/api_new/transactions/_transaction.json.jbuilder
@@ -22,7 +22,7 @@ handle_array_expansion(:transaction_assignments, transaction.transaction_assignm
 	handle_item_expansion(tra, opts)
 end
 
-handle_array_expansion(:payments, transaction.ordered_payments, {json: json, __expand: __expand, item_as: :subtransaction_payment}) do |py, opts|
+handle_array_expansion(:payments, transaction.payments.ordered, {json: json, __expand: __expand, item_as: :subtransaction_payment}) do |py, opts|
 	handle_item_expansion(py, opts)
 end
 

--- a/spec/factories/modern_donations.rb
+++ b/spec/factories/modern_donations.rb
@@ -8,9 +8,9 @@ FactoryBot.define do
   end
  
   factory :modern_donation_base, class: "ModernDonation" do
-    amount { transaction_assignment.trx.subtransaction.ordered_payments.last.gross_amount }
+    amount { transaction_assignment.trx.subtransaction.subtransaction_payments.ordered.last.gross_amount }
     transaction_assignment { association :transaction_assignment_base }
-    legacy_donation { transaction_assignment.trx.subtransaction.ordered_payments.last.legacy_payment.donation}
+    legacy_donation { transaction_assignment.trx.subtransaction.subtransaction_payments.ordered.last.legacy_payment.donation}
   end
 
 end

--- a/spec/lib/insert/insert_refunds_spec.rb
+++ b/spec/lib/insert/insert_refunds_spec.rb
@@ -47,7 +47,8 @@ describe InsertRefunds do
                 net_amount: example[:amount],
                 fee_total: 0,
                 supporter: supporter,
-                nonprofit: nonprofit
+                nonprofit: nonprofit,
+                date: Time.current
                 )
               }
 


### PR DESCRIPTION
This adds a mechanism for getting a list of SubtransactionPayments in order without using SQL. Useful when you have a bunch of payments which haven't yet been saved to the database.﻿
