### PR TITLE
Setup testing for Ruby 2.5, 2.6, 2.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 
 name: Main build
-env: 
-  ruby: '2.5.9'
 on: 
   pull_request:
     types: [opened, reopened, synchronize]
@@ -15,6 +13,8 @@ jobs:
         matrix:
           os: [ubuntu-20.04]
           node: [14.19.1]
+          ruby: ['2.5.9', '2.6.10', '2.7.6']
+        fail-fast: false
       steps:
         - uses: actions/checkout@v2
         - uses: dorny/paths-filter@v2
@@ -60,10 +60,15 @@ jobs:
           with:
             node-version: ${{ matrix.node }}
             cache: 'npm'
+        - name: set environment variables
+          uses: allenevans/set-env@v2.0.0
+          with:
+            CUSTOM_RUBY_VERSION: ${{ matrix.ruby }}
         - uses: ruby/setup-ruby@v1
           with:
-            ruby-version: ${{ env.ruby }}
+            ruby-version: ${{ matrix.ruby }}
             bundler-cache: true
+      
         - run: bin/setup
         - if: steps.changes.outputs.ruby == 'true'
           name: run spec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-ruby '2.5.9'
+ruby ENV['CUSTOM_RUBY_VERSION'] || '2.5.9' # heroku needs a specific ruby version in the Gemfile
+
 gem 'rake'
 gem 'rails', '~> 4.0'
 


### PR DESCRIPTION
- Add ability to pass in specific a custom Ruby version for testing with the CUSTOM_RUBY_VERSION env variable
- Create Ruby version testing matrix for Ruby 2.5, 2.6 and 2.7

This will be needed by the move to 2.6 so it make sense to separate it out.

Note: we expect only the 2.5 build task should pass here.
