### PR TITLE
Remove Ruby 2.7.6 from the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         matrix:
           os: [ubuntu-20.04]
           node: [14.19.1]
-          ruby: ['2.6.10', '2.7.6']
+          ruby: ['2.6.10']
         fail-fast: false
       steps:
         - uses: actions/checkout@v2


### PR DESCRIPTION
Eventually, we'll need to get 2.7 working but for now, it's not worth the annoyance of seeing the 2.7 builds fail.
