### PR TITLE
Add Houidable tests

### DIFF
--- a/spec/models/nonprofit_spec.rb
+++ b/spec/models/nonprofit_spec.rb
@@ -2,6 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Nonprofit, type: :model do
+  it_behaves_like 'an houidable entity', :np
 
   it {is_expected.to validate_presence_of(:name)}
   

--- a/spec/models/supporter_spec.rb
+++ b/spec/models/supporter_spec.rb
@@ -2,6 +2,8 @@
 require 'rails_helper'
 
 RSpec.describe Supporter, type: :model do
+  it_behaves_like 'an houidable entity', :supp
+
   it { is_expected.to have_many(:addresses).class_name("SupporterAddress")}
   it { is_expected.to belong_to(:primary_address).class_name("SupporterAddress")}
   

--- a/spec/support/contexts/houidable_context.rb
+++ b/spec/support/contexts/houidable_context.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+
+# tests whether an class properly has an houidable configured
+# @param [String,symbol] prefix the prefix expected for generated houids
+#   For example, for supporters, with houids that look like `supp_3wN...`,
+#   the prefix is `:supp`.
+# @param [String, symbol] attribute the attribute where houids stored. This is usually `:houid`
+#   but in some cases could be something else
+shared_examples 'an houidable entity' do |prefix, attribute|
+
+  let(:houid_attribute) { attribute || :houid }
+  
+  it {
+    is_expected.to have_attributes(houid_prefix: prefix.to_sym)
+  }
+
+  it {
+    is_expected.to have_attributes(houid_attribute: houid_attribute.to_sym)
+  }
+end


### PR DESCRIPTION
- Add shared example for testing whether a class is set up for generating Houid's
- Add tests for supporters and nonprofits to verify they are an Houidable entity
