### PR TITLE
StripeMockHelper now delegates any missing methods to StripeMock

### DIFF
--- a/spec/factories/stripe_accounts.rb
+++ b/spec/factories/stripe_accounts.rb
@@ -4,43 +4,43 @@ FactoryBot.define do
     object {"{}"}
 
     trait :with_pending do 
-      object { StripeMock.mock_webhook_event('account.updated.with-pending')['data']['object']}
+      object { StripeMockHelper.mock_webhook_event('account.updated.with-pending')['data']['object']}
     end
 
     trait :with_temporarily_verified do 
-      object { StripeMock.mock_webhook_event('account.updated.with-temporarily_verified')['data']['object']}
+      object { StripeMockHelper.mock_webhook_event('account.updated.with-temporarily_verified')['data']['object']}
     end
     
     trait :with_temporarily_verified_with_deadline do
-      object { StripeMock.mock_webhook_event('account.updated.with-temporarily_verified-with-deadline')['data']['object']}
+      object { StripeMockHelper.mock_webhook_event('account.updated.with-temporarily_verified-with-deadline')['data']['object']}
     end
 
     trait :with_verified do
-      object { StripeMock.mock_webhook_event('account.updated.with-verified')['data']['object']}
+      object { StripeMockHelper.mock_webhook_event('account.updated.with-verified')['data']['object']}
     end
 
     trait :with_verified_and_bank_provided_with_active_but_empty_future_requirements do
-      object { StripeMock.mock_webhook_event('account.updated.with-verified-and-bank-provided-with-active-but-empty-future_requirements')['data']['object']}
+      object { StripeMockHelper.mock_webhook_event('account.updated.with-verified-and-bank-provided-with-active-but-empty-future_requirements')['data']['object']}
     end
 
     trait :with_verified_and_bank_provided_but_future_requirements do 
-      object { StripeMock.mock_webhook_event('account.updated.with-verified-and-bank-provided-but-future-requirements')['data']['object']}
+      object { StripeMockHelper.mock_webhook_event('account.updated.with-verified-and-bank-provided-but-future-requirements')['data']['object']}
     end
 
     trait :with_verified_and_bank_provided_but_future_requirements_pending do 
-      object { StripeMock.mock_webhook_event('account.updated.with-verified-and-bank-provided-but-future-requirements-pending')['data']['object']}
+      object { StripeMockHelper.mock_webhook_event('account.updated.with-verified-and-bank-provided-but-future-requirements-pending')['data']['object']}
     end
 
     trait :with_unverified do
-      object { StripeMock.mock_webhook_event('account.updated.with-unverified')['data']['object']}
+      object { StripeMockHelper.mock_webhook_event('account.updated.with-unverified')['data']['object']}
     end
 
     trait :with_unverified_from_verified do
-      object { StripeMock.mock_webhook_event('account.updated.with-unverified-from-verified')['data']['object']}
+      object { StripeMockHelper.mock_webhook_event('account.updated.with-unverified-from-verified')['data']['object']}
     end
 
     trait :without_future_requirements do
-      object {StripeMock.mock_webhook_event('account.updated.without-future-requirements')['data']['object']}
+      object {StripeMockHelper.mock_webhook_event('account.updated.without-future-requirements')['data']['object']}
     end
   end
 end

--- a/spec/factory_specs/stripe/stripe_cards_spec.rb
+++ b/spec/factory_specs/stripe/stripe_cards_spec.rb
@@ -15,12 +15,12 @@ describe :stripe_card do
   it 'creates 1 Stripe::Customer' do
     create(:stripe_card_base)
 
-    expect(StripeMock.instance.customers.count).to eq 1
+    expect(StripeMockHelper.instance.customers.count).to eq 1
   end
 
   it 'has created a single source on the customer' do
     create(:stripe_card_base)
 
-    expect(StripeMock.instance.customers.first[1][:sources][:total_count]).to eq 1
+    expect(StripeMockHelper.instance.customers.first[1][:sources][:total_count]).to eq 1
   end
 end

--- a/spec/lib/cancel_billing_subscriptions_spec.rb
+++ b/spec/lib/cancel_billing_subscriptions_spec.rb
@@ -88,7 +88,7 @@ describe CancelBillingSubscription do
 
     describe 'with a failure' do
       def prepare_stripe_error
-        StripeMock.prepare_error(Stripe::StripeError.new('some failure'), :retrieve_customer_subscription)
+        StripeMockHelper.prepare_error(Stripe::StripeError.new('some failure'), :retrieve_customer_subscription)
       end
 
       it 'has a status of :unprocessable entity' do

--- a/spec/lib/export/export_payments_spec.rb
+++ b/spec/lib/export/export_payments_spec.rb
@@ -222,7 +222,7 @@ describe ExportPayments do
         nonprofit.save!
         cust = Stripe::Customer.create()
         card.stripe_customer_id = cust.id
-        source = Stripe::Customer.create_source(cust.id, {source: StripeMock.generate_card_token(brand: 'Visa', country: 'US')})
+        source = Stripe::Customer.create_source(cust.id, {source: StripeMockHelper.generate_card_token(brand: 'Visa', country: 'US')})
         card.stripe_card_id = source.id
         card.save!
         allow(Stripe::Charge).to receive(:create).and_wrap_original {|m, *args| a = m.call(*args);

--- a/spec/lib/insert/insert_bank_account_spec.rb
+++ b/spec/lib/insert/insert_bank_account_spec.rb
@@ -72,7 +72,7 @@ describe InsertBankAccount do
 
       it 'Stripe::Account.retrieve fails' do
         expect(StripeAccountUtils).to receive(:find_or_create).and_return("account_id")
-        StripeMock.prepare_error(Stripe::StripeError.new("some error happened"), :get_account )
+        StripeMockHelper.prepare_error(Stripe::StripeError.new("some error happened"), :get_account )
 
         expect { InsertBankAccount.with_stripe(nonprofit, user, {:stripe_bank_account_token => 'blah'})}.to(raise_error{|error|
           expect(error).to be_a Stripe::StripeError
@@ -83,11 +83,11 @@ describe InsertBankAccount do
     describe 'works with account retrieval' do
       before (:each) { nonprofit.vetted = true; nonprofit.save!}
       let(:stripe_acct) {Stripe::Account.create(managed: true, country: 'US', display_name: "test_display_name")}
-      let(:stripe_bank_account_token) { StripeMock.generate_bank_token(country: "US", routing_number: "110000000", account_number: "000123456789") }
+      let(:stripe_bank_account_token) { StripeMockHelper.generate_bank_token(country: "US", routing_number: "110000000", account_number: "000123456789") }
 
       it 'sets failure message when external_account create fails' do
         expect(Stripe::Account).to receive(:retrieve).and_return(stripe_acct)
-        StripeMock.prepare_error(Stripe::StripeError.new("hmm"), :create_external_account)
+        StripeMockHelper.prepare_error(Stripe::StripeError.new("hmm"), :create_external_account)
         expect { InsertBankAccount.with_stripe(nonprofit, user, {:stripe_bank_account_token => stripe_bank_account_token}) }.to raise_error {|error|
           expect(error).to be_a ArgumentError
           expect(error.message).to eq 'Failed to connect the bank account: #<Stripe::StripeError: hmm>'
@@ -124,7 +124,7 @@ describe InsertBankAccount do
         old_bank_account_true
       }
       let(:stripe_acct) {Stripe::Account.create(managed: true, country: 'US', display_name: "test_display_name")}
-      let(:stripe_bank_account_token) { StripeMock.generate_bank_token(country: "US", routing_number: "110000000", account_number: "000123456789") }
+      let(:stripe_bank_account_token) { StripeMockHelper.generate_bank_token(country: "US", routing_number: "110000000", account_number: "000123456789") }
 
       let(:old_bank_account_nil) { force_create(:bank_account, nonprofit: nonprofit, deleted: false)}
       let(:old_bank_account_false) { force_create(:bank_account, nonprofit: nonprofit, deleted: false)}

--- a/spec/lib/insert/insert_card_spec.rb
+++ b/spec/lib/insert/insert_card_spec.rb
@@ -4,7 +4,7 @@ describe InsertCard do
   describe'.with_stripe' do
 
 
-  let(:stripe_card_token) { StripeMock.generate_card_token(last4: '9191', exp_year:2011)}
+  let(:stripe_card_token) { StripeMockHelper.generate_card_token(last4: '9191', exp_year:2011)}
   let(:default_card_attribs) {
     {
       created_at: Time.now,
@@ -135,7 +135,7 @@ describe InsertCard do
 
     describe 'card exists' do
       before(:each) {
-        @first_card_tok = StripeMock.generate_card_token(:last4 => '9999', :exp_year => '2122')
+        @first_card_tok = StripeMockHelper.generate_card_token(:last4 => '9999', :exp_year => '2122')
         @stripe_customer = Stripe::Customer.create()
         @stripe_customer.sources.create({token: @first_card_tok})
 
@@ -184,7 +184,7 @@ describe InsertCard do
     end
 
     it 'handle card errors' do
-      StripeMock.prepare_error(
+      StripeMockHelper.prepare_error(
         Stripe::CardError.new('card error', 
           300, 
           nil, 
@@ -200,7 +200,7 @@ describe InsertCard do
     end
 
     it 'handle stripe errors' do
-      StripeMock.prepare_error(Stripe::StripeError.new('card error'), :new_customer)
+      StripeMockHelper.prepare_error(Stripe::StripeError.new('card error'), :new_customer)
       card_data = { :holder_type => 'Nonprofit', :holder_id => nonprofit.id, :stripe_card_id => 'card_88888', :stripe_card_token => stripe_card_token, :name => "card_name" }
 
       card_ret = InsertCard::with_stripe(card_data);

--- a/spec/lib/insert/insert_charge_spec.rb
+++ b/spec/lib/insert/insert_charge_spec.rb
@@ -123,7 +123,7 @@ describe InsertCharge do
 
     describe 'handle StripeAccountUtils Find and Create failure' do
       before(:each){
-        StripeMock.prepare_error(Stripe::StripeError.new("chaos"), :new_account)
+        StripeMockHelper.prepare_error(Stripe::StripeError.new("chaos"), :new_account)
       }
       it 'does it fail properly' do
         expect{ InsertCharge.with_stripe(amount: 100,
@@ -158,7 +158,7 @@ describe InsertCharge do
           card_for_other_supporter.stripe_card_id = new_source.id
           card_for_other_supporter.save!
           #billing_subscription
-        # StripeMock.prepare_error(Stripe::StripeError.new("chaos"), :get_customer)
+        # StripeMockHelper.prepare_error(Stripe::StripeError.new("chaos"), :get_customer)
         }
 
         def create_expected_charge_args(expected_card, fee_total)
@@ -180,7 +180,7 @@ describe InsertCharge do
         it 'handles card error' do
 
           expect(Stripe::Charge).to receive(:create).with(*create_expected_charge_args(card, fee_total)).and_wrap_original{|m, *args| m.call(*args)}
-          StripeMock.prepare_card_error(:card_declined)
+          StripeMockHelper.prepare_card_error(:card_declined)
           finished_result = InsertCharge.with_stripe(amount: 100,
                                                     :nonprofit_id => nonprofit.id,
                                                     :supporter_id => supporter.id,
@@ -202,7 +202,7 @@ describe InsertCharge do
 
         it 'handles general Stripe error' do
           expect(Stripe::Charge).to receive(:create).with(*create_expected_charge_args(card, fee_total)).and_wrap_original{|m, *args| m.call(*args)}
-          StripeMock.prepare_error(Stripe::StripeError.new("blah"), :new_charge)
+          StripeMockHelper.prepare_error(Stripe::StripeError.new("blah"), :new_charge)
 
           finished_result = InsertCharge.with_stripe(amount: 100,
                                                     :nonprofit_id => nonprofit.id,

--- a/spec/lib/insert/insert_payout_spec.rb
+++ b/spec/lib/insert/insert_payout_spec.rb
@@ -71,7 +71,7 @@ describe InsertPayout do
         end
         
         let!(:ba) do
-          ba = InsertBankAccount.with_stripe(nonprofit, user, {stripe_bank_account_token: StripeMock.generate_bank_token(), name: bank_name})
+          ba = InsertBankAccount.with_stripe(nonprofit, user, {stripe_bank_account_token: StripeMockHelper.generate_bank_token(), name: bank_name})
           ba.pending_verification = false
           ba.save!
           ba
@@ -112,7 +112,7 @@ describe InsertPayout do
           let(:supporter) {force_create(:supporter, nonprofit: nonprofit)}
         end
         let!(:ba) do
-          ba = InsertBankAccount.with_stripe(nonprofit, user, {stripe_bank_account_token: StripeMock.generate_bank_token(), name: bank_name})
+          ba = InsertBankAccount.with_stripe(nonprofit, user, {stripe_bank_account_token: StripeMockHelper.generate_bank_token(), name: bank_name})
           ba.pending_verification = false
           ba.save!
           ba
@@ -172,7 +172,7 @@ describe InsertPayout do
         it 'fails properly when Stripe payout call fails' do
           #we have a deactivation record but deactivate set to false
           force_create(:nonprofit_deactivation, nonprofit: nonprofit, deactivated: false)
-          StripeMock.prepare_error(Stripe::StripeError.new("Payout failed"), :new_payout)
+          StripeMockHelper.prepare_error(Stripe::StripeError.new("Payout failed"), :new_payout)
 
           entities_yesterday
           expected_payments
@@ -219,7 +219,7 @@ describe InsertPayout do
         end
 
         let!(:ba) do
-          ba = InsertBankAccount.with_stripe(nonprofit, user, {stripe_bank_account_token: StripeMock.generate_bank_token(), name: bank_name})
+          ba = InsertBankAccount.with_stripe(nonprofit, user, {stripe_bank_account_token: StripeMockHelper.generate_bank_token(), name: bank_name})
           ba.pending_verification = false
           ba.save!
           ba
@@ -281,7 +281,7 @@ describe InsertPayout do
         end
 
         it 'fails properly when Stripe payout call fails' do
-          StripeMock.prepare_error(Stripe::StripeError.new("Payout failed"), :new_payout)
+          StripeMockHelper.prepare_error(Stripe::StripeError.new("Payout failed"), :new_payout)
 
           result = InsertPayout.with_stripe(nonprofit.id, {stripe_account_id: nonprofit.stripe_account_id,
                                                     email: user_email,

--- a/spec/lib/insert/insert_tickets_spec.rb
+++ b/spec/lib/insert/insert_tickets_spec.rb
@@ -414,7 +414,7 @@ describe InsertTickets do
           nonprofit.stripe_account_id = Stripe::Account.create()['id']
           nonprofit.save!
           c = Stripe::Customer.create
-          source = Stripe::Customer.create_source(c.id, {source: StripeMock.generate_card_token})
+          source = Stripe::Customer.create_source(c.id, {source: StripeMockHelper.generate_card_token})
           card.stripe_card_id = source.id
           card.stripe_customer_id = c.id
           card.save!

--- a/spec/lib/pay_recurring_donation_spec.rb
+++ b/spec/lib/pay_recurring_donation_spec.rb
@@ -25,7 +25,7 @@ describe PayRecurringDonation  do
     let(:stripe_cust_id) { customer = Stripe::Customer.create();
     customer.id}
     let(:card) {
-      card = Stripe::Customer.create_source(stripe_cust_id, {source: StripeMock.generate_card_token(brand: 'Visa', country: 'US')})
+      card = Stripe::Customer.create_source(stripe_cust_id, {source: StripeMockHelper.generate_card_token(brand: 'Visa', country: 'US')})
       force_create(:card, holder: supporter, stripe_customer_id: stripe_cust_id, stripe_card_id: card.id)
     }
     let(:donation) {force_create(:donation, supporter: supporter, amount: 300, card: card, nonprofit: nonprofit)}

--- a/spec/lib/query/query_payments_spec.rb
+++ b/spec/lib/query/query_payments_spec.rb
@@ -101,7 +101,7 @@ describe QueryPayments do
       nonprofit.save!
       cust = Stripe::Customer.create()
       card.stripe_customer_id = cust.id
-      source = Stripe::Customer.create_source(cust.id, {source: StripeMock.generate_card_token(brand: 'Visa', country: 'US')})
+      source = Stripe::Customer.create_source(cust.id, {source: StripeMockHelper.generate_card_token(brand: 'Visa', country: 'US')})
       card.stripe_card_id = source.id
       card.save!
       expect(Stripe::Charge).to receive(:create).exactly(3).times.and_wrap_original {|m, *args| a = m.call(*args);

--- a/spec/lib/stripe_account_utils_spec.rb
+++ b/spec/lib/stripe_account_utils_spec.rb
@@ -78,7 +78,7 @@ describe StripeAccountUtils do
     end
 
     it 'uses the redacted nonprofit info' do
-      StripeMock.prepare_error(Stripe::InvalidRequestError.new("things are bad", ''), :new_account)
+      StripeMockHelper.prepare_error(Stripe::InvalidRequestError.new("things are bad", ''), :new_account)
       result = StripeAccountUtils.create(nonprofit_with_bad_values)
       acct = Stripe::Account.retrieve(result)
       expect(acct.company.address.to_h.has_key?(:zip_code)).to be_falsy
@@ -89,7 +89,7 @@ describe StripeAccountUtils do
 
   describe 'testing with valid nonprofit' do
     it 'handles Stripe errors properly' do
-      StripeMock.prepare_error(Stripe::StripeError.new, :new_account)
+      StripeMockHelper.prepare_error(Stripe::StripeError.new, :new_account)
       expect { StripeAccountUtils.create(nonprofit)}.to(raise_error{|error|
         expect(error).to be_a Stripe::StripeError
         expect(nonprofit.stripe_account_id).to be_blank

--- a/spec/mailers/dispute_mailer_spec.rb
+++ b/spec/mailers/dispute_mailer_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe DisputeMailer, :type => :mailer do
     end
     let(:nonprofit) { force_create(:nonprofit, name: "spec_nonprofit_full")}
     let(:json) do
-      event =StripeMock.mock_webhook_event('charge.dispute.updated')
+      event =StripeMockHelper.mock_webhook_event('charge.dispute.updated')
       event['data']['object']
     end
     let(:supporter) { force_create(:supporter, nonprofit: nonprofit)}

--- a/spec/models/nonprofit_spec.rb
+++ b/spec/models/nonprofit_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Nonprofit, type: :model do
 
   describe 'with cards' do
     around(:each) do |ex|
-      StripeMock.start
+      StripeMockHelper.start
       ex.run
-      StripeMock.stop
+      StripeMockHelper.stop
     end
     
     before(:each) do

--- a/spec/models/stripe_event_spec.rb
+++ b/spec/models/stripe_event_spec.rb
@@ -43,19 +43,19 @@ RSpec.describe StripeEvent, :type => :model do
 
     it 'skips processing already processed events' do
       event_object_for_pending
-      StripeEvent.handle(StripeMock.mock_webhook_event('account.updated.with-pending'))
+      StripeEvent.handle(StripeMockHelper.mock_webhook_event('account.updated.with-pending'))
       expect(StripeAccount.count).to eq 0
     end
 
     it 'skips processing weve already processed a newer event for object' do
       later_event_object
-      StripeEvent.handle(StripeMock.mock_webhook_event('account.updated.with-pending'))
+      StripeEvent.handle(StripeMockHelper.mock_webhook_event('account.updated.with-pending'))
       expect(StripeAccount.count).to eq 0
     end
 
     describe 'new StripeAccount' do
       describe 'handles unverified' do
-        let(:event_json) { StripeMock.mock_webhook_event('account.updated.with-unverified')}
+        let(:event_json) { StripeMockHelper.mock_webhook_event('account.updated.with-unverified')}
 
         let(:last_event) { StripeEvent.last}
         let(:last_account) { StripeAccount.last}
@@ -110,7 +110,7 @@ RSpec.describe StripeEvent, :type => :model do
       end
 
       describe 'handles temporarily_verified' do
-        let(:event_json) { StripeMock.mock_webhook_event('account.updated.with-temporarily_verified')}
+        let(:event_json) { StripeMockHelper.mock_webhook_event('account.updated.with-temporarily_verified')}
 
         let(:last_event) { StripeEvent.last}
         let(:last_account) { StripeAccount.last}
@@ -164,7 +164,7 @@ RSpec.describe StripeEvent, :type => :model do
       end
 
       describe 'handles verified' do
-        let(:event_json) { StripeMock.mock_webhook_event('account.updated.with-verified')}
+        let(:event_json) { StripeMockHelper.mock_webhook_event('account.updated.with-verified')}
         let(:last_event) { StripeEvent.last}
         let(:last_account) { StripeAccount.last}
         
@@ -220,7 +220,7 @@ RSpec.describe StripeEvent, :type => :model do
 
     describe 'old StripeAccount' do 
       describe 'handles unverified' do
-        let(:event_json) { StripeMock.mock_webhook_event('account.updated.with-unverified')}
+        let(:event_json) { StripeMockHelper.mock_webhook_event('account.updated.with-unverified')}
         let(:last_event) { StripeEvent.last}
         let(:last_account) { create(:stripe_account, :with_unverified, stripe_account_id:'acct_1G8Y94CcxDUSisy4')}
 
@@ -280,7 +280,7 @@ RSpec.describe StripeEvent, :type => :model do
       end
 
       describe 'handles from pending to unverified' do
-        let(:event_json) { StripeMock.mock_webhook_event('account.updated.with-unverified')}
+        let(:event_json) { StripeMockHelper.mock_webhook_event('account.updated.with-unverified')}
         let(:last_event) { StripeEvent.last}
         let(:last_account) { create(:stripe_account, :with_pending, stripe_account_id:'acct_1G8Y94CcxDUSisy4')}
 
@@ -342,7 +342,7 @@ RSpec.describe StripeEvent, :type => :model do
       end
 
       describe 'handles temporarily_verified' do
-        let(:event_json) { StripeMock.mock_webhook_event('account.updated.with-temporarily_verified')}
+        let(:event_json) { StripeMockHelper.mock_webhook_event('account.updated.with-temporarily_verified')}
 
         let(:last_event) { StripeEvent.last}
         let(:last_account) { create(:stripe_account, stripe_account_id:'acct_1G8Y94CcxDUSisy4')}
@@ -400,7 +400,7 @@ RSpec.describe StripeEvent, :type => :model do
       end
 
       describe 'handles verified' do
-        let(:event_json) { StripeMock.mock_webhook_event('account.updated.with-verified')}
+        let(:event_json) { StripeMockHelper.mock_webhook_event('account.updated.with-verified')}
         let(:last_event) { StripeEvent.last}
         let(:last_account) { create(:stripe_account, stripe_account_id:'acct_1G8Y94CcxDUSisy4', currently_due: ['something'])}
         describe 'when in verification process' do
@@ -456,7 +456,7 @@ RSpec.describe StripeEvent, :type => :model do
       end
 
       describe 'handles pending' do
-        let(:event_json) { StripeMock.mock_webhook_event('account.updated.with-pending')}
+        let(:event_json) { StripeMockHelper.mock_webhook_event('account.updated.with-pending')}
         let(:last_event) { StripeEvent.last}
         let(:last_account) { create(:stripe_account, stripe_account_id:'acct_1G8Y94CcxDUSisy4', currently_due: ['something'])}
         describe 'when in verification process' do
@@ -516,7 +516,7 @@ RSpec.describe StripeEvent, :type => :model do
 
       describe 'handles verified to unverified' do
         let(:deadline) { Time.utc(2020, 2, 28, 22, 27, 35)}
-        let(:event_json) { StripeMock.mock_webhook_event('account.updated.with-unverified-from-verified')}
+        let(:event_json) { StripeMockHelper.mock_webhook_event('account.updated.with-unverified-from-verified')}
         let(:last_event) { StripeEvent.last}
         let(:last_account) { create(:stripe_account, stripe_account_id:'acct_1G8Y94CcxDUSisy4')}
 

--- a/spec/support/contexts/charge_context.rb
+++ b/spec/support/contexts/charge_context.rb
@@ -17,7 +17,7 @@ RSpec.shared_context :charge_succeeded_context do
   include_context :charge_context do 
 
     let(:event_json) do 
-      event_json = StripeMock.mock_webhook_event('charge.succeeded')
+      event_json = StripeMockHelper.mock_webhook_event('charge.succeeded')
       event_json
     end
   end

--- a/spec/support/contexts/disputes_context.rb
+++ b/spec/support/contexts/disputes_context.rb
@@ -92,7 +92,7 @@ RSpec.shared_context :dispute_created_context do
   include_context :disputes_context do 
 
     let(:event_json) do 
-      event_json = StripeMock.mock_webhook_event('charge.dispute.created')
+      event_json = StripeMockHelper.mock_webhook_event('charge.dispute.created')
       StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
       event_json
     end
@@ -174,7 +174,7 @@ RSpec.shared_context :dispute_funds_withdrawn_context do
   include_context :disputes_context do 
 
     let(:event_json) do 
-      event_json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
+      event_json = StripeMockHelper.mock_webhook_event('charge.dispute.funds_withdrawn')
       StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
       event_json
     end
@@ -266,7 +266,7 @@ end
 RSpec.shared_context :dispute_funds_reinstated_context do
   include_context :disputes_context
   let(:event_json) do
-    event_json =StripeMock.mock_webhook_event('charge.dispute.funds_reinstated')
+    event_json =StripeMockHelper.mock_webhook_event('charge.dispute.funds_reinstated')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
     event_json
   end
@@ -377,7 +377,7 @@ end
 RSpec.shared_context :dispute_lost_context do
   include_context :disputes_context
   let(:event_json) do
-    event_json =StripeMock.mock_webhook_event('charge.dispute.closed-lost')
+    event_json =StripeMockHelper.mock_webhook_event('charge.dispute.closed-lost')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
     event_json
   end
@@ -468,7 +468,7 @@ end
 RSpec.shared_context :dispute_won_context do
   include_context :disputes_context
   let(:event_json) do
-    event_json =StripeMock.mock_webhook_event('charge.dispute.closed-won')
+    event_json =StripeMockHelper.mock_webhook_event('charge.dispute.closed-won')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, event_json['data']['object'])
     event_json
   end
@@ -579,7 +579,7 @@ end
 RSpec.shared_context :dispute_created_and_withdrawn_at_same_time_context do 
   include_context :disputes_context
   let(:event_json_created) do
-    StripeMock.mock_webhook_event('charge.dispute.created-with-one-withdrawn')
+    StripeMockHelper.mock_webhook_event('charge.dispute.created-with-one-withdrawn')
   end
 
   let(:json_created) { event_json_created['data']['object']}
@@ -587,7 +587,7 @@ RSpec.shared_context :dispute_created_and_withdrawn_at_same_time_context do
   let(:json_funds_withdrawn) {event_json_funds_withdrawn['data']['object']}
 
   let(:event_json_funds_withdrawn) do
-    json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.funds_withdrawn')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
@@ -688,7 +688,7 @@ end
 RSpec.shared_context :dispute_created_and_withdrawn_in_order_context do 
   include_context :dispute_created_and_withdrawn_at_same_time_context
   let(:event_json_created) do
-    json = StripeMock.mock_webhook_event('charge.dispute.created')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.created')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
@@ -698,7 +698,7 @@ RSpec.shared_context :dispute_created_and_withdrawn_in_order_context do
   let(:json_funds_withdrawn) {event_json_funds_withdrawn['data']['object']}
 
   let(:event_json_funds_withdrawn) do
-    json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.funds_withdrawn')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
@@ -799,7 +799,7 @@ end
 RSpec.shared_context :dispute_created_withdrawn_and_lost_in_order_context do 
   include_context :disputes_context
   let(:event_json_created) do
-    json = StripeMock.mock_webhook_event('charge.dispute.created')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.created')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
@@ -807,7 +807,7 @@ RSpec.shared_context :dispute_created_withdrawn_and_lost_in_order_context do
   let(:json_created) { event_json_created['data']['object']}
 
   let(:event_json_funds_withdrawn) do
-    json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.funds_withdrawn')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
@@ -815,7 +815,7 @@ RSpec.shared_context :dispute_created_withdrawn_and_lost_in_order_context do
   let(:json_funds_withdrawn) {event_json_funds_withdrawn['data']['object']}
 
   let(:event_json_lost) do
-    json = StripeMock.mock_webhook_event('charge.dispute.closed-lost')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.closed-lost')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
@@ -915,7 +915,7 @@ RSpec.shared_context :dispute_created_with_withdrawn_and_lost_in_order_context d
   include_context :dispute_created_withdrawn_and_lost_in_order_context
 
   let(:event_json_created) do
-    json = StripeMock.mock_webhook_event('charge.dispute.created-with-one-withdrawn')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.created-with-one-withdrawn')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
@@ -1004,21 +1004,21 @@ RSpec.shared_context :dispute_lost_created_and_funds_withdrawn_at_same_time_cont
   
   include_context :disputes_context
   let(:event_json_created) do
-    json = StripeMock.mock_webhook_event('charge.dispute.created')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.created')
     json
   end
 
   let(:json_created) { event_json_created['data']['object']}
 
   let(:event_json_funds_withdrawn) do
-    json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.funds_withdrawn')
     json
   end
 
   let(:json_funds_withdrawn) {event_json_funds_withdrawn['data']['object']}
 
   let(:event_json_lost) do
-    json = StripeMock.mock_webhook_event('charge.dispute.closed-lost')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.closed-lost')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
@@ -1034,7 +1034,7 @@ RSpec.shared_context :dispute_lost_created_and_funds_withdrawn_at_same_time_cont
       gross_amount: 80000))}
 
   let(:event_json_created) do
-    json = StripeMock.mock_webhook_event('charge.dispute.created-with-one-withdrawn')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.created-with-one-withdrawn')
     json
   end
 end
@@ -1121,7 +1121,7 @@ end
 RSpec.shared_context :__dispute_with_two_partial_disputes_withdrawn_at_same_time_context do
   include_context :disputes_context
   let(:event_json_dispute_partial1) do
-    json = StripeMock.mock_webhook_event('charge.dispute.created-with-one-withdrawn--partial1')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.created-with-one-withdrawn--partial1')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
@@ -1129,7 +1129,7 @@ RSpec.shared_context :__dispute_with_two_partial_disputes_withdrawn_at_same_time
   let(:json_partial1) { event_json_dispute_partial1['data']['object']}
 
   let(:event_json_dispute_partial2) do
-    json = StripeMock.mock_webhook_event('charge.dispute.created-with-one-withdrawn--partial2')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.created-with-one-withdrawn--partial2')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end
@@ -1328,7 +1328,7 @@ RSpec.shared_context :legacy_dispute_context do
   let(:reinstated_payment) {reinstated_transaction.payment}
 
   let(:event_json) do
-    json = StripeMock.mock_webhook_event('charge.dispute.funds_withdrawn')
+    json = StripeMockHelper.mock_webhook_event('charge.dispute.funds_withdrawn')
     StripeMockHelper.stripe_helper.upsert_stripe_object(:dispute, json['data']['object'])
     json
   end

--- a/spec/support/contexts/shared_donation_charge_context.rb
+++ b/spec/support/contexts/shared_donation_charge_context.rb
@@ -42,7 +42,7 @@ RSpec.shared_context :shared_donation_charge_context do
 
 
   def generate_card_token(brand="Visa", country='US')
-    StripeMock.generate_card_token({brand: brand, country: country})
+    StripeMockHelper.generate_card_token({brand: brand, country: country})
   end
 
   around(:each){|example|

--- a/spec/support/contexts/shared_rd_donation_value_context.rb
+++ b/spec/support/contexts/shared_rd_donation_value_context.rb
@@ -381,7 +381,7 @@ RSpec.shared_context :shared_rd_donation_value_context do
       card.stripe_customer_id = 'some other id'
       cust = Stripe::Customer.create()
       card.stripe_customer_id = cust['id']
-      source = Stripe::Customer.create_source(cust.id, {source: StripeMock.generate_card_token})
+      source = Stripe::Customer.create_source(cust.id, {source: StripeMockHelper.generate_card_token})
       card.stripe_card_id = source.id
       card.save!
 

--- a/spec/support/stripe_mock_helper.rb
+++ b/spec/support/stripe_mock_helper.rb
@@ -1,59 +1,59 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 
 
-# StripeMockHelper adds some helper methods to RSpec. Additionally, it builds on
-# the features in StripeMock by creating
-
-module StripeMockHelper
-
-  # Creates a default test helper for the current StripeMock session
-  def self.create_default_helper
-    @@default_helper ||= StripeMock.create_test_helper
-  end
+# StripeMockHelper wraps the StripeMock to simplify creating a single test helper as part of
+# a test session. Generally, you can use StripeMockHelper like StripeMock except it adds a "default_helper"
+# to get the StripeTestHelper for the session.
+StripeMockHelper = Class.new do
+  
+  delegate_missing_to :StripeMock
 
   # Most StripeMock sessions only need a single test helper so you can get it here
   # @return a Stripe test helper or nil if none is set
-  def self.default_helper
-    if defined? @@default_helper
-      @@default_helper 
+  def default_helper
+    if defined? @default_helper
+      @default_helper 
     else
       nil
     end
   end
 
-  # Clears the default test helper for the current StripeMock session
-  def self.clear_default_helper
-    remove_class_variable :@@default_helper if defined? @@default_helper
-  end
-
+  alias_method :stripe_helper, :default_helper
   
   # sets up a StripeMock session and sets up StripeMock::default_helper
   # note: Rspec is set up to autostop a StripeMock session when an example finishes
-  def self.start
+  def start
     unless default_helper
       StripeMock.start
       create_default_helper
     end
   end
 
-  # stosp a StripeMock session and clears StripeMock::default_helper
-  def self.stop
+  # stops a StripeMock session and clears StripeMock::default_helper
+  def stop
     clear_default_helper
     StripeMock.stop
   end
 
-  # helper to get StripeMock::default_helper
-  def self.stripe_helper
-    default_helper
-  end
-
   # wraps a block in a StripeMock session and sets up StripeMock::default_helper
-  def self.mock(&block)
+  def mock(&block)
     start
 
     block.call
     
     stop
   end
-end
+
+  private
+  
+  # Clears the default test helper for the current StripeMock session
+  def clear_default_helper
+    remove_instance_variable :@default_helper if defined? @default_helper
+  end
+  
+  # Creates a default test helper for the current StripeMock session
+  def create_default_helper
+    @default_helper ||= StripeMock.create_test_helper
+  end
+end.new
     

--- a/spec/support/stripe_mock_helper.rb
+++ b/spec/support/stripe_mock_helper.rb
@@ -4,6 +4,7 @@
 # StripeMockHelper wraps the StripeMock to simplify creating a single test helper as part of
 # a test session. Generally, you can use StripeMockHelper like StripeMock except it adds a "default_helper"
 # to get the StripeTestHelper for the session.
+# @see StripeMock
 StripeMockHelper = Class.new do
   
   delegate_missing_to :StripeMock


### PR DESCRIPTION
It is a bit confusing using StripeMock in some places and StripeMockHelper in other places. In order to simplify things, StripeMockHelper delegates any missing method calls to StripeMock. This allows us to use StripeMockHelper as a drop-in replacement for StripeMock everywhere.

Depends on #391