### PR TITLE
Add debugging for Mailchimp list models

### DIFF
--- a/app/legacy_lib/insert_nonprofit_keys.rb
+++ b/app/legacy_lib/insert_nonprofit_keys.rb
@@ -13,22 +13,12 @@ module InsertNonprofitKeys
       if response['error']
         raise Exception.new(response['error'])
       end
-      response['access_token'] = Cypher.encrypt(response['access_token'])
 
-      key_row_id = Qx.select("*")
-        .from(:nonprofit_keys).where(nonprofit_id: npo_id)
-        .execute.map{|h| h['id']}.first
+      nonprofit_key = Nonprofit.find(npo_id).nonprofit_key
+      nonprofit_key = Nonprofit.find(npo_id).build_nonprofit_key unless nonprofit_key
 
-      if key_row_id.nil?
-        Qx.insert_into(:nonprofit_keys)
-          .values({nonprofit_id: npo_id, mailchimp_token: response['access_token'].to_json})
-          .ts.execute
-      else
-        Qx.update(:nonprofit_keys)
-          .set(mailchimp_token: response['access_token'])
-          .ts.where({'id' => key_row_id})
-          .execute
-      end
+      nonprofit_key.mailchimp_token = response['access_token']
+      nonprofit_key.save!
 
       return response['access_token']
     end

--- a/app/legacy_lib/mailchimp.rb
+++ b/app/legacy_lib/mailchimp.rb
@@ -56,6 +56,18 @@ module Mailchimp
     return mailchimp_token
   end
 
+  # Get all lists owned by the nonprofit represented by the mailchimp token
+  def get_all_lists(mailchimp_token)
+    uri = base_uri(mailchimp_token)
+    puts "URI #{uri}"
+    puts "KEY #{mailchimp_token}"
+    get(uri+'/lists', {
+        basic_auth: {username: '', password: mailchimp_token},
+        headers: {'Content-Type' => 'application/json'},
+      }
+    )
+  end
+
   # Given a nonprofit id and a list of tag master ids that they make into email lists,
   # create those email lists on mailchimp and return an array of hashes of mailchimp list ids, names, and tag_master_id
 	def self.create_mailchimp_lists(npo_id, tag_master_ids)

--- a/app/legacy_lib/query_nonprofit_keys.rb
+++ b/app/legacy_lib/query_nonprofit_keys.rb
@@ -4,12 +4,9 @@
 module QueryNonprofitKeys
 
   def self.get_key(npo_id, key_name)
-    query = Qx.select(key_name)
-      .from(:nonprofit_keys)
-      .where({'nonprofit_id' => npo_id})
-      .execute
-    raise ActiveRecord::RecordNotFound.new("Nonprofit key does not exist: #{key_name}") if query.empty?
-		Cypher.decrypt(JSON.parse query.first[key_name])
+    item = Nonprofit.find(npo_id).nonprofit_key&.send(key_name.to_sym)
+    raise ActiveRecord::RecordNotFound.new("Nonprofit key does not exist: #{key_name}") unless item
+		item
   end
 
 end

--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -78,6 +78,8 @@ class Nonprofit < ActiveRecord::Base
   has_many :periodic_reports
   has_many :export_formats
 
+  has_one :nonprofit_key
+
   has_one :bank_account, -> { where("COALESCE(bank_accounts.deleted, false) = false") }, dependent: :destroy
   has_one :billing_subscription, dependent: :destroy
   has_one :billing_plan, through: :billing_subscription

--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -79,6 +79,7 @@ class Nonprofit < ActiveRecord::Base
   has_many :export_formats
 
   has_one :nonprofit_key
+  has_many :email_lists
 
   has_one :bank_account, -> { where("COALESCE(bank_accounts.deleted, false) = false") }, dependent: :destroy
   has_one :billing_subscription, dependent: :destroy

--- a/app/models/nonprofit_key.rb
+++ b/app/models/nonprofit_key.rb
@@ -1,0 +1,18 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+
+# This is really just for mailchimp keys.
+
+# Actually handled through InsertNonprofitKeys
+class NonprofitKey < ActiveRecord::Base
+  belongs_to :nonprofit, required: true
+
+  validates_presence_of :mailchimp_token
+
+  def mailchimp_token
+    read_attribute(:mailchimp_token).nil? ? nil : Cypher.decrypt(read_attribute(:mailchimp_token))
+  end
+
+  def mailchimp_token=(access_token)
+    write_attribute(:mailchimp_token, access_token.nil? ? nil : Cypher.encrypt(access_token))
+  end
+end

--- a/db/migrate/20220419171847_change_nonprofit_keys_mailchimp_token_to_jsonb.rb
+++ b/db/migrate/20220419171847_change_nonprofit_keys_mailchimp_token_to_jsonb.rb
@@ -1,0 +1,13 @@
+class ChangeNonprofitKeysMailchimpTokenToJsonb < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      ALTER TABLE "nonprofit_keys" ALTER COLUMN "mailchimp_token" TYPE jsonb USING mailchimp_token::jsonb
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE "nonprofit_keys" ALTER COLUMN "mailchimp_token" TYPE text USING mailchimp_token::text
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220219001337) do
+ActiveRecord::Schema.define(version: 20220419171847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -648,7 +648,7 @@ ActiveRecord::Schema.define(version: 20220219001337) do
 
   create_table "nonprofit_keys", force: :cascade do |t|
     t.integer  "nonprofit_id"
-    t.text     "mailchimp_token"
+    t.jsonb    "mailchimp_token"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
   end

--- a/spec/factories/nonprofit_keys.rb
+++ b/spec/factories/nonprofit_keys.rb
@@ -1,0 +1,7 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+FactoryBot.define do
+  factory :nonprofit_key do
+    nonprofit
+    mailchimp_token {'a token'}
+  end
+end

--- a/spec/models/nonprofit_key_spec.rb
+++ b/spec/models/nonprofit_key_spec.rb
@@ -1,0 +1,50 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require 'rails_helper'
+
+RSpec.describe NonprofitKey, type: :model do
+
+  around(:each) {|example|
+
+    current_cypher_key = ENV['CYPHER_KEY']
+    ENV['CYPHER_KEY'] = "xGhMrqIixKvQ4S1bqv8CYwxGhMrqIixKvQ4S1bqv8CY=\n" # test cypher key; don't use anywhere for real code
+    example.run
+    ENV['CYPHER_KEY'] = current_cypher_key
+
+  }
+
+  it {
+    is_expected.to belong_to(:nonprofit).required(true)
+  }
+
+  it {
+    is_expected.to validate_presence_of(:mailchimp_token)
+  }
+
+
+  describe '#mailchimp_token' do
+    it {
+      expect(create(:nonprofit_key).mailchimp_token).to eq "a token"
+    }
+
+
+
+    it 'roundtrips mailchimp_token properly' do
+      key = create(:nonprofit_key)
+      key.mailchimp_token = "a different token"
+      key.save!
+      
+      new_key_object = NonprofitKey.find(key.id)
+
+      expect(new_key_object.mailchimp_token).to eq "a different token"
+    end
+
+    it 'handles nil values properly' do
+      key = create(:nonprofit_key)
+      expect {
+        key.mailchimp_token = nil
+      }.to_not raise_error
+      expect(key.mailchimp_token).to be_nil
+    end
+  end
+  
+end

--- a/spec/models/nonprofit_spec.rb
+++ b/spec/models/nonprofit_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe Nonprofit, type: :model do
 
   it {is_expected.to have_many(:supporter_cards).class_name('Card').through(:supporters).source(:cards)}
 
+  it {is_expected.to have_many(:email_lists)}
+  it {is_expected.to have_one(:nonprofit_key)}
+
   describe 'with cards' do
     before(:each) do
       @nonprofit = create(:nonprofit_with_cards)


### PR DESCRIPTION
Currently, it's kind of hard to debug the Mailchimp lists because:

* there's no model for NonprofitKey
* there's no relations for email_lists on Nonprofit


This corrects these limitations.

Additionally, it uses this NonprofitKey model for inserting the mailchimp access_token when a list is created.

Lastly, it properly converts nonprofit_keys.mailchimp_token to jsonb; the data in that field is JSON but it's being held as a TEXT field which doesn't really make sense.


