### PR TITLE
Add SimpleObject

### DIFF
--- a/app/models/simple_object.rb
+++ b/app/models/simple_object.rb
@@ -1,0 +1,14 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+#
+# ONLY USED FOR TESTING
+# This file is basically a super simple mock for testing certain behaviors around events and relationship
+# We use it in specs only
+class SimpleObject < ActiveRecord::Base
+  include Model::Houidable
+  setup_houid :smplobj, :houid
+  belongs_to :parent, class_name: "SimpleObject"
+  belongs_to :nonprofit
+
+  has_many :friends, class_name: "SimpleObject", foreign_key: 'friend_id'
+
+end

--- a/db/migrate/20220112210520_create_simple_objects.rb
+++ b/db/migrate/20220112210520_create_simple_objects.rb
@@ -1,0 +1,12 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+class CreateSimpleObjects < ActiveRecord::Migration
+  def change
+    create_table :simple_objects do |t|
+      t.string :houid
+      t.references :parent
+      t.references :friend
+      t.references :nonprofit
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -934,6 +934,15 @@ ActiveRecord::Schema.define(version: 20220419171847) do
   add_index "sessions", ["session_id"], name: "index_sessions_on_session_id", using: :btree
   add_index "sessions", ["updated_at"], name: "index_sessions_on_updated_at", using: :btree
 
+  create_table "simple_objects", force: :cascade do |t|
+    t.string   "houid"
+    t.integer  "parent_id"
+    t.integer  "friend_id"
+    t.integer  "nonprofit_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
   create_table "source_tokens", id: false, force: :cascade do |t|
     t.uuid     "token",                                    null: false
     t.datetime "expiration"

--- a/spec/factories/simple_objects.rb
+++ b/spec/factories/simple_objects.rb
@@ -1,0 +1,16 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+FactoryBot.define do
+  factory :simple_object do
+    factory :simple_object_with_nonprofit do 
+      nonprofit {create(:nonprofit_base)}
+    
+      factory :simple_object_with_parent do
+        parent { create(:simple_object, parent: create(:simple_object), )}
+
+        factory :simple_object_with_friends_and_parent do
+          friends {[create(:simple_object), create(:simple_object, parent: create(:simple_object))]} 
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are certain common behaviors and mixins that we want to verify are correct. Those behaviors relate to actual objects in the database. We could test those mixins on every class which uses the mixin but it becomes hard to separate failures based on the mixin itself versus something that's actually wrong with the mixin itself. This simple class and table allows us to use real database-backed objects for testing but we can modify the structure to fit the tests needed instead of the reverse.

Ideally, this table would only be added to the DB when running in the test environment. Unfortunately, I'm not aware of a good way to actually do that.

- Add simple_objects table
- Add SimpleObject class
- Add simple_object factories
