### PR TITLE
Remove the locale_for_supporter methods in InsertRecurringDonation and InsertDonation

### DIFF
--- a/app/legacy_lib/insert_donation.rb
+++ b/app/legacy_lib/insert_donation.rb
@@ -103,7 +103,7 @@ module InsertDonation
     update_donation_keys(result)
 
     JobQueue.queue(JobTypes::NonprofitPaymentNotificationJob, result['donation'].id, result['donation'].payment.id)
-    JobQueue.queue(JobTypes::DonorDirectDebitNotificationJob, result['donation'].id, locale_for_supporter(result['donation'].supporter.id))
+    JobQueue.queue(JobTypes::DonorDirectDebitNotificationJob, result['donation'].id, result['donation'].supporter.locale)
     # do this for making test consistent
     result['activity'] = {}
     result
@@ -190,13 +190,6 @@ private
   # Return either the parsed DateTime from a date in data, or right now
   def self.date_from_data(data)
     data.merge('date' => data['date'].blank? ? Time.current : Chronic.parse(data['date']))
-  end
-
-  def self.locale_for_supporter(supporter_id)
-    Psql.execute(
-      Qexpr.new.select(:locale).from(:supporters)
-        .where("id=$id", id: supporter_id)
-    ).first['locale']
   end
 
   def self.payment_provider(data)

--- a/app/legacy_lib/insert_recurring_donation.rb
+++ b/app/legacy_lib/insert_recurring_donation.rb
@@ -98,7 +98,7 @@ module InsertRecurringDonation
     end
 
     DonationMailer.delay.nonprofit_payment_notification(result['donation']['id'])
-    DonationMailer.delay.donor_direct_debit_notification(result['donation']['id'], locale_for_supporter(result['donation']['supporter_id']))
+    DonationMailer.delay.donor_direct_debit_notification(result['donation']['id'], Supporter.find(result['donation']['supporter_id']).locale)
 
     { status: 200, json: result }
   end
@@ -238,14 +238,6 @@ def self.get_test_start_date(data)
     return Chronic.parse(data[:recurring_donation][:start_date])
 
 
-  end
-
-
-  def self.locale_for_supporter(supporter_id)
-    Psql.execute(
-      Qexpr.new.select(:locale).from(:supporters)
-        .where("id=$id", id: supporter_id)
-    ).first['locale']
   end
 
   def self.payment_provider(data)


### PR DESCRIPTION
If you look at `.locale_for_supporter` in `InsertDonation` and `InsertRecurringDonation`, it's not really useful. You can do the same far more simply by taking a Supporter object and calling `#locale`. So we're doing that now.
