### PR TITLE
Add YARD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ javascripts/api
 .byebug_history
 
 /payouts
+
+# yard related directories
+/ruby_docs
+/.yardoc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+-m markdown -o ./ruby_docs

--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,7 @@ group :development, :ci, :test do
   gem 'shoulda-matchers'
   gem 'rspec-json_expectations'
   gem 'debug'
+  gem 'yard'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,6 +500,9 @@ GEM
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    webrick (1.7.0)
+    yard (0.9.27)
+      webrick (~> 1.7.0)
 
 PLATFORMS
   ruby
@@ -595,6 +598,7 @@ DEPENDENCIES
   traceroute
   tunemygc
   webmock
+  yard
 
 RUBY VERSION
    ruby 2.6.10p210

--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ Each component should have its own file.
 ### react:lib
 This generator creates a basic Typescript module along with a test file.
 
+## Documentation
+
+You can get generate documentation for the Ruby source by running:
+
+`bundle exec yard doc`
+
+Alternatively, you can have it run in local webserver and autoupdate by running:
+
+`bundle exec yard server -r`
+
 ### Providing the complete corresponding source code
 
 **Note: This is not legal advice and provides a suggestion which may be compliant. You should talk with your legal counsel if you have


### PR DESCRIPTION
In the process of documenting a PR, I realized we don't have a good way to actually make sure that documentations is valid and usable. This adds YARD to our project.

To generate the docs, call `bundle exec yard doc`. To have a live updating version of the docs, try `bundle exec yard server -r`


