### PR TITLE
Remove unused `Campaign#recurring_fund`

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -20,7 +20,6 @@ class Campaign < ActiveRecord::Base
 		:vimeo_video_id,
 		:youtube_video_id,
 		:summary,
-		:recurring_fund, # bool: whether this is a recurring campaign
 		:body,
 		:goal_amount_dollars, #accessor: translated into goal_amount (cents)
 		:show_total_raised, # bool

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -17,7 +17,6 @@
     app.end_date_time = app.campaign_end_datetime
     app.hide_activities = <%= @campaign.hide_activity_feed %>
 		app.days_remaining = '<%= @campaign.days_left %>'
-		app.recurring_fund = <%= @campaign.recurring_fund? %>
     app.vimeo_id = "<%= @campaign.vimeo_video_id ? @campaign.vimeo_video_id : '' %>"
     app.current_campaign_editor = <%= current_campaign_editor? %>
     app.is_parent_campaign = <%= @campaign.parent_campaign? %>

--- a/db/migrate/20220608214048_remove_recurring_fund_from_campaigns.rb
+++ b/db/migrate/20220608214048_remove_recurring_fund_from_campaigns.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+class RemoveRecurringFundFromCampaigns < ActiveRecord::Migration
+  def change
+    remove_column :campaigns, :recurring_fund
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220606201226) do
+ActiveRecord::Schema.define(version: 20220608214048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,7 +127,6 @@ ActiveRecord::Schema.define(version: 20220606201226) do
     t.boolean  "published"
     t.string   "background_image",              limit: 255
     t.integer  "total_supporters"
-    t.boolean  "recurring_fund"
     t.string   "slug",                          limit: 255
     t.string   "youtube_video_id",              limit: 255
     t.string   "tagline",                       limit: 255

--- a/spec/lib/insert/insert_duplicate_spec.rb
+++ b/spec/lib/insert/insert_duplicate_spec.rb
@@ -60,7 +60,6 @@ describe InsertDuplicate do
       :main_image => nil,
       :published => false,
       :receipt_message => nil,
-      :recurring_fund => nil,
       :show_recurring_amount => false,
       :show_total_count => true,
       :show_total_raised => true,


### PR DESCRIPTION
Based on https://github.com/houdiniproject/houdini/pull/1143

There's a column called `recurring_fund` on `Campaign`. I can't find any place that it's used so let's remove it.
