### PR TITLE
Make entire side nav link bounding box clickable

### DIFF
--- a/app/assets/stylesheets/components/side_nav.scss
+++ b/app/assets/stylesheets/components/side_nav.scss
@@ -45,8 +45,7 @@ $sideNav-spacing: 8px 15px;
 	color: white;
 	font-weight: bold;
 	cursor: pointer;
-	display: table;
-	table-layout: fixed;
+	display: block;
 	@include transform(translateZ(0));
 	@include transition(color 0.2s ease-out);
 }


### PR DESCRIPTION
Based on https://github.com/houdiniproject/houdini/pull/1192

Previously, the background of the bounding box for links in the side nav wasn't clickable. This mean you have to be pointing at the icon or text. That's annoying as h*ck.

This changes the layout for side nav links to "block". Now, the entire bounding box if clickable.

