### PR TITLE
Add Supporter.undeleted_tag_masters, .email_lists, .active_email_lists

### DIFF
--- a/app/models/supporter.rb
+++ b/app/models/supporter.rb
@@ -66,8 +66,23 @@ class Supporter < ActiveRecord::Base
   has_many :activities, dependent: :destroy
   has_many :tickets
   has_many :recurring_donations
-  has_many :tag_joins, dependent: :destroy
-  has_many :tag_masters, through: :tag_joins
+
+  concerning :Tags do
+    included do
+      has_many :tag_joins, dependent: :destroy
+      has_many :tag_masters, through: :tag_joins
+      has_many :undeleted_tag_masters, -> { not_deleted }, through: :tag_joins, source: 'tag_master'
+    end
+  end
+
+  concerning :EmailLists do
+    include Supporter::Tags # not needed but helpful for tracking dependencies
+    included do
+      has_many :email_lists, through: :tag_masters
+      has_many :active_email_lists, through: :undeleted_tag_masters, source: :email_list
+    end
+  end
+  
   has_many :custom_field_joins, dependent: :destroy
   has_many :custom_field_masters, through: :custom_field_joins
   belongs_to :merged_into, class_name: 'Supporter', :foreign_key => 'merged_into'

--- a/spec/factories/email_lists.rb
+++ b/spec/factories/email_lists.rb
@@ -2,4 +2,9 @@ FactoryBot.define do
   factory :email_list do
     
   end
+
+  factory :email_list_base, class: 'EmailList' do
+    sequence(:list_name) {|i|"list_name#{i}"}
+    sequence(:mailchimp_list_id) {|i| "mailchimp_list_id#{i}"}
+  end
 end

--- a/spec/factories/tag_joins.rb
+++ b/spec/factories/tag_joins.rb
@@ -6,4 +6,8 @@ FactoryBot.define do
     created_at {DateTime.now}
     updated_at {DateTime.now}
   end
+
+  factory :tag_join_base, class: 'TagJoin' do
+    tag_master { association :tag_master_base}
+  end
 end

--- a/spec/factories/tag_masters.rb
+++ b/spec/factories/tag_masters.rb
@@ -3,4 +3,9 @@ FactoryBot.define do
   factory :tag_master do
 
   end
+
+  factory :tag_master_base, class: "TagMaster" do
+    sequence(:name) {|i| "tag_name_#{i}"}
+    deleted { false }
+  end
 end


### PR DESCRIPTION
Currently, there is no way to relation for the email lists that a supporter belongs to. `.email_lists` provides that.

Additionally, it would be helpful to have a relation for all of the email lists that a supporter belongs to which are associated with undeleted tags. Currently, it's not impossible that a supporter could still have a tag_join on an undeleted TagMaster (unlikely but possible). To workaround that, we add an `.undeleted_tag_masters` to only find the tag_masters which are undeleted. Additionally we then create a `.active_email_lists` relation which goes through the `:undeleted_tag_masters` relationship.

Lastly, I've moved the parts of the Supporter class  related to tags and emails lists into their own concerns; this makes it clear what relates to what when you look at the class.


