### PR TITLE
Add ApplicationRecord

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+
+  include Model::Houidable
+  include Model::AsMoneyable
+end


### PR DESCRIPTION
Rails uses an ApplicationRecord for newer versions of Rails. It is useful sharing some common model features so let's just add it now.

