### PR TITLE
Add Supporter#calculated_first_name and #calculated_last_name

### DIFF
--- a/app/models/supporter.rb
+++ b/app/models/supporter.rb
@@ -94,6 +94,30 @@ class Supporter < ActiveRecord::Base
     end
   end
 
+  def calculated_first_name
+    name_parts = name&.strip&.split(' ')&.map(&:strip)
+    case name_parts&.count || 0
+    when 0
+      nil
+    when 1
+      name_parts[0]
+    else
+      name_parts[0..-2].join(" ")
+    end
+  end
+
+  def calculated_last_name
+    name_parts = name&.strip&.split(' ')&.map(&:strip)
+    case name_parts&.count || 0
+    when 0
+      nil
+    when 1
+      nil
+    else
+      name_parts[-1]
+    end
+  end
+
   def profile_picture size=:normal
     return unless self.profile
     self.profile.get_profile_picture(size)

--- a/spec/models/supporter_spec.rb
+++ b/spec/models/supporter_spec.rb
@@ -5,6 +5,61 @@ RSpec.describe Supporter, type: :model do
   it { is_expected.to have_many(:addresses).class_name("SupporterAddress")}
   it { is_expected.to belong_to(:primary_address).class_name("SupporterAddress")}
 
+
+  describe "#calculated_first_name" do
+    it "has nil name" do
+      supporter = build_stubbed(:supporter, name: nil)
+      expect(supporter.calculated_first_name).to be_nil
+    end
+
+    it "has blank name" do
+      supporter = build_stubbed(:supporter, name: "")
+      expect(supporter.calculated_first_name).to be_nil
+    end
+
+    it "has one word name" do
+      supporter = build_stubbed(:supporter, name: "Penelope")
+      expect(supporter.calculated_first_name).to eq "Penelope"
+    end
+
+    it "has two word name" do
+      supporter = build_stubbed(:supporter, name: "Penelope Schultz")
+      expect(supporter.calculated_first_name).to eq "Penelope"
+    end
+
+    it "has three word name" do
+      supporter = build_stubbed(:supporter, name: "Penelope Rebecca Schultz")
+      expect(supporter.calculated_first_name).to eq "Penelope Rebecca"
+    end
+  end
+
+  describe "#calculated_last_name" do
+    it "has nil name" do
+      supporter = build_stubbed(:supporter, name: nil)
+      expect(supporter.calculated_last_name).to be_nil
+    end
+
+    it "has blank name" do
+      supporter = build_stubbed(:supporter, name: "")
+      expect(supporter.calculated_last_name).to be_nil
+    end
+
+    it "has one word name" do
+      supporter = build_stubbed(:supporter, name: "Penelope")
+      expect(supporter.calculated_last_name).to be_nil
+    end
+
+    it "has two word name" do
+      supporter = build_stubbed(:supporter, name: "Penelope Schultz")
+      expect(supporter.calculated_last_name).to eq "Schultz"
+    end
+
+    it "has three word name" do
+      supporter = build_stubbed(:supporter, name: "Penelope Rebecca Schultz")
+      expect(supporter.calculated_last_name).to eq "Schultz"
+    end
+  end
+
   describe "#cleanup_name" do 
     it 'keeps name when no first and last name' do
       s = Supporter.new(name: 'Penelope')


### PR DESCRIPTION
There was no easily usable method for calculating the first and last name of a Supporter. This adds such methods for getting that based on the formula used in QuerySupporters
