### PR TITLE
Backport ActiveModel::Errors::UnknownAttributesError, add a spec and update the various backports around AttributeAssignment to Rails 5.2

### DIFF
--- a/config/initializers/1_attribute_assignment_patch.rb
+++ b/config/initializers/1_attribute_assignment_patch.rb
@@ -2,7 +2,7 @@
 # this is available in newer versions of rails that we aren't running
 if Rails.version < '5.2'
   require "active_support/core_ext/hash/keys"
-  require "active_model/errors" unless ActiveModel.const_defined?(:Errors)
+  require "active_model/errors"
   require "active_model/forbidden_attributes_protection"
 
   module ActiveModel

--- a/config/initializers/1_attribute_assignment_patch.rb
+++ b/config/initializers/1_attribute_assignment_patch.rb
@@ -1,9 +1,57 @@
 # frozen_string_literal: true
 # this is available in newer versions of rails that we aren't running
-if Rails.version < '5'
+if Rails.version < '5.2'
   require "active_support/core_ext/hash/keys"
+  require "active_model/errors" unless ActiveModel.const_defined?(:Errors)
+  require "active_model/forbidden_attributes_protection"
 
   module ActiveModel
+    # from https://github.com/rails/rails/blob/26521331e5923a0c50fa50984d2f924e5f26c50b/activemodel/lib/active_model/errors.rb
+    class Errors
+      # Raised when unknown attributes are supplied via mass assignment.
+      class UnknownAttributeError < NoMethodError
+        attr_reader :record, :attribute
+
+        def initialize(record, attribute)
+          @record = record
+          @attribute = attribute
+          super("unknown attribute '#{attribute}' for #{@record.class}.")
+        end
+      end
+    end
+
+
+    # Raised when forbidden attributes are used for mass assignment.
+    #
+    #   class Person < ActiveRecord::Base
+    #   end
+    #
+    #   params = ActionController::Parameters.new(name: 'Bob')
+    #   Person.new(params)
+    #   # => ActiveModel::ForbiddenAttributesError
+    #
+    #   params.permit!
+    #   Person.new(params)
+    #   # => #<Person id: nil, name: "Bob">
+    # from :https://github.com/rails/rails/blob/26521331e5923a0c50fa50984d2f924e5f26c50b/activemodel/lib/active_model/forbidden_attributes_protection.rb
+    class ForbiddenAttributesError < StandardError
+    end
+
+    # from :https://github.com/rails/rails/blob/26521331e5923a0c50fa50984d2f924e5f26c50b/activemodel/lib/active_model/forbidden_attributes_protection.rb
+    module ForbiddenAttributesProtection # :nodoc:
+      private
+        def sanitize_for_mass_assignment(attributes)
+          if attributes.respond_to?(:permitted?)
+            raise ActiveModel::ForbiddenAttributesError if !attributes.permitted?
+            attributes.to_h
+          else
+            attributes
+          end
+        end
+        alias :sanitize_forbidden_attributes :sanitize_for_mass_assignment
+    end
+
+    # from https://github.com/rails/rails/blob/26521331e5923a0c50fa50984d2f924e5f26c50b/activemodel/lib/active_model/attribute_assignment.rb
     module AttributeAssignment
       include ActiveModel::ForbiddenAttributesProtection
 
@@ -27,29 +75,31 @@ if Rails.version < '5'
       #   cat.name # => 'Gorby'
       #   cat.status # => 'sleeping'
       def assign_attributes(new_attributes)
-        unless new_attributes.respond_to?(:each_pair)
-          raise ArgumentError, "When assigning attributes, you must pass a hash as an argument, #{new_attributes.class} passed."
+        if !new_attributes.respond_to?(:stringify_keys)
+          raise ArgumentError, "When assigning attributes, you must pass a hash as an argument."
         end
         return if new_attributes.empty?
-
-        _assign_attributes(sanitize_for_mass_assignment(new_attributes))
+  
+        attributes = new_attributes.stringify_keys
+        _assign_attributes(sanitize_for_mass_assignment(attributes))
       end
-
+  
       alias attributes= assign_attributes
-
+  
       private
+  
         def _assign_attributes(attributes)
           attributes.each do |k, v|
             _assign_attribute(k, v)
           end
         end
-
+  
         def _assign_attribute(k, v)
           setter = :"#{k}="
           if respond_to?(setter)
             public_send(setter, v)
           else
-            raise UnknownAttributeError.new(self, k.to_s)
+            raise ActiveModel::Errors::UnknownAttributeError.new(self, k)
           end
         end
     end

--- a/spec/backport/action_model_attribute_assignment_spec.rb
+++ b/spec/backport/action_model_attribute_assignment_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require 'rails_helper'
+require "active_support/core_ext/hash/indifferent_access"
+require "active_support/hash_with_indifferent_access"
+
+# from https://github.com/rails/rails/blob/ac6aa32f7cf66264ba87eabed7c042bb60bcf3a2/activemodel/test/cases/attribute_assignment_test.rb
+describe ActiveModel::AttributeAssignment do
+
+  let(:model) {
+    Class.new do 
+      include ActiveModel::AttributeAssignment
+
+      attr_accessor :name, :description
+
+      def initialize(attributes = {})
+        assign_attributes(attributes)
+      end
+
+      def broken_attribute=(value)
+        raise ErrorFromAttributeWriter
+      end
+
+      protected
+
+      attr_writer :metadata
+    end
+
+  }
+
+  let(:protected_params) {
+    Class.new do 
+      attr_accessor :permitted
+      alias :permitted? :permitted
+  
+      delegate :keys, :key?, :has_key?, :empty?, to: :@parameters
+  
+      def initialize(attributes)
+        @parameters = attributes.with_indifferent_access
+        @permitted = false
+      end
+  
+      def permit!
+        @permitted = true
+        self
+      end
+  
+      def [](key)
+        @parameters[key]
+      end
+  
+      def to_h
+        @parameters
+      end
+  
+      def stringify_keys
+        dup
+      end
+  
+      def dup
+        super.tap do |duplicate|
+          duplicate.instance_variable_set :@permitted, permitted?
+        end
+      end
+    end
+  }
+
+  
+
+  before(:each) {
+    stub_const("Model", model)
+    stub_const("ProtectedParams", protected_params)
+    stub_const("ErrorFromAttributeWriter", Class.new(StandardError))
+
+  }
+
+  it "simple assignment" do
+    model = Model.new
+
+    model.assign_attributes(name: "hello", description: "world")
+    assert_equal "hello", model.name
+    assert_equal "world", model.description
+  end
+
+  it "assign non-existing attribute" do
+    model = Model.new
+    error = assert_raises(ActiveModel::Errors::UnknownAttributeError) do
+      model.assign_attributes(hz: 1)
+    end
+
+    assert_equal model, error.record
+    assert_equal "hz", error.attribute
+  end
+
+  it "assign private attribute" do
+    model = Model.new
+    assert_raises(ActiveModel::Errors::UnknownAttributeError) do
+      model.assign_attributes(metadata: { a: 1 })
+    end
+  end
+
+  it "does not swallow errors raised in an attribute writer" do
+    assert_raises(ErrorFromAttributeWriter) do
+      Model.new(broken_attribute: 1)
+    end
+  end
+
+  it "an ArgumentError is raised if a non-hash-like object is passed" do
+    assert_raises(ArgumentError) do
+      Model.new(1)
+    end
+  end
+
+  it "forbidden attributes cannot be used for mass assignment" do
+    params = ProtectedParams.new(name: "Guille", description: "m")
+
+    assert_raises(ActiveModel::ForbiddenAttributesError) do
+      Model.new(params)
+    end
+  end
+
+  it "permitted attributes can be used for mass assignment" do
+    params = ProtectedParams.new(name: "Guille", description: "desc")
+    params.permit!
+    model = Model.new(params)
+
+    assert_equal "Guille", model.name
+    assert_equal "desc", model.description
+  end
+
+  it "regular hash should still be used for mass assignment" do
+    model = Model.new(name: "Guille", description: "m")
+
+    assert_equal "Guille", model.name
+    assert_equal "m", model.description
+  end
+
+  it "assigning no attributes should not raise, even if the hash is un-permitted" do
+    model = Model.new
+    assert_nil model.assign_attributes(ProtectedParams.new({}))
+  end
+end


### PR DESCRIPTION
I found out that an error was missing in the backport fo ActiveModel::AttributeAssignment. That made me realize that we didn't have any specs for that and that led to some upgrading of the backport to get those specs to pass. I think we're good now.
