### PR TITLE
Fix for direct to s3 upload bug

### DIFF
--- a/app/controllers/aws_presigned_posts_controller.rb
+++ b/app/controllers/aws_presigned_posts_controller.rb
@@ -9,9 +9,9 @@ class AwsPresignedPostsController < ApplicationController
     uuid = SecureRandom.uuid
     p = S3Bucket.presigned_post({
       key: "tmp/#{uuid}/${filename}",
-      success_action_status: 201,
+      success_action_status: "201",
       acl: 'public-read',
-      expiration: 30.days.from_now
+      expires: 30.days.from_now
     })
 
     render json: {

--- a/client/js/common/direct-to-s3-upload.es6
+++ b/client/js/common/direct-to-s3-upload.es6
@@ -25,10 +25,9 @@ const uploadFile = R.curry(input => {
   return flyd.flatMap(
     pair => {
       var [input, presignedPost] = pair
-      var url = `https://${presignedPost.s3_direct_url.host}`
+      var url = `${presignedPost.s3_direct_url}`
       var file = input.files[0]
       var fileUrl = `${url}/tmp/${presignedPost.s3_uuid}/${file.name}`
-      var urlWithPort = `${url}:${presignedPost.s3_direct_url.port}`
       var payload = R.merge(JSON.parse(presignedPost.s3_presigned_post), {file})
 
       return flyd.map(resp => ({uri: fileUrl, file}), postFormData(url, payload))


### PR DESCRIPTION
There was a change in the way AWS direct to s3 uploads worked that we didn't catch during the Ruby upgrades. This addresses that.
