### PR TITLE
Update the PG backport

### DIFF
--- a/config/initializers/0_postgresql_adapter_monkeypatch.rb
+++ b/config/initializers/0_postgresql_adapter_monkeypatch.rb
@@ -1,48 +1,53 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-require 'active_record/connection_adapters/postgresql_adapter'
 
-class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
-  def set_standard_conforming_strings
-    old, self.client_min_messages = client_min_messages, 'warning'
-    execute('SET standard_conforming_strings = on', 'SCHEMA') rescue nil
-  ensure
-    self.client_min_messages = old
-  end
+
+if Rails.version < '6' # I don't know the exact version here but I know it was fixed by version 6
+
+  require 'active_record/connection_adapters/postgresql/schema_statements'
 
   #
   # Monkey-patch the refused Rails 4.2 patch at https://github.com/rails/rails/pull/31330
-  # Changed the module/class hierarchy to work with Rails 3.2
-  # Based on solution for Rails 4.2 https://github.com/rails/rails/issues/28780#issuecomment-354868174
   #
   # Updates sequence logic to support PostgreSQL 10.
   #
-  # Resets the sequence of a table's primary key to the maximum value.
-  def reset_pk_sequence!(table, pk = nil, sequence = nil) #:nodoc:
-    unless pk and sequence
-      default_pk, default_sequence = pk_and_sequence_for(table)
 
-      pk ||= default_pk
-      sequence ||= default_sequence
-    end
+  module ActiveRecord
+    module ConnectionAdapters
+      module PostgreSQL
+        module SchemaStatements
+          # Resets the sequence of a table's primary key to the maximum value.
+          def reset_pk_sequence!(table, pk = nil, sequence = nil) #:nodoc:
+            unless pk and sequence
+              default_pk, default_sequence = pk_and_sequence_for(table)
 
-    if @logger && pk && !sequence
-      @logger.warn "#{table} has primary key #{pk} with no default sequence"
-    end
+              pk ||= default_pk
+              sequence ||= default_sequence
+            end
 
-    if pk && sequence
-      quoted_sequence = quote_table_name(sequence)
-      max_pk = select_value("SELECT MAX(#{quote_column_name pk}) FROM #{quote_table_name(table)}")
-      if max_pk.nil?
-        if postgresql_version >= 100000
-          minvalue = select_value("SELECT seqmin FROM pg_sequence WHERE seqrelid = #{quote(quoted_sequence)}::regclass")
-        else
-          minvalue = select_value("SELECT min_value FROM #{quoted_sequence}")
+            if @logger && pk && !sequence
+              @logger.warn "#{table} has primary key #{pk} with no default sequence"
+            end
+
+            if pk && sequence
+              quoted_sequence = quote_table_name(sequence)
+              max_pk = select_value("SELECT MAX(#{quote_column_name pk}) FROM #{quote_table_name(table)}")
+              if max_pk.nil?
+                if postgresql_version >= 100000
+                  minvalue = select_value("SELECT seqmin FROM pg_sequence WHERE seqrelid = #{quote(quoted_sequence)}::regclass")
+                else
+                  minvalue = select_value("SELECT min_value FROM #{quoted_sequence}")
+                end
+              end
+
+              select_value <<-end_sql, 'SCHEMA'
+                SELECT setval(#{quote(quoted_sequence)}, #{max_pk ? max_pk : minvalue}, #{max_pk ? true : false})
+              end_sql
+            end
+          end
         end
       end
-
-      select_value <<-end_sql, 'SCHEMA'
-      SELECT setval(#{quote(quoted_sequence)}, #{max_pk ? max_pk : minvalue}, #{max_pk ? true : false})
-      end_sql
     end
   end
+else
+  puts "No Longer need PostgreSQL Adapter Monkeypatch"
 end


### PR DESCRIPTION
Depends on #334

The monkeypatch for Postgresql hasn't seemed to cause any issues but I had modified various things to get it to work on Rails 3.2. It seems prudent to update this to the correct monkeypatch for Rails 4. I also made it so that we would get a notification when we know it's no longer needed.
