### PR TITLE
Move recurring donation cancel into its own method

### DIFF
--- a/app/models/recurring_donation.rb
+++ b/app/models/recurring_donation.rb
@@ -79,6 +79,15 @@ class RecurringDonation < ActiveRecord::Base
     !failed? && !cancelled? && (end_date.nil? || end_date > Time.current);
   end
 
+  def cancel!(email)
+    if persisted?
+      self.active = false
+      self.cancelled_by = email
+      self.cancelled_at = Time.current
+      save!
+    end
+  end
+
   # XXX let's make these monthly_totals a query
   # Or just push it into the front-end
   def self.monthly_total

--- a/app/models/recurring_donation.rb
+++ b/app/models/recurring_donation.rb
@@ -80,12 +80,10 @@ class RecurringDonation < ActiveRecord::Base
   end
 
   def cancel!(email)
-    if persisted?
-      self.active = false
-      self.cancelled_by = email
-      self.cancelled_at = Time.current
-      save!
-    end
+    self.active = false
+    self.cancelled_by = email
+    self.cancelled_at = Time.current
+    save!
   end
 
   # XXX let's make these monthly_totals a query

--- a/lib/update/update_recurring_donations.rb
+++ b/lib/update/update_recurring_donations.rb
@@ -105,14 +105,9 @@ module UpdateRecurringDonations
 
   # Cancel a recurring donation (set active='f') and record the supporter/user email who did it
   def self.cancel(rd_id, email, dont_notify_nonprofit=false)
-    Psql.execute(
-      Qexpr.new.update(:recurring_donations, {
-        active: false,
-        cancelled_by: email,
-        cancelled_at: Time.current
-      })
-      .where("id=$id", id: rd_id.to_i)
-    )
+    recurring_donation = RecurringDonation.find(rd_id)
+    recurring_donation.cancel!(email)
+    
     rd = QueryRecurringDonations.fetch_for_edit(rd_id)['recurring_donation']
     Supporter.find(rd['supporter_id']).supporter_notes.create!(content: "This supporter's recurring donation for $#{Format::Currency.cents_to_dollars(rd['amount'])} was cancelled by #{rd['cancelled_by']} on #{Format::Date.simple(rd['cancelled_at'])}", user: User.find(540));
     if (!dont_notify_nonprofit)

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -25,5 +25,9 @@ FactoryBot.define do
       supporter { association  :supporter}
       amount  {500}
     end
-  end  
+  end 
+  
+  factory :donation_base, class: 'Donation' do
+    amount { 999 }
+  end
 end

--- a/spec/factories/recurring_donations.rb
+++ b/spec/factories/recurring_donations.rb
@@ -3,4 +3,12 @@ FactoryBot.define do
   factory :recurring_donation do
     
   end
+
+  factory :recurring_donation_base, class: 'RecurringDonation' do
+    active {true}
+    sequence(:edit_token) {|i| "edit_token_#{i}"}
+    start_date { Time.current }
+    interval { 1 }
+    time_unit { 'month' }
+  end
 end

--- a/spec/lib/update/update_recurring_donations_spec.rb
+++ b/spec/lib/update/update_recurring_donations_spec.rb
@@ -5,15 +5,13 @@ describe UpdateRecurringDonations do
   let!(:automated_user) { create(:automated_user)}
   # deactivate a recurring donation
   describe '.cancel' do
-    before(:each) do
-    end
 
     let(:np) { force_create(:nonprofit)}
     let(:s) { force_create(:supporter)}
-    let(:donation)  {force_create(:donation, nonprofit_id: np.id, supporter_id: s.id)}
+    let(:donation)  {create(:donation, nonprofit_id: np.id, supporter_id: s.id, amount: 999)}
     let(:email) {'test@test.com' }
     let!(:rd) {
-      inner_rd = force_create(:recurring_donation, amount:999, active:true, supporter_id: s.id, donation_id: donation.id, nonprofit_id: np.id)
+      inner_rd = create(:recurring_donation_base, amount:999, active:true, supporter_id: s.id, donation_id: donation.id, nonprofit_id: np.id)
       UpdateRecurringDonations.cancel(inner_rd.id, email)}
 
 

--- a/spec/models/recurring_donation_spec.rb
+++ b/spec/models/recurring_donation_spec.rb
@@ -53,17 +53,7 @@ RSpec.describe RecurringDonation, type: :model do
       expect{ build_stubbed(:recurring_donation_base).cancel!}.to raise_error ArgumentError
     end
 
-    it 'does nothing if the recurring donation is not persisted' do
-      recurring_donation = build(:recurring_donation_base)
-      recurring_donation.cancel!("penelope@rebecca.schultz")
-      expect(recurring_donation).to have_attributes(
-        'active' => true,
-        'cancelled_at' => nil,
-        'cancelled_by' => nil
-      )
-    end
-
-    it 'cancels a persisted rd properly' do 
+    it 'cancels an rd properly' do 
       nonprofit = create(:nonprofit_base)
       supporter = create(:supporter_base, nonprofit: nonprofit)
       donation = create(:donation_base, nonprofit: nonprofit, supporter_id: supporter.id, amount: 999)


### PR DESCRIPTION
Previously we used some wonky code to handle RD cancellation. This moves that work into RecurringDonation where it belongs
