### PR TITLE
Additional validation on periodic reports to avoid assigning unauthorized users to reports from other nonprofits

### DIFF
--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,18 +13,18 @@ FactoryBot.define do
 
   factory :user_as_nonprofit_admin, class: User do
     transient do
-      nonprofit { create(:fv_poverty) }
+      nonprofit { create(:nonprofit_base) }
     end
     sequence(:email) {|i| "user#{i}@example.string.com"}
     password {"whocares"}
     roles {[
-      build(:role, name: 'nonprofit_admin', host: create(:fv_poverty))
+      build(:role, name: 'nonprofit_admin', host: create(:nonprofit_base))
     ]}
   end
 
   factory :user_as_nonprofit_associate, class: User do
     transient do
-      nonprofit { create(:fv_poverty) }
+      nonprofit { create(:nonprofit_base) }
     end
 
     sequence(:email) {|i| "user#{i}@example.string.com"}
@@ -36,12 +36,12 @@ FactoryBot.define do
 
   factory :user_as_super_admin, class: User do
     transient do
-      nonprofit { create(:fv_poverty) }
+      nonprofit { create(:nonprofit_base) }
     end
     sequence(:email) {|i| "user#{i}@example.string.com"}
     password {"whocares"}
     roles {[
-      build(:role, name: 'nonprofit_associate', host: create(:fv_poverty)),
+      build(:role, name: 'nonprofit_associate', host: create(:nonprofit_base)),
       build(:role, name: 'super_admin')
     ]}
   end

--- a/spec/models/periodic_report_spec.rb
+++ b/spec/models/periodic_report_spec.rb
@@ -2,9 +2,9 @@
 require 'rails_helper'
 
 RSpec.describe PeriodicReport, type: :model do
-  let(:user) { create(:user) }
-  let(:users_list) { User.where(user_id: user.id) }
   let(:nonprofit) { create(:nonprofit_base) }
+  let(:user) { create(:user, roles: [build(:role, name: 'nonprofit_associate', host: nonprofit)]) }
+  let(:users_list) { User.where(id: user.id) }
 
   describe '#validation' do
     let(:attributes) do
@@ -33,6 +33,26 @@ RSpec.describe PeriodicReport, type: :model do
       attributes[:period] = :invalid_period
       periodic_report = subject
       expect(periodic_report.valid?).to be_falsy
+    end
+
+    context 'users validation' do
+      it 'is not valid if user does not belong to given nonprofit' do
+        attributes[:users] = [create(:user)]
+        periodic_report = subject
+        expect(periodic_report.valid?).to be_falsy
+      end
+
+      it 'is not valid if a list of users is not provided' do
+        attributes[:users] = []
+        periodic_report = subject
+        expect(periodic_report.valid?).to be_falsy
+      end
+
+      it 'is valid if the user provided is a super admin' do
+        attributes[:users] = [create(:user, roles: [build(:role, name: 'super_admin')])]
+        periodic_report = subject
+        expect(periodic_report.valid?).to be_truthy
+      end
     end
   end
 


### PR DESCRIPTION
While I was debugging https://github.com/CommitChange/tix/issues/3785 I noticed there's nothing preventing that we assign users to reports that they should not see, so I added more validation to prevent that from happening.