### PR TITLE
Backports for various Rails features

### DIFF
--- a/config/initializers/1_attribute_assignment_patch.rb
+++ b/config/initializers/1_attribute_assignment_patch.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+# this is available in newer versions of rails that we aren't running
+if Rails.version < '5'
+  require "active_support/core_ext/hash/keys"
+
+  module ActiveModel
+    module AttributeAssignment
+      include ActiveModel::ForbiddenAttributesProtection
+
+      # Allows you to set all the attributes by passing in a hash of attributes with
+      # keys matching the attribute names.
+      #
+      # If the passed hash responds to <tt>permitted?</tt> method and the return value
+      # of this method is +false+ an <tt>ActiveModel::ForbiddenAttributesError</tt>
+      # exception is raised.
+      #
+      #   class Cat
+      #     include ActiveModel::AttributeAssignment
+      #     attr_accessor :name, :status
+      #   end
+      #
+      #   cat = Cat.new
+      #   cat.assign_attributes(name: "Gorby", status: "yawning")
+      #   cat.name # => 'Gorby'
+      #   cat.status # => 'yawning'
+      #   cat.assign_attributes(status: "sleeping")
+      #   cat.name # => 'Gorby'
+      #   cat.status # => 'sleeping'
+      def assign_attributes(new_attributes)
+        unless new_attributes.respond_to?(:each_pair)
+          raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
+        end
+        return if new_attributes.empty?
+
+        _assign_attributes(sanitize_for_mass_assignment(new_attributes))
+      end
+
+      alias attributes= assign_attributes
+
+      private
+        def _assign_attributes(attributes)
+          attributes.each do |k, v|
+            _assign_attribute(k, v)
+          end
+        end
+
+        def _assign_attribute(k, v)
+          setter = :"#{k}="
+          if respond_to?(setter)
+            public_send(setter, v)
+          else
+            raise UnknownAttributeError.new(self, k.to_s)
+          end
+        end
+    end
+  end
+else
+  puts "Monkeypatch for ActiveModel::AttributeAssignment no longer needed"
+end

--- a/config/initializers/2_module_patch.rb
+++ b/config/initializers/2_module_patch.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+# this is available in newer versions of rails that we aren't running
+if Rails.version < '5.1'
+  class Module
+    # When building decorators, a common pattern may emerge:
+    #
+    #   class Partition
+    #     def initialize(event)
+    #       @event = event
+    #     end
+    #
+    #     def person
+    #       detail.person || creator
+    #     end
+    #
+    #     private
+    #       def respond_to_missing?(name, include_private = false)
+    #         @event.respond_to?(name, include_private)
+    #       end
+    #
+    #       def method_missing(method, *args, &block)
+    #         @event.send(method, *args, &block)
+    #       end
+    #   end
+    #
+    # With <tt>Module#delegate_missing_to</tt>, the above is condensed to:
+    #
+    #   class Partition
+    #     delegate_missing_to :@event
+    #
+    #     def initialize(event)
+    #       @event = event
+    #     end
+    #
+    #     def person
+    #       detail.person || creator
+    #     end
+    #   end
+    #
+    # The target can be anything callable within the object, e.g. instance
+    # variables, methods, constants, etc.
+    #
+    # The delegated method must be public on the target, otherwise it will
+    # raise +DelegationError+. If you wish to instead return +nil+,
+    # use the <tt>:allow_nil</tt> option.
+    #
+    # The <tt>marshal_dump</tt> and <tt>_dump</tt> methods are exempt from
+    # delegation due to possible interference when calling
+    # <tt>Marshal.dump(object)</tt>, should the delegation target method
+    # of <tt>object</tt> add or remove instance variables.
+    def delegate_missing_to(target, allow_nil: nil)
+      target = target.to_s
+      target = "self.#{target}" if DELEGATION_RESERVED_METHOD_NAMES.include?(target)
+
+      module_eval <<-RUBY, __FILE__, __LINE__ + 1
+        def respond_to_missing?(name, include_private = false)
+          # It may look like an oversight, but we deliberately do not pass
+          # +include_private+, because they do not get delegated.
+          return false if name == :marshal_dump || name == :_dump
+          #{target}.respond_to?(name) || super
+        end
+        def method_missing(method, *args, &block)
+          if #{target}.respond_to?(method)
+            #{target}.public_send(method, *args, &block)
+          else
+            begin
+              super
+            rescue NoMethodError
+              if #{target}.nil?
+                if #{allow_nil == true}
+                  nil
+                else
+                  raise DelegationError, "\#{method} delegated to #{target}, but #{target} is nil"
+                end
+              else
+                raise
+              end
+            end
+          end
+        end
+        ruby2_keywords(:method_missing)
+      RUBY
+    end
+  end
+else
+  puts "Monkeypatch for Module#delegate_missing_to no longer needed"
+end

--- a/config/initializers/4_ar_delegated_type_monkeypatch.rb
+++ b/config/initializers/4_ar_delegated_type_monkeypatch.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+if Rails.version < '7'
+  require "active_support/core_ext/string/inquiry"
+
+  module ActiveRecord
+    # == Delegated types
+    #
+    # Class hierarchies can map to relational database tables in many ways. Active Record, for example, offers
+    # purely abstract classes, where the superclass doesn't persist any attributes, and single-table inheritance,
+    # where all attributes from all levels of the hierarchy are represented in a single table. Both have their
+    # places, but neither are without their drawbacks.
+    #
+    # The problem with purely abstract classes is that all concrete subclasses must persist all the shared
+    # attributes themselves in their own tables (also known as class-table inheritance). This makes it hard to
+    # do queries across the hierarchy. For example, imagine you have the following hierarchy:
+    #
+    #   Entry < ApplicationRecord
+    #   Message < Entry
+    #   Comment < Entry
+    #
+    # How do you show a feed that has both +Message+ and +Comment+ records, which can be easily paginated?
+    # Well, you can't! Messages are backed by a messages table and comments by a comments table. You can't
+    # pull from both tables at once and use a consistent OFFSET/LIMIT scheme.
+    #
+    # You can get around the pagination problem by using single-table inheritance, but now you're forced into
+    # a single mega table with all the attributes from all subclasses. No matter how divergent. If a Message
+    # has a subject, but the comment does not, well, now the comment does anyway! So STI works best when there's
+    # little divergence between the subclasses and their attributes.
+    #
+    # But there's a third way: Delegated types. With this approach, the "superclass" is a concrete class
+    # that is represented by its own table, where all the superclass attributes that are shared amongst all the
+    # "subclasses" are stored. And then each of the subclasses have their own individual tables for additional
+    # attributes that are particular to their implementation. This is similar to what's called multi-table
+    # inheritance in Django, but instead of actual inheritance, this approach uses delegation to form the
+    # hierarchy and share responsibilities.
+    #
+    # Let's look at that entry/message/comment example using delegated types:
+    #
+    #   # Schema: entries[ id, account_id, creator_id, created_at, updated_at, entryable_type, entryable_id ]
+    #   class Entry < ApplicationRecord
+    #     belongs_to :account
+    #     belongs_to :creator
+    #     delegated_type :entryable, types: %w[ Message Comment ]
+    #   end
+    #
+    #   module Entryable
+    #     extend ActiveSupport::Concern
+    #
+    #     included do
+    #       has_one :entry, as: :entryable, touch: true
+    #     end
+    #   end
+    #
+    #   # Schema: messages[ id, subject, body ]
+    #   class Message < ApplicationRecord
+    #     include Entryable
+    #   end
+    #
+    #   # Schema: comments[ id, content ]
+    #   class Comment < ApplicationRecord
+    #     include Entryable
+    #   end
+    #
+    # As you can see, neither +Message+ nor +Comment+ are meant to stand alone. Crucial metadata for both classes
+    # resides in the +Entry+ "superclass". But the +Entry+ absolutely can stand alone in terms of querying capacity
+    # in particular. You can now easily do things like:
+    #
+    #   Account.find(1).entries.order(created_at: :desc).limit(50)
+    #
+    # Which is exactly what you want when displaying both comments and messages together. The entry itself can
+    # be rendered as its delegated type easily, like so:
+    #
+    #   # entries/_entry.html.erb
+    #   <%= render "entries/entryables/#{entry.entryable_name}", entry: entry %>
+    #
+    #   # entries/entryables/_message.html.erb
+    #   <div class="message">
+    #     <div class="subject"><%= entry.message.subject %></div>
+    #     <p><%= entry.message.body %></p>
+    #     <i>Posted on <%= entry.created_at %> by <%= entry.creator.name %></i>
+    #   </div>
+    #
+    #   # entries/entryables/_comment.html.erb
+    #   <div class="comment">
+    #     <%= entry.creator.name %> said: <%= entry.comment.content %>
+    #   </div>
+    #
+    # == Sharing behavior with concerns and controllers
+    #
+    # The entry "superclass" also serves as a perfect place to put all that shared logic that applies to both
+    # messages and comments, and which acts primarily on the shared attributes. Imagine:
+    #
+    #   class Entry < ApplicationRecord
+    #     include Eventable, Forwardable, Redeliverable
+    #   end
+    #
+    # Which allows you to have controllers for things like +ForwardsController+ and +RedeliverableController+
+    # that both act on entries, and thus provide the shared functionality to both messages and comments.
+    #
+    # == Creating new records
+    #
+    # You create a new record that uses delegated typing by creating the delegator and delegatee at the same time,
+    # like so:
+    #
+    #   Entry.create! entryable: Comment.new(content: "Hello!"), creator: Current.user
+    #
+    # If you need more complicated composition, or you need to perform dependent validation, you should build a factory
+    # method or class to take care of the complicated needs. This could be as simple as:
+    #
+    #   class Entry < ApplicationRecord
+    #     def self.create_with_comment(content, creator: Current.user)
+    #       create! entryable: Comment.new(content: content), creator: creator
+    #     end
+    #   end
+    #
+    # == Adding further delegation
+    #
+    # The delegated type shouldn't just answer the question of what the underlying class is called. In fact, that's
+    # an anti-pattern most of the time. The reason you're building this hierarchy is to take advantage of polymorphism.
+    # So here's a simple example of that:
+    #
+    #   class Entry < ApplicationRecord
+    #     delegated_type :entryable, types: %w[ Message Comment ]
+    #     delegate :title, to: :entryable
+    #   end
+    #
+    #   class Message < ApplicationRecord
+    #     def title
+    #       subject
+    #     end
+    #   end
+    #
+    #   class Comment < ApplicationRecord
+    #     def title
+    #       content.truncate(20)
+    #     end
+    #   end
+    #
+    # Now you can list a bunch of entries, call +Entry#title+, and polymorphism will provide you with the answer.
+    #
+    # == Nested Attributes
+    #
+    # Enabling nested attributes on a delegated_type association allows you to
+    # create the entry and message in one go:
+    #
+    #   class Entry < ApplicationRecord
+    #     delegated_type :entryable, types: %w[ Message Comment ]
+    #     accepts_nested_attributes_for :entryable
+    #   end
+    #
+    #   params = { entry: { entryable_type: 'Message', entryable_attributes: { subject: 'Smiling' } } }
+    #   entry = Entry.create(params[:entry])
+    #   entry.entryable.id # => 2
+    #   entry.entryable.subject # => 'Smiling'
+    module DelegatedType
+      # Defines this as a class that'll delegate its type for the passed +role+ to the class references in +types+.
+      # That'll create a polymorphic +belongs_to+ relationship to that +role+, and it'll add all the delegated
+      # type convenience methods:
+      #
+      #   class Entry < ApplicationRecord
+      #     delegated_type :entryable, types: %w[ Message Comment ], dependent: :destroy
+      #   end
+      #
+      #   Entry#entryable_class # => +Message+ or +Comment+
+      #   Entry#entryable_name  # => "message" or "comment"
+      #   Entry.messages        # => Entry.where(entryable_type: "Message")
+      #   Entry#message?        # => true when entryable_type == "Message"
+      #   Entry#message         # => returns the message record, when entryable_type == "Message", otherwise nil
+      #   Entry#message_id      # => returns entryable_id, when entryable_type == "Message", otherwise nil
+      #   Entry.comments        # => Entry.where(entryable_type: "Comment")
+      #   Entry#comment?        # => true when entryable_type == "Comment"
+      #   Entry#comment         # => returns the comment record, when entryable_type == "Comment", otherwise nil
+      #   Entry#comment_id      # => returns entryable_id, when entryable_type == "Comment", otherwise nil
+      #
+      # You can also declare namespaced types:
+      #
+      #   class Entry < ApplicationRecord
+      #     delegated_type :entryable, types: %w[ Message Comment Access::NoticeMessage ], dependent: :destroy
+      #   end
+      #
+      #   Entry.access_notice_messages
+      #   entry.access_notice_message
+      #   entry.access_notice_message?
+      #
+      # === Options
+      #
+      # The +options+ are passed directly to the +belongs_to+ call, so this is where you declare +dependent+ etc.
+      # The following options can be included to specialize the behavior of the delegated type convenience methods.
+      #
+      # [:foreign_key]
+      #   Specify the foreign key used for the convenience methods. By default this is guessed to be the passed
+      #   +role+ with an "_id" suffix. So a class that defines a
+      #   <tt>delegated_type :entryable, types: %w[ Message Comment ]</tt> association will use "entryable_id" as
+      #   the default <tt>:foreign_key</tt>.
+      # [:primary_key]
+      #   Specify the method that returns the primary key of associated object used for the convenience methods.
+      #   By default this is +id+.
+      #
+      # Option examples:
+      #   class Entry < ApplicationRecord
+      #     delegated_type :entryable, types: %w[ Message Comment ], primary_key: :uuid, foreign_key: :entryable_uuid
+      #   end
+      #
+      #   Entry#message_uuid      # => returns entryable_uuid, when entryable_type == "Message", otherwise nil
+      #   Entry#comment_uuid      # => returns entryable_uuid, when entryable_type == "Comment", otherwise nil
+      def delegated_type(role, types:, **options)
+        belongs_to role, options.delete(:scope), **options.merge(polymorphic: true)
+        define_delegated_type_methods role, types: types, options: options
+      end
+
+      private
+        def define_delegated_type_methods(role, types:, options:)
+          primary_key = options[:primary_key] || "id"
+          role_type = "#{role}_type"
+          role_id   = options[:foreign_key] || "#{role}_id"
+
+          define_method "#{role}_class" do
+            public_send("#{role}_type").constantize
+          end
+
+          define_method "#{role}_name" do
+            public_send("#{role}_class").model_name.singular.inquiry
+          end
+
+          define_method "build_#{role}" do |*params|
+            public_send("#{role}=", public_send("#{role}_class").new(*params))
+          end
+
+          types.each do |type|
+            scope_name = type.tableize.tr("/", "_")
+            singular   = scope_name.singularize
+            query      = "#{singular}?"
+
+            scope scope_name, -> { where(role_type => type) }
+
+            define_method query do
+              public_send(role_type) == type
+            end
+
+            define_method singular do
+              public_send(role) if public_send(query)
+            end
+
+            define_method "#{singular}_#{primary_key}" do
+              public_send(role_id) if public_send(query)
+            end
+          end
+        end
+    end
+  end
+
+  # add our delegated type from 7.0
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::Base.send(:extend, ActiveRecord::DelegatedType)
+  end
+else
+  puts "Monkeypatch for ActiveRecord::DelegatedType not needed"
+end

--- a/spec/backport/action_controller_renderer_spec.rb
+++ b/spec/backport/action_controller_renderer_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require 'rails_helper'
+
+
+# from https://github.com/rails/rails/blob/eddb809b92808de50235a7975106ff974bee540f/actionpack/test/controller/renderer_test.rb
+describe ActionController::Renderer do
+
+
+  FIXTURE_LOAD_PATH = File.join(File.dirname(__FILE__), '../fixtures/backport')
+  FIXTURES = Pathname.new(FIXTURE_LOAD_PATH)
+  
+
+  before(:each) {
+    @_original_path_set = ActionController::Base.view_paths
+    ActionController::Base.view_paths = FIXTURE_LOAD_PATH
+  
+  
+
+
+    stub_const("ApplicationController",
+      Class.new(ActionController::Base) do 
+      end)
+
+    
+    stub_const("ResourcesController", Class.new(ActionController::Base) do 
+      def index() head :ok end
+      alias_method :show, :index
+    end)
+
+    stub_const("CommentsController", Class.new(ResourcesController))
+    stub_const("AccountsController", Class.new(ResourcesController))
+    stub_const("ImagesController", Class.new(ResourcesController))
+
+  }
+
+  after(:each) {
+    ActionController::Base.view_paths = @_original_path_set
+  }
+  it "action controller base has a renderer" do
+    assert ActionController::Base.renderer
+  end
+
+  it "creating with a controller" do
+    controller = CommentsController
+    renderer   = ActionController::Renderer.for controller
+
+    assert_equal controller, renderer.controller
+  end
+
+  it "creating from a controller" do
+    controller = AccountsController
+    renderer   = controller.renderer
+
+    assert_equal controller, renderer.controller
+  end
+
+  it "creating with new defaults" do
+    renderer = ApplicationController.renderer
+
+    new_defaults = { https: true }
+    new_renderer = renderer.with_defaults(new_defaults).new
+    content = new_renderer.render(inline: "<%= request.ssl? %>")
+
+    assert_equal "true", content
+  end
+
+  it "rendering with a class renderer" do
+    renderer = ApplicationController.renderer
+    content  = renderer.render template: "ruby_template"
+
+    assert_equal "Hello from Ruby code", content
+  end
+
+  it "rendering with an instance renderer" do
+    renderer = ApplicationController.renderer.new
+    content  = renderer.render template: "test/hello_world"
+
+    assert_equal "Hello world!", content
+  end
+
+  it "rendering with a controller class" do
+    assert_equal "Hello world!", ApplicationController.render("test/hello_world")
+  end
+
+  it "rendering with locals" do
+    renderer = ApplicationController.renderer
+    content  = renderer.render template: "test/render_file_with_locals",
+                               locals: { secret: "bar" }
+
+    assert_equal "The secret is bar\n", content
+  end
+
+  
+  it "rendering with assigns" do
+    renderer = ApplicationController.renderer
+    content  = renderer.render template: "test/render_file_with_ivar",
+                               assigns: { secret: "foo" }
+
+    assert_equal "The secret is foo\n", content
+  end
+
+  # We don't use this
+  # it "render a renderable object" do
+  #   renderer = ApplicationController.renderer
+
+  #   assert_equal(
+  #     %(Hello, World!),
+  #     renderer.render(TestRenderable.new)
+  #   )
+  # end
+
+  it "rendering with custom env" do
+    renderer = ApplicationController.renderer.new method: "post"
+    content  = renderer.render inline: "<%= request.post? %>"
+
+    assert_equal "true", content
+  end
+
+  it "rendering with custom env using a key that is not in RACK_KEY_TRANSLATION" do
+    value    = "warden is here"
+    renderer = ApplicationController.renderer.new warden: value
+    content  = renderer.render inline: "<%= request.env['warden'] %>"
+
+    assert_equal value, content
+  end
+
+  it "rendering with defaults" do
+    renderer = ApplicationController.renderer.new https: true
+    content = renderer.render inline: "<%= request.ssl? %>"
+
+    assert_equal "true", content
+  end
+
+  it "same defaults from the same controller" do
+    renderer_defaults = ->(controller) { controller.renderer.defaults }
+
+    assert_equal renderer_defaults[AccountsController], renderer_defaults[AccountsController]
+    assert_equal renderer_defaults[AccountsController], renderer_defaults[CommentsController]
+  end
+
+  it "rendering with different formats" do
+    html = "Hello world!"
+    xml  = "<p>Hello world!</p>\n"
+
+    assert_equal html, render["respond_to/using_defaults"]
+    assert_equal xml,  render["respond_to/using_defaults.xml.builder"] 
+    assert_equal xml,  render["respond_to/using_defaults", formats: :xml]
+  end
+
+  it "rendering with helpers" do
+    assert_equal "<p>1\n<br />2</p>", render[inline: '<%= simple_format "1\n2" %>']
+  end
+
+  it "rendering with user specified defaults" do
+    ApplicationController.renderer.defaults.merge!(hello: "hello", https: true)
+    renderer = ApplicationController.renderer.new
+    content = renderer.render inline: "<%= request.ssl? %>"
+
+    assert_equal "true", content
+  end
+
+  it "return valid asset URL with defaults" do
+    renderer = ApplicationController.renderer
+    content  = renderer.render inline: "<%= asset_url 'asset.jpg' %>"
+
+    assert_equal "http://example.org/asset.jpg", content
+  end
+
+  it "return valid asset URL when https is true" do
+    renderer = ApplicationController.renderer.new https: true
+    content  = renderer.render inline: "<%= asset_url 'asset.jpg' %>"
+
+    assert_equal "https://example.org/asset.jpg", content
+  end
+
+  private
+    def render
+      @render ||= ApplicationController.renderer.method(:render)
+    end
+end

--- a/spec/fixtures/backport/respond_to/using_defaults.html.erb
+++ b/spec/fixtures/backport/respond_to/using_defaults.html.erb
@@ -1,0 +1,1 @@
+Hello world!

--- a/spec/fixtures/backport/respond_to/using_defaults.xml.builder
+++ b/spec/fixtures/backport/respond_to/using_defaults.xml.builder
@@ -1,0 +1,1 @@
+xml.p "Hello world!"

--- a/spec/fixtures/backport/ruby_template.ruby
+++ b/spec/fixtures/backport/ruby_template.ruby
@@ -1,0 +1,2 @@
+body = ""
+body << ["Hello", "from", "Ruby", "code"].join(" ")

--- a/spec/fixtures/backport/test/hello_world.erb
+++ b/spec/fixtures/backport/test/hello_world.erb
@@ -1,0 +1,1 @@
+Hello world!

--- a/spec/fixtures/backport/test/render_file_with_ivar.erb
+++ b/spec/fixtures/backport/test/render_file_with_ivar.erb
@@ -1,0 +1,1 @@
+The secret is <%= @secret %>

--- a/spec/fixtures/backport/test/render_file_with_locals.erb
+++ b/spec/fixtures/backport/test/render_file_with_locals.erb
@@ -1,0 +1,1 @@
+The secret is <%= secret %>


### PR DESCRIPTION
This backports a number of features for Rails used by the webhooks code.

- Add patch for lack of `ActiveModel::AttributeAssignment` module
- Add patch for lack of `Module#delegate_missing_to`
- Add `ActiveRecord::DelegatedType` from upstream Rails
- Add specs running `ControllerName.render` to easily get the result of running a template from a particular controller
