### PR TITLE
body key in MailchimpBatchOperation's needs to be a string

### DIFF
--- a/app/models/mailchimp_batch_operation.rb
+++ b/app/models/mailchimp_batch_operation.rb
@@ -23,7 +23,7 @@ class MailchimpBatchOperation
     if (supporter.email) 
       result = {method: method, path: path}
       if body
-        result[:body] = body
+        result[:body] = JSON::dump(body)
       end
       result
     else

--- a/spec/models/mailchimp_batch_operation_spec.rb
+++ b/spec/models/mailchimp_batch_operation_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe MailchimpBatchOperation, :type => :model do
 
   context 'when method == POST' do
     describe '#to_h' do 
-      it 'has no body key' do
+      it 'has a body key' do
         supporter = build_stubbed(:supporter_base, email:"something@email.com")
         email_list = build_stubbed(:email_list_base)
         operation = MailchimpBatchOperation.new(supporter: supporter, list: email_list, method: 'POST')
 
-        expect(operation.to_h).to match({method: "POST", path: email_list.list_members_path, body: an_instance_of(Hash)})
+        expect(operation.to_h).to match({method: "POST", path: email_list.list_members_path, body: an_instance_of(String)})
       end
     end
   end


### PR DESCRIPTION
The Mailchimp API expects the body keys sent to `/batches` to be a string containing JSON, not the JSON as objects. This corrects that bug.