### PR TITLE
Revert "Add similarity to supporters name search"

### DIFF
--- a/app/legacy_lib/query_supporters.rb
+++ b/app/legacy_lib/query_supporters.rb
@@ -231,7 +231,6 @@ module QuerySupporters
     if query[:search].present?
       expr = expr.and_where(%Q(
         supporters.fts @@ websearch_to_tsquery('english', $search)
-        OR supporters.name % $search
         OR (
           supporters.phone IS NOT NULL
           AND supporters.phone != ''

--- a/app/models/supporter.rb
+++ b/app/models/supporter.rb
@@ -96,7 +96,6 @@ class Supporter < ActiveRecord::Base
   scope :deleted, -> {where(deleted: true)}
   scope :merged, -> {where('merged_at IS NOT NULL')}
   scope :not_merged, -> {where('merged_at IS NULL')}
-  scope :similar_names, -> (name) { where('name % ?', name) }
 
   geocoded_by :full_address
   reverse_geocoded_by :latitude, :longitude do |obj, results|

--- a/db/migrate/20220221223739_add_similarity_to_name_search.rb
+++ b/db/migrate/20220221223739_add_similarity_to_name_search.rb
@@ -1,7 +1,0 @@
-class AddSimilarityToNameSearch < ActiveRecord::Migration
-  def change
-    enable_extension :pg_trgm
-
-    add_index :supporters, :name, name: :name_search_idx, order: {name: :gin_trgm_ops}
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,6 @@ ActiveRecord::Schema.define(version: 20220419171847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_trgm"
   enable_extension "pg_stat_statements"
   enable_extension "uuid-ossp"
 
@@ -1085,7 +1084,6 @@ ActiveRecord::Schema.define(version: 20220419171847) do
   add_index "supporters", ["anonymous", "nonprofit_id"], name: "index_supporters_on_anonymous_and_nonprofit_id", using: :btree
   add_index "supporters", ["fts"], name: "supporters_fts_idx", using: :gin
   add_index "supporters", ["name"], name: "index_supporters_on_name", using: :btree
-  add_index "supporters", ["name"], name: "name_search_idx", using: :btree
   add_index "supporters", ["nonprofit_id", "deleted"], name: "supporters_nonprofit_id_not_deleted", where: "(NOT deleted)", using: :btree
   add_index "supporters", ["nonprofit_id", "imported_at"], name: "index_supporters_on_nonprofit_id_and_imported_at", using: :btree
   add_index "supporters", ["nonprofit_id", "phone_index", "deleted"], name: "index_supporters_on_nonprofit_id_and_phone_index_and_deleted", where: "((phone IS NOT NULL) AND ((phone)::text <> ''::text))", using: :btree
@@ -1269,10 +1267,10 @@ ActiveRecord::Schema.define(version: 20220419171847) do
   create_trigger :update_donations_fts, sql_definition: <<-SQL
       CREATE TRIGGER update_donations_fts BEFORE INSERT OR UPDATE ON public.donations FOR EACH ROW EXECUTE FUNCTION update_fts_on_donations()
   SQL
-  create_trigger :update_supporters_phone_index, sql_definition: <<-SQL
-      CREATE TRIGGER update_supporters_phone_index BEFORE INSERT OR UPDATE ON public.supporters FOR EACH ROW EXECUTE FUNCTION update_phone_index_on_supporters()
-  SQL
   create_trigger :update_supporters_fts, sql_definition: <<-SQL
       CREATE TRIGGER update_supporters_fts BEFORE INSERT OR UPDATE ON public.supporters FOR EACH ROW EXECUTE FUNCTION update_fts_on_supporters()
+  SQL
+  create_trigger :update_supporters_phone_index, sql_definition: <<-SQL
+      CREATE TRIGGER update_supporters_phone_index BEFORE INSERT OR UPDATE ON public.supporters FOR EACH ROW EXECUTE FUNCTION update_phone_index_on_supporters()
   SQL
 end

--- a/spec/lib/query/query_supporters_spec.rb
+++ b/spec/lib/query/query_supporters_spec.rb
@@ -242,57 +242,6 @@ describe QuerySupporters do
         expect(result[:data].count).to eq 0
       end
     end
-
-    context 'when searching for a supporter by name' do
-      context 'when the name is the same' do
-        it 'finds the supporter' do
-          result = QuerySupporters.full_search(np.id, { search: 'Cacau' })
-          expect(result[:data][0]['id']).to eq supporter1.id
-        end
-      end
-
-      context 'when the name being searched has more characters' do
-        it 'finds the supporter' do
-          result = QuerySupporters.full_search(np.id, { search: 'Cacau Borges' })
-          expect(result[:data][0]['id']).to eq supporter1.id
-        end
-      end
-
-      context 'when the name being searched has less characters' do
-        it 'finds the supporter' do
-          result = QuerySupporters.full_search(np.id, { search: 'Cac' })
-          expect(result[:data][0]['id']).to eq supporter1.id
-        end
-      end
-
-      context 'when the name being searched is different' do
-        it 'does not find the supporter' do
-          result = QuerySupporters.full_search(np.id, { search: 'Olivia' })
-          expect(result[:data].count).to eq 0
-        end
-      end
-
-      context 'when multiple supporters have a similar name' do
-        it 'finds multiple supporters' do
-          supporter2.name = 'Cacau Borges'
-          supporter2.save!
-          result = QuerySupporters.full_search(np.id, { search: 'Cacau' })
-          expect(result[:data].count).to eq 2
-        end
-      end
-
-      context 'when searching for a name with a different spelling' do
-        it 'finds the supporter' do
-          result = QuerySupporters.full_search(np.id, { search: 'Kacau' })
-          expect(result[:data][0]['id']).to eq supporter1.id
-        end
-
-        it 'finds the supporter' do
-          result = QuerySupporters.full_search(np.id, { search: 'Peenelohpe' })
-          expect(result[:data][0]['id']).to eq supporter2.id
-        end
-      end
-    end
   end
 
   describe '.dupes_on_name_and_phone' do


### PR DESCRIPTION
Since we had issues with the similarity search and we haven't merged the replacement, I think it'd make sense to revert this so we can actually deploy changes again.

This reverts commit 401bd231113df055f98b9f6c17bd7c00805a3566.
