### PR TITLE
Add #run and hide #adapter in PeriodicReport

### DIFF
--- a/app/legacy_lib/scheduled_jobs.rb
+++ b/app/legacy_lib/scheduled_jobs.rb
@@ -122,7 +122,7 @@ module ScheduledJobs
         if Time.current.day == 1
           active_periodic_reports = PeriodicReport.active
           active_periodic_reports.each do |report|
-            report.adapter.run
+            report.run
           end
           "Sent #{active_periodic_reports.count} periodic reports!"
         end

--- a/app/models/periodic_report.rb
+++ b/app/models/periodic_report.rb
@@ -18,9 +18,8 @@ class PeriodicReport < ActiveRecord::Base
 
   scope :active, -> { where(active: true) }
 
-  def adapter
-    PeriodicReportAdapter.build({ report_type: report_type, nonprofit_id: nonprofit_id, period: period, users: users })
-  end
+  # run the report
+  delegate :run, to: :adapter
 
   private
 
@@ -49,5 +48,9 @@ class PeriodicReport < ActiveRecord::Base
         errors.add(:users, 'must be a user of the nonprofit or a super admin')
       end
     end
+  end
+
+  def adapter
+    PeriodicReportAdapter.build({ report_type: report_type, nonprofit_id: nonprofit_id, period: period, users: users })
   end
 end

--- a/spec/models/periodic_report_spec.rb
+++ b/spec/models/periodic_report_spec.rb
@@ -91,7 +91,10 @@ RSpec.describe PeriodicReport, type: :model do
     end
   end
 
-  describe '#adapter' do
+  describe '#run' do
+
+    it { is_expected.to delegate_method(:run).to(:adapter) }
+
     context 'when the report is for failed recurring donations' do
       let(:attributes) do
         {
@@ -103,8 +106,6 @@ RSpec.describe PeriodicReport, type: :model do
       end
       let(:options) { attributes.except(:active).merge({ :nonprofit_id => nonprofit.id }) }
 
-      subject { nonprofit.periodic_reports.create(attributes).adapter }
-
       let(:failed_recurring_donations_report) { double }
 
       before do
@@ -115,7 +116,8 @@ RSpec.describe PeriodicReport, type: :model do
       end
 
       it 'calls the correct corresponding adapter' do
-        expect(subject).to eq(failed_recurring_donations_report)
+        expect(failed_recurring_donations_report).to receive(:run)
+        nonprofit.periodic_reports.create(attributes).run
       end
     end
 
@@ -130,8 +132,6 @@ RSpec.describe PeriodicReport, type: :model do
       end
       let(:options) { attributes.except(:active).merge({ :nonprofit_id => nonprofit.id }) }
 
-      subject { nonprofit.periodic_reports.create(attributes).adapter }
-
       let(:cancelled_recurring_donations_report) { double }
 
       before do
@@ -142,7 +142,8 @@ RSpec.describe PeriodicReport, type: :model do
       end
 
       it 'calls the correct corresponding adapter' do
-        expect(subject).to eq(cancelled_recurring_donations_report)
+        expect(cancelled_recurring_donations_report).to receive(:run)
+        nonprofit.periodic_reports.create(attributes).run
       end
     end
   end


### PR DESCRIPTION
When working on #345, I realized we could simplify the calls to running a PeriodicReport's adapter from a report. We can do that by adding `PeriodicReport#run` and then delegating that to the adapter itself. Then you don't even need to know the adapter itself exists. 

Once I did that, I realized another thing: there isn't an obvious reason why someone would need `PeriodicReport#adapter`. Since that's the case, I've made `#adapter` private. We can change it back later if we see a need but for now, this makes the most sense I think.

