### PR TITLE
Remove attr_accessible from EmailList and add a spec for EmailList

### DIFF
--- a/app/models/email_list.rb
+++ b/app/models/email_list.rb
@@ -1,6 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 class EmailList < ActiveRecord::Base
-  attr_accessible :list_name, :mailchimp_list_id, :nonprofit, :tag_master
   belongs_to :nonprofit
   belongs_to :tag_master
 end

--- a/spec/models/email_list_spec.rb
+++ b/spec/models/email_list_spec.rb
@@ -1,0 +1,7 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require 'rails_helper'
+
+RSpec.describe EmailList, :type => :model do
+  it { is_expected.to belong_to(:nonprofit) }
+  it { is_expected.to belong_to(:tag_master) }
+end


### PR DESCRIPTION
attr_accessible was a deprecated way to make sure that only specific params are passed through from the controller. The correct method going forward is Strong Parameters but in this case, no controller action ever creates an EmailList object. So the entire problem is irrelevant so we'll just remove the attr_accessible.

Also add a spec for EmailList to verify the relationships are setup correctly.
