### PR TITLE
Fix supporter searches

### DIFF
--- a/app/legacy_lib/query_supporters.rb
+++ b/app/legacy_lib/query_supporters.rb
@@ -231,7 +231,7 @@ module QuerySupporters
     if query[:search].present?
       expr = expr.and_where(%Q(
         supporters.fts @@ websearch_to_tsquery('english', $search)
-        OR supporters.name % $search
+        OR supporters.name % $old_search
         OR (
           supporters.phone IS NOT NULL
           AND supporters.phone != ''
@@ -239,7 +239,7 @@ module QuerySupporters
           AND supporters.phone_index != ''
           AND supporters.phone_index = (regexp_replace($search, '\\D','', 'g'))
         )
-      ), search: query[:search], old_search: '%' + query[:search] + '%')
+      ), search: query[:search], old_search: '(' + query[:search].split.map{|s| "%" + s + "%"}.join("|") + ')')
     end
     if query[:notes].present?
       notes_subquery = Qx.select("STRING_AGG(content, ' ') as content, supporter_id")

--- a/app/legacy_lib/query_supporters.rb
+++ b/app/legacy_lib/query_supporters.rb
@@ -230,7 +230,7 @@ module QuerySupporters
     end
     if query[:search].present?
 
-      icky_bad_search = query[:search].split.map{|s| 
+      split_name_or_search = query[:search].split.map{|s| 
       [
         "OR supporters.name ILIKE #{ActiveRecord::Base.quote_value("%" + s + "%", nil)}", # we need to use this manual quoting because there's no good way to do the quoting
             #with the dollar signed substitution in Qx
@@ -240,7 +240,7 @@ module QuerySupporters
 
       where_string = %Q(
         supporters.fts @@ websearch_to_tsquery('english', $search)
-        #{icky_bad_search}
+        #{split_name_or_search}
         OR (
           supporters.phone IS NOT NULL
           AND supporters.phone != ''

--- a/app/legacy_lib/query_supporters.rb
+++ b/app/legacy_lib/query_supporters.rb
@@ -229,9 +229,18 @@ module QuerySupporters
       expr = expr.and_where("payments.max_date < timezone(COALESCE(nonprofits.timezone, \'UTC\'), timezone(\'UTC\', $date)) OR payments.count = 0", date: date_ago)
     end
     if query[:search].present?
-      expr = expr.and_where(%Q(
+
+      icky_bad_search = query[:search].split.map{|s| 
+      [
+        "OR supporters.name ILIKE #{ActiveRecord::Base.quote_value("%" + s + "%", nil)}", # we need to use this manual quoting because there's no good way to do the quoting
+            #with the dollar signed substitution in Qx
+
+        "OR supporters.name % #{ActiveRecord::Base.quote_value("%" + s + "%", nil)}"
+      ]}.flatten.join("\n")
+
+      where_string = %Q(
         supporters.fts @@ websearch_to_tsquery('english', $search)
-        OR supporters.name % $old_search
+        #{icky_bad_search}
         OR (
           supporters.phone IS NOT NULL
           AND supporters.phone != ''
@@ -239,7 +248,9 @@ module QuerySupporters
           AND supporters.phone_index != ''
           AND supporters.phone_index = (regexp_replace($search, '\\D','', 'g'))
         )
-      ), search: query[:search], old_search: '(' + query[:search].split.map{|s| "%" + s + "%"}.join("|") + ')')
+      )
+
+      expr = expr.and_where(where_string, search: query[:search])
     end
     if query[:notes].present?
       notes_subquery = Qx.select("STRING_AGG(content, ' ') as content, supporter_id")

--- a/config/initializers/17_postgres_opclass_support.rb
+++ b/config/initializers/17_postgres_opclass_support.rb
@@ -1,0 +1,263 @@
+# rubocop:disable all
+
+# These changes add support for PostgreSQL operator classes when creating
+# indexes and dumping/loading schemas. Taken from Rails pull request
+# https://github.com/rails/rails/pull/19090.
+#
+# License:
+#
+# Copyright (c) 2004-2016 David Heinemeier Hansson
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+if Rails.version < '5'
+  require 'date'
+  require 'set'
+  require 'bigdecimal'
+  require 'bigdecimal/util'
+
+  # As the Struct definition is changed in this PR/patch we have to first remove
+  # the existing one.
+  ActiveRecord::ConnectionAdapters.send(:remove_const, :IndexDefinition)
+
+  module ActiveRecord
+    module ConnectionAdapters #:nodoc:
+      # Abstract representation of an index definition on a table. Instances of
+      # this type are typically created and returned by methods in database
+      # adapters. e.g. ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#indexes
+      
+      # this is needed because opclasses would otherwise be missing
+      # from Rails 5.2
+      class IndexDefinition < Struct.new(:table, :name, :unique, :columns, :lengths, :orders, :where, :type, :using, :opclasses) #:nodoc:
+      end
+    end
+  end
+
+
+  module ActiveRecord
+    module ConnectionAdapters # :nodoc:
+      module SchemaStatements
+        # from Rails 5.2
+        def options_for_index_columns(options)
+          if options.is_a?(Hash)
+            options.symbolize_keys
+          else
+            Hash.new { |hash, column| hash[column] = options }
+          end
+        end
+
+        # from Rails 5.2
+        def quoted_columns_for_index(column_names, **options)
+          return [column_names] if column_names.is_a?(String)
+
+          quoted_columns = Hash[column_names.map { |name| [name.to_sym, quote_column_name(name).dup] }]
+          add_options_for_index_columns(quoted_columns, options).values
+        end
+
+        # from Rails 5.2
+        def add_options_for_index_columns(quoted_columns, **options)
+          if supports_index_sort_order?
+            quoted_columns = add_index_sort_order(quoted_columns, options)
+          end
+
+          quoted_columns
+        end
+
+        # from Rails 5.2
+        def index_column_names(column_names)
+          if column_names.is_a?(String) && /\W/.match?(column_names)
+            column_names
+          else
+            Array(column_names)
+          end
+        end
+        
+        # from Rails 5.2
+        def index_name_options(column_names)
+          if column_names.is_a?(String) && /\W/.match?(column_names)
+            column_names = column_names.scan(/\w+/).join("_")
+          end
+
+          { column: column_names }
+        end
+
+        # From rails 5.2 but modified for Rails 4
+        def add_index_options(table_name, column_name, options = {}) #:nodoc:
+          column_names = index_column_names(column_name)
+          index_name   = index_name(table_name, index_name_options(column_names))
+
+          options.assert_valid_keys(:unique, :order, :name, :where, :length, :internal, :using, :algorithm, :type, :opclass)
+
+          index_type = options[:unique] ? "UNIQUE" : ""
+          index_type = options[:type].to_s if options.key?(:type)
+          index_name = options[:name].to_s if options.key?(:name)
+          max_index_length = options.fetch(:internal, false) ? index_name_length : allowed_index_name_length
+
+          if options.key?(:algorithm)
+            algorithm = index_algorithms.fetch(options[:algorithm]) {
+              raise ArgumentError.new("Algorithm must be one of the following: #{index_algorithms.keys.map(&:inspect).join(', ')}")
+            }
+          end
+
+          using = "USING #{options[:using]}" if options[:using].present?
+
+          if supports_partial_index?
+            index_options = options[:where] ? " WHERE #{options[:where]}" : ""
+          end
+
+          if index_name.length > max_index_length
+            raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' is too long; the limit is #{max_index_length} characters"
+          end
+          if table_exists?(table_name) && index_name_exists?(table_name, index_name, false)
+            raise ArgumentError, "Index name '#{index_name}' on table '#{table_name}' already exists"
+          end
+          index_columns = quoted_columns_for_index(column_names, options).join(", ")
+
+          [index_name, index_type, index_columns, index_options, algorithm, using]
+        end
+      end
+    end
+  end
+
+  module ActiveRecord
+    module ConnectionAdapters
+      module PostgreSQL
+        module SchemaStatements
+          # Returns an array of indexes for the given table.
+          # mostly Rails 6.1 BUT modified to fit Rails 4
+          # for example, we don't use a specific schema
+          def indexes(table_name)
+            result = query(<<-SQL, 'SCHEMA')
+              SELECT distinct i.relname, d.indisunique, d.indkey, pg_get_indexdef(d.indexrelid), t.oid
+              FROM pg_class t
+              INNER JOIN pg_index d ON t.oid = d.indrelid
+              INNER JOIN pg_class i ON d.indexrelid = i.oid
+              WHERE i.relkind = 'i'
+                AND d.indisprimary = 'f'
+                AND t.relname = '#{table_name}'
+                AND i.relnamespace IN (SELECT oid FROM pg_namespace WHERE nspname = ANY (current_schemas(false)) )
+              ORDER BY i.relname
+            SQL
+
+            result.map do |row|
+              index_name = row[0]
+              unique = row[1] == 't'
+              indkey = row[2].split(" ")
+              inddef = row[3] # index definition
+              oid = row[4]
+
+              using, expressions, where = inddef.scan(/ USING (\w+?) \((.+?)\)(?: WHERE (.+))?\z/m).flatten
+
+              orders = {}
+              opclasses = {}
+              columns  = nil
+              if indkey.include?("0")
+                # this means the index is not column based but has function or operator involved. For example,
+                # one could have an index on `supporters` for `lower(name)`.
+                columns = expressions
+                
+              else
+                # the index is column based so we need to find out which columns are involved
+                columns = Hash[query(<<~SQL, "SCHEMA")].values_at(*indkey).compact
+                  SELECT a.attnum, a.attname
+                  FROM pg_attribute a
+                  WHERE a.attrelid = #{oid}
+                  AND a.attnum IN (#{indkey.join(",")})
+                SQL
+
+                # add info on sort order (only desc order is explicitly specified, asc is the default)
+                # and non-default opclasses
+                expressions.scan(/(?<column>\w+)"?\s?(?<opclass>\w+_ops)?\s?(?<desc>DESC)?\s?(?<nulls>NULLS (?:FIRST|LAST))?/).each do |column, opclass, desc, nulls|
+                  opclasses[column] = opclass.to_sym if opclass
+                  if nulls
+                    orders[column] = [desc, nulls].compact.join(" ")
+                  else
+                    orders[column] = :desc if desc
+                  end
+                end
+              end
+              
+              IndexDefinition.new(table_name, index_name, unique, columns, [], orders, where, nil, using.to_sym, opclasses)
+            end
+
+            
+          end
+
+          # modification of Rails 4 to handle opclasses properly. Not really Rails 5.2 because we ignore the comments
+          def add_index(table_name, column_name, options = {}) #:nodoc:
+            index_name, index_type, index_columns_and_opclasses, index_options, index_algorithm, index_using = add_index_options(table_name, column_name, options)
+            execute "CREATE #{index_type} INDEX #{index_algorithm} #{quote_column_name(index_name)} ON #{quote_table_name(table_name)} #{index_using} (#{index_columns_and_opclasses})#{index_options}"
+          end
+
+
+          # from rails 5.2 this is just for adding opclass to the columns
+          def add_options_for_index_columns(quoted_columns, **options)
+            quoted_columns = add_index_opclass(quoted_columns, options)
+            super
+          end
+
+          # from rails 5.2
+          def add_index_opclass(quoted_columns, **options)
+            opclasses = options_for_index_columns(options[:opclass])
+            quoted_columns.each do |name, column|
+              column << " #{opclasses[name]}" if opclasses[name].present?
+            end
+          end
+        end
+      end
+    end
+  end
+
+  module ActiveRecord
+    class SchemaDumper
+      private
+
+        # Rails 4.2 but add the opclasses line
+        def indexes(table, stream)
+          if (indexes = @connection.indexes(table)).any?
+            add_index_statements = indexes.map do |index|
+              statement_parts = [
+                "add_index #{remove_prefix_and_suffix(index.table).inspect}",
+                index.columns.inspect,
+                "name: #{index.name.inspect}",
+              ]
+              statement_parts << 'unique: true' if index.unique
+
+              index_lengths = (index.lengths || []).compact
+              statement_parts << "length: #{Hash[index.columns.zip(index.lengths)].inspect}" if index_lengths.any?
+
+              index_orders = index.orders || {}
+              statement_parts << "order: #{index.orders.inspect}" if index_orders.any?
+              statement_parts << "where: #{index.where.inspect}" if index.where
+              statement_parts << "using: #{index.using.inspect}" if index.using
+              statement_parts << "type: #{index.type.inspect}" if index.type
+              statement_parts << "opclass: #{index.opclasses}" if index.opclasses.present?
+
+              "  #{statement_parts.join(', ')}"
+            end
+
+            stream.puts add_index_statements.sort.join("\n")
+            stream.puts
+          end
+        end
+    end
+  end
+else
+  console.log("You might not need this code anymore")
+end

--- a/db/migrate/20220221223739_add_similarity_to_name_search.rb
+++ b/db/migrate/20220221223739_add_similarity_to_name_search.rb
@@ -1,7 +1,0 @@
-class AddSimilarityToNameSearch < ActiveRecord::Migration
-  def change
-    enable_extension :pg_trgm
-
-    add_index :supporters, :name, name: :name_search_idx, order: {name: :gin_trgm_ops}
-  end
-end

--- a/db/migrate/20220516224148_add_index_for_name.rb
+++ b/db/migrate/20220516224148_add_index_for_name.rb
@@ -1,0 +1,7 @@
+class AddIndexForName < ActiveRecord::Migration
+  def change
+    enable_extension :pg_trgm
+    enable_extension :btree_gin
+    add_index :supporters, :name, name: 'name_search_idx', using: :gin, opclass: {name: "gin_trgm_ops"}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20220419171847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_trgm"
   enable_extension "pg_stat_statements"
   enable_extension "uuid-ossp"
 
@@ -321,6 +320,7 @@ ActiveRecord::Schema.define(version: 20220419171847) do
     t.tsvector "fts"
   end
 
+  add_index "donations", "lower(designation)", name: "donations_designation", using: :btree
   add_index "donations", ["amount"], name: "donations_amount", using: :btree
   add_index "donations", ["anonymous"], name: "index_donations_on_anonymous", using: :btree
   add_index "donations", ["campaign_id"], name: "donations_campaign_id", using: :btree
@@ -1082,10 +1082,12 @@ ActiveRecord::Schema.define(version: 20220419171847) do
     t.string   "houid"
   end
 
+  add_index "supporters", "lower((email)::text)", name: "supporters_email", where: "(deleted <> true)", using: :btree
+  add_index "supporters", "lower((name)::text)", name: "supporters_lower_name", where: "(deleted <> true)", using: :btree
+  add_index "supporters", "to_tsvector('english'::regconfig, (((COALESCE(name, ''::character varying))::text || ' '::text) || (COALESCE(email, ''::character varying))::text))", name: "supporters_general_idx", using: :gin
   add_index "supporters", ["anonymous", "nonprofit_id"], name: "index_supporters_on_anonymous_and_nonprofit_id", using: :btree
   add_index "supporters", ["fts"], name: "supporters_fts_idx", using: :gin
   add_index "supporters", ["name"], name: "index_supporters_on_name", using: :btree
-  add_index "supporters", ["name"], name: "name_search_idx", using: :btree
   add_index "supporters", ["nonprofit_id", "deleted"], name: "supporters_nonprofit_id_not_deleted", where: "(NOT deleted)", using: :btree
   add_index "supporters", ["nonprofit_id", "imported_at"], name: "index_supporters_on_nonprofit_id_and_imported_at", using: :btree
   add_index "supporters", ["nonprofit_id", "phone_index", "deleted"], name: "index_supporters_on_nonprofit_id_and_phone_index_and_deleted", where: "((phone IS NOT NULL) AND ((phone)::text <> ''::text))", using: :btree
@@ -1269,10 +1271,10 @@ ActiveRecord::Schema.define(version: 20220419171847) do
   create_trigger :update_donations_fts, sql_definition: <<-SQL
       CREATE TRIGGER update_donations_fts BEFORE INSERT OR UPDATE ON public.donations FOR EACH ROW EXECUTE FUNCTION update_fts_on_donations()
   SQL
-  create_trigger :update_supporters_phone_index, sql_definition: <<-SQL
-      CREATE TRIGGER update_supporters_phone_index BEFORE INSERT OR UPDATE ON public.supporters FOR EACH ROW EXECUTE FUNCTION update_phone_index_on_supporters()
-  SQL
   create_trigger :update_supporters_fts, sql_definition: <<-SQL
       CREATE TRIGGER update_supporters_fts BEFORE INSERT OR UPDATE ON public.supporters FOR EACH ROW EXECUTE FUNCTION update_fts_on_supporters()
+  SQL
+  create_trigger :update_supporters_phone_index, sql_definition: <<-SQL
+      CREATE TRIGGER update_supporters_phone_index BEFORE INSERT OR UPDATE ON public.supporters FOR EACH ROW EXECUTE FUNCTION update_phone_index_on_supporters()
   SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220419171847) do
+ActiveRecord::Schema.define(version: 20220516224148) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pg_stat_statements"
   enable_extension "uuid-ossp"
+  enable_extension "pg_trgm"
+  enable_extension "btree_gin"
 
   create_table "activities", force: :cascade do |t|
     t.integer  "supporter_id"
@@ -1088,6 +1090,7 @@ ActiveRecord::Schema.define(version: 20220419171847) do
   add_index "supporters", ["anonymous", "nonprofit_id"], name: "index_supporters_on_anonymous_and_nonprofit_id", using: :btree
   add_index "supporters", ["fts"], name: "supporters_fts_idx", using: :gin
   add_index "supporters", ["name"], name: "index_supporters_on_name", using: :btree
+  add_index "supporters", ["name"], name: "name_search_idx", using: :gin, opclass: {"name"=>:gin_trgm_ops}
   add_index "supporters", ["nonprofit_id", "deleted"], name: "supporters_nonprofit_id_not_deleted", where: "(NOT deleted)", using: :btree
   add_index "supporters", ["nonprofit_id", "imported_at"], name: "index_supporters_on_nonprofit_id_and_imported_at", using: :btree
   add_index "supporters", ["nonprofit_id", "phone_index", "deleted"], name: "index_supporters_on_nonprofit_id_and_phone_index_and_deleted", where: "((phone IS NOT NULL) AND ((phone)::text <> ''::text))", using: :btree

--- a/spec/lib/query/query_supporters_spec.rb
+++ b/spec/lib/query/query_supporters_spec.rb
@@ -11,6 +11,7 @@ describe QuerySupporters do
   
   let(:np) { force_create(:nonprofit)}
   let(:supporter1) { force_create(:supporter, nonprofit: np, name: 'Cacau')}
+  let(:eric_schultz) {force_create(:supporter, nonprofit:np, name: "Eric Schultz")}
   let(:supporter2) { force_create(:supporter, nonprofit: np, name: 'Penelope')}
   let(:campaign) { force_create(:campaign, nonprofit: np, slug: "slug stuff")}
   let(:campaign_gift_option) { force_create(:campaign_gift_option, campaign: campaign, name: campaign_gift_option_name, amount_one_time: gift_level_one_time, amount_recurring: gift_level_recurring)}
@@ -237,8 +238,8 @@ describe QuerySupporters do
         supporter1.save!
       }
 
-      it 'finds when using character filled phone number' do 
-        result = QuerySupporters.full_search(np.id, { search: "A search term" })
+      it 'finds when using character filled phone number' do
+        result = QuerySupporters.full_search(np.id, { search: "search term" }) # if this starts with A it will catch Cacau is that bad? I don't know
         expect(result[:data].count).to eq 0
       end
     end
@@ -262,6 +263,30 @@ describe QuerySupporters do
         it 'finds the supporter' do
           result = QuerySupporters.full_search(np.id, { search: 'Cac' })
           expect(result[:data][0]['id']).to eq supporter1.id
+        end
+      end
+
+      context 'when the name being searched has part of the full name' do
+        it 'finds the supporter' do
+          eric_schultz
+          result = QuerySupporters.full_search(np.id, { search: 'eri' })
+          expect(result[:data][0]['id']).to eq eric_schultz.id
+        end
+      end
+
+      context 'when the name being searched has parts of the full name for both words' do
+        it 'finds the supporter' do
+          eric_schultz
+          result = QuerySupporters.full_search(np.id, { search: 'eri schu' })
+          expect(result[:data][0]['id']).to eq eric_schultz.id
+        end
+      end
+
+      context 'when the name being searched has parts of the full name but one part is wrong' do
+        it 'finds the supporter' do
+          eric_schultz
+          result = QuerySupporters.full_search(np.id, { search: 'jim schu' })
+          expect(result[:data][0]['id']).to eq eric_schultz.id
         end
       end
 


### PR DESCRIPTION
Closes #347 

I had to backport quite a bit of code from Rails 5 and 6 because opclasses just aren't supported in Rails 4 schemas. That would explain why we were getting inconsistent results.

Additionally, I noticed that indexes which use expressions instead of columns weren't being properly handled. For example, we had an index on supporters for `lower(name)`. That wasn't being written out. This is now written out and roundtripped properly.

We do have to be careful in the changes in `config/initializers/17_postgres_opclass_support.rb` since it modifies the db so please review in detail.

- Remove old similarity search
- Add support for opclasses and expression based indexes into Rails 4
- Allow QuerySupporters to use the new trigram search
