### PR TITLE
Standardize disputes

### DIFF
--- a/spec/factories/disputes.rb
+++ b/spec/factories/disputes.rb
@@ -1,7 +1,7 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 FactoryBot.define do
   factory :dispute do
-    stripe_dispute_id {"dp_05RsQX2eZvKYlo2C0FRTGSSA"}
+    stripe_dispute_id {"dp_05RsQX2eZvKYlo2C0FRTGSSA"} # the default dispute
     trait :autocreate_dispute do
       sequence(:stripe_dispute_id, 'a') {|i| "dp_05RsQX2eZvKYlo2C0FRTGSS" + i}
     end

--- a/spec/fixtures/stripe_webhooks/charge.dispute.closed-won.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.closed-won.json
@@ -17,7 +17,7 @@
           "available_on": 1565008160,
           "created": 1565008160,
           "currency": "usd",
-          "description": "Chargeback withdrawal for ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "description": "Chargeback withdrawal for ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "exchange_rate": null,
           "fee": 1500,
           "fee_details": [
@@ -30,7 +30,7 @@
             }
           ],
           "net": -24000,
-          "source": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",
             "data": [],
@@ -48,7 +48,7 @@
           "available_on": 1572381790,
           "created": 1572381790,
           "currency": "usd",
-          "description": "Chargeback reversal for ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "description": "Chargeback reversal for ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "exchange_rate": null,
           "fee": -1500,
           "fee_details": [
@@ -61,7 +61,7 @@
             }
           ],
           "net": 24000,
-          "source": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",
             "data": [],
@@ -73,7 +73,7 @@
           "type": "adjustment"
         }
       ],
-      "charge": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+      "charge": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
       "created": 1565008160,
       "currency": "usd",
       "evidence": {

--- a/spec/fixtures/stripe_webhooks/charge.dispute.closed-won.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.closed-won.json
@@ -5,7 +5,7 @@
   "created": 1572381790,
   "data": {
     "object": {
-      "id": "dp_15RsQX2eZvKYlo2C0ERTYUIA",
+      "id": "dp_05RsQX2eZvKYlo2C0FRTGSSA",
       "object": "dispute",
       "amount": 22500,
       "balance_transaction": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",

--- a/spec/fixtures/stripe_webhooks/charge.dispute.closed-won.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.closed-won.json
@@ -7,13 +7,13 @@
     "object": {
       "id": "dp_05RsQX2eZvKYlo2C0FRTGSSA",
       "object": "dispute",
-      "amount": 22500,
+      "amount": 80000,
       "balance_transaction": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
       "balance_transactions": [
         {
           "id": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
           "object": "balance_transaction",
-          "amount": -22500,
+          "amount": -80000,
           "available_on": 1565008160,
           "created": 1565008160,
           "currency": "usd",
@@ -29,7 +29,7 @@
               "type": "stripe_fee"
             }
           ],
-          "net": -24000,
+          "net": -81500,
           "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",
@@ -44,7 +44,7 @@
         {
           "id": "txn_1Y71X0BCJIIhvMWmMmtTY4m1",
           "object": "balance_transaction",
-          "amount": 22500,
+          "amount": 80000,
           "available_on": 1572381790,
           "created": 1572381790,
           "currency": "usd",
@@ -60,7 +60,7 @@
               "type": "stripe_fee"
             }
           ],
-          "net": 24000,
+          "net": 81500,
           "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",

--- a/spec/fixtures/stripe_webhooks/charge.dispute.funds_reinstated.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.funds_reinstated.json
@@ -17,7 +17,7 @@
           "available_on": 1567603760,
           "created": 1567603760,
           "currency": "usd",
-          "description": "Chargeback withdrawal for ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "description": "Chargeback withdrawal for ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "exchange_rate": null,
           "fee": 1500,
           "fee_details": [
@@ -30,7 +30,7 @@
             }
           ],
           "net": -24000,
-          "source": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",
             "data": [],
@@ -48,7 +48,7 @@
           "available_on": 1574977390,
           "created": 1574977390,
           "currency": "usd",
-          "description": "Chargeback reversal for ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "description": "Chargeback reversal for ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "exchange_rate": null,
           "fee": -1500,
           "fee_details": [
@@ -61,7 +61,7 @@
             }
           ],
           "net": 24000,
-          "source": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",
             "data": [],
@@ -73,7 +73,7 @@
           "type": "adjustment"
         }
       ],
-      "charge": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+      "charge": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
       "created": 1567603760,
       "currency": "usd",
       "evidence": {

--- a/spec/fixtures/stripe_webhooks/charge.dispute.funds_reinstated.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.funds_reinstated.json
@@ -7,13 +7,13 @@
     "object": {
       "id": "dp_05RsQX2eZvKYlo2C0FRTGSSA",
       "object": "dispute",
-      "amount": 22500,
+      "amount": 80000,
       "balance_transaction": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
       "balance_transactions": [
         {
           "id": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
           "object": "balance_transaction",
-          "amount": -22500,
+          "amount": -80000,
           "available_on": 1567603760,
           "created": 1567603760,
           "currency": "usd",
@@ -29,7 +29,7 @@
               "type": "stripe_fee"
             }
           ],
-          "net": -24000,
+          "net": -81500,
           "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",
@@ -44,7 +44,7 @@
         {
           "id": "txn_1Y71X0BCJIIhvMWmMmtTY4m1",
           "object": "balance_transaction",
-          "amount": 22500,
+          "amount": 80000,
           "available_on": 1574977390,
           "created": 1574977390,
           "currency": "usd",
@@ -60,7 +60,7 @@
               "type": "stripe_fee"
             }
           ],
-          "net": 24000,
+          "net": 81500,
           "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",

--- a/spec/fixtures/stripe_webhooks/charge.dispute.funds_reinstated.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.funds_reinstated.json
@@ -5,7 +5,7 @@
   "created": 1574977390,
   "data": {
     "object": {
-      "id": "dp_15RsQX2eZvKYlo2C0ERTYUIA",
+      "id": "dp_05RsQX2eZvKYlo2C0FRTGSSA",
       "object": "dispute",
       "amount": 22500,
       "balance_transaction": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",

--- a/spec/fixtures/stripe_webhooks/charge.dispute.updated.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.updated.json
@@ -17,7 +17,7 @@
           "available_on": 1567603760,
           "created": 1567603760,
           "currency": "usd",
-          "description": "Chargeback withdrawal for ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "description": "Chargeback withdrawal for ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "exchange_rate": null,
           "fee": 1500,
           "fee_details": [
@@ -30,7 +30,7 @@
             }
           ],
           "net": -24000,
-          "source": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",
             "data": [],
@@ -48,7 +48,7 @@
           "available_on": 1574977390,
           "created": 1574977390,
           "currency": "usd",
-          "description": "Chargeback reversal for ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "description": "Chargeback reversal for ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "exchange_rate": null,
           "fee": -1500,
           "fee_details": [
@@ -61,7 +61,7 @@
             }
           ],
           "net": 24000,
-          "source": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+          "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",
             "data": [],
@@ -73,7 +73,7 @@
           "type": "adjustment"
         }
       ],
-      "charge": "ch_1Y7vFYBCJIIhvMWmsdRJWSw5",
+      "charge": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
       "created": 1567603760,
       "currency": "usd",
       "evidence": {

--- a/spec/fixtures/stripe_webhooks/charge.dispute.updated.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.updated.json
@@ -7,13 +7,13 @@
     "object": {
       "id": "dp_05RsQX2eZvKYlo2C0FRTGSSA",
       "object": "dispute",
-      "amount": 22500,
+      "amount": 80000,
       "balance_transaction": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
       "balance_transactions": [
         {
           "id": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",
           "object": "balance_transaction",
-          "amount": -22500,
+          "amount": -80000,
           "available_on": 1567603760,
           "created": 1567603760,
           "currency": "usd",
@@ -29,7 +29,7 @@
               "type": "stripe_fee"
             }
           ],
-          "net": -24000,
+          "net": -81500,
           "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",
@@ -44,7 +44,7 @@
         {
           "id": "txn_1Y71X0BCJIIhvMWmMmtTY4m1",
           "object": "balance_transaction",
-          "amount": 22500,
+          "amount": 80000,
           "available_on": 1574977390,
           "created": 1574977390,
           "currency": "usd",
@@ -60,7 +60,7 @@
               "type": "stripe_fee"
             }
           ],
-          "net": 24000,
+          "net": 81500,
           "source": "ch_1Y7zzfBCJIIhvMWmSiNWrPAC",
           "sourced_transfers": {
             "object": "list",

--- a/spec/fixtures/stripe_webhooks/charge.dispute.updated.json
+++ b/spec/fixtures/stripe_webhooks/charge.dispute.updated.json
@@ -5,7 +5,7 @@
   "created": 1574977390,
   "data": {
     "object": {
-      "id": "dp_15RsQX2eZvKYlo2C0ERTYUIA",
+      "id": "dp_05RsQX2eZvKYlo2C0FRTGSSA",
       "object": "dispute",
       "amount": 22500,
       "balance_transaction": "txn_1Y75JVBCJIIhvMWmsnGK1JLD",

--- a/spec/mailers/dispute_mailer_spec.rb
+++ b/spec/mailers/dispute_mailer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe DisputeMailer, :type => :mailer do
     let(:mail) { DisputeMailer.funds_reinstated(dispute) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("$240 reinstated for dispute dp_15RsQX2eZvKYlo2C0ERTYUIA for spec_nonprofit_full")
+      expect(mail.subject).to eq("$240 reinstated for dispute dp_05RsQX2eZvKYlo2C0FRTGSSA for spec_nonprofit_full")
       expect(mail.to).to eq(["support@commitchange.com"])
       expect(mail.from).to eq(["support@commitchange.com"])
     end
@@ -53,7 +53,7 @@ RSpec.describe DisputeMailer, :type => :mailer do
     let(:mail) { DisputeMailer.won(dispute) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("WON dispute dp_15RsQX2eZvKYlo2C0ERTYUIA for spec_nonprofit_full")
+      expect(mail.subject).to eq("WON dispute dp_05RsQX2eZvKYlo2C0FRTGSSA for spec_nonprofit_full")
       expect(mail.to).to eq(["support@commitchange.com"])
       expect(mail.from).to eq(["support@commitchange.com"])
     end
@@ -95,7 +95,7 @@ RSpec.describe DisputeMailer, :type => :mailer do
     let(:mail) { DisputeMailer.updated(dispute) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("Updated dispute dp_15RsQX2eZvKYlo2C0ERTYUIA for spec_nonprofit_full, evidence due on 2019-09-16 00:59:59 UTC")
+      expect(mail.subject).to eq("Updated dispute dp_05RsQX2eZvKYlo2C0FRTGSSA for spec_nonprofit_full, evidence due on 2019-09-16 00:59:59 UTC")
       expect(mail.to).to eq(["support@commitchange.com"])
       expect(mail.from).to eq(["support@commitchange.com"])
     end

--- a/spec/mailers/dispute_mailer_spec.rb
+++ b/spec/mailers/dispute_mailer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe DisputeMailer, :type => :mailer do
     let(:mail) { DisputeMailer.funds_reinstated(dispute) }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("$240 reinstated for dispute dp_05RsQX2eZvKYlo2C0FRTGSSA for spec_nonprofit_full")
+      expect(mail.subject).to eq("$815 reinstated for dispute dp_05RsQX2eZvKYlo2C0FRTGSSA for spec_nonprofit_full")
       expect(mail.to).to eq(["support@commitchange.com"])
       expect(mail.from).to eq(["support@commitchange.com"])
     end
@@ -88,7 +88,7 @@ RSpec.describe DisputeMailer, :type => :mailer do
       stripe_charge_id: 'ch_1Y7zzfBCJIIhvMWmSiNWrPAC', nonprofit: nonprofit, payment:force_create(:payment,
          supporter:supporter,
         nonprofit: nonprofit,
-        gross_amount: 22500))}
+        gross_amount: 80000))}
   
     let(:obj) { StripeDispute.create(object:json) }
     let(:dispute) { obj.dispute }

--- a/spec/mailers/dispute_mailer_spec.rb
+++ b/spec/mailers/dispute_mailer_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe DisputeMailer, :type => :mailer do
     end
     let(:supporter) { force_create(:supporter, nonprofit: nonprofit)}
     let!(:charge) { force_create(:charge, supporter: supporter, 
-      stripe_charge_id: 'ch_1Y7vFYBCJIIhvMWmsdRJWSw5', nonprofit: nonprofit, payment:force_create(:payment,
+      stripe_charge_id: 'ch_1Y7zzfBCJIIhvMWmSiNWrPAC', nonprofit: nonprofit, payment:force_create(:payment,
          supporter:supporter,
         nonprofit: nonprofit,
         gross_amount: 22500))}

--- a/spec/support/contexts/disputes_context.rb
+++ b/spec/support/contexts/disputes_context.rb
@@ -271,7 +271,7 @@ RSpec.shared_context :dispute_funds_reinstated_context do
     event_json
   end
   let!(:charge) { force_create(:charge, supporter: supporter, 
-    stripe_charge_id: 'ch_1Y7vFYBCJIIhvMWmsdRJWSw5', nonprofit: nonprofit, payment:force_create(:payment,
+    stripe_charge_id: 'ch_1Y7zzfBCJIIhvMWmSiNWrPAC', nonprofit: nonprofit, payment:force_create(:payment,
        supporter:supporter,
       nonprofit: nonprofit,
       gross_amount: 22500))}
@@ -302,7 +302,7 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   end
 
   it 'has a correct charge id ' do 
-    expect(obj.stripe_charge_id).to eq "ch_1Y7vFYBCJIIhvMWmsdRJWSw5"
+    expect(obj.stripe_charge_id).to eq "ch_1Y7zzfBCJIIhvMWmSiNWrPAC"
   end
 
   it 'has a correct dispute id' do 
@@ -473,7 +473,7 @@ RSpec.shared_context :dispute_won_context do
     event_json
   end
   let!(:charge) { force_create(:charge, supporter: supporter, 
-    stripe_charge_id: 'ch_1Y7vFYBCJIIhvMWmsdRJWSw5', nonprofit: nonprofit, payment:force_create(:payment,
+    stripe_charge_id: 'ch_1Y7zzfBCJIIhvMWmSiNWrPAC', nonprofit: nonprofit, payment:force_create(:payment,
        supporter:supporter,
       nonprofit: nonprofit,
       gross_amount: 22500))}
@@ -504,7 +504,7 @@ RSpec.shared_context :dispute_won_specs do
   end
 
   it 'has a correct charge id ' do 
-    expect(obj.stripe_charge_id).to eq "ch_1Y7vFYBCJIIhvMWmsdRJWSw5"
+    expect(obj.stripe_charge_id).to eq "ch_1Y7zzfBCJIIhvMWmSiNWrPAC"
   end
 
   it 'has a correct dispute id' do 

--- a/spec/support/contexts/disputes_context.rb
+++ b/spec/support/contexts/disputes_context.rb
@@ -306,7 +306,7 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   end
 
   it 'has a correct dispute id' do 
-    expect(obj.stripe_dispute_id).to eq "dp_15RsQX2eZvKYlo2C0ERTYUIA"
+    expect(obj.stripe_dispute_id).to eq "dp_05RsQX2eZvKYlo2C0FRTGSSA"
   end
 
   it 'has a started_at of Time.at(1567603760)' do
@@ -508,7 +508,7 @@ RSpec.shared_context :dispute_won_specs do
   end
 
   it 'has a correct dispute id' do 
-    expect(obj.stripe_dispute_id).to eq "dp_15RsQX2eZvKYlo2C0ERTYUIA"
+    expect(obj.stripe_dispute_id).to eq "dp_05RsQX2eZvKYlo2C0FRTGSSA"
   end
   
   it 'has a started_at of Time.at(1565008160)' do

--- a/spec/support/contexts/disputes_context.rb
+++ b/spec/support/contexts/disputes_context.rb
@@ -274,7 +274,7 @@ RSpec.shared_context :dispute_funds_reinstated_context do
     stripe_charge_id: 'ch_1Y7zzfBCJIIhvMWmSiNWrPAC', nonprofit: nonprofit, payment:force_create(:payment,
        supporter:supporter,
       nonprofit: nonprofit,
-      gross_amount: 22500))}
+      gross_amount: 80000))}
 end
 
 RSpec.shared_context :dispute_funds_reinstated_specs do
@@ -297,8 +297,8 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
     expect(obj.net_change).to eq 0
   end
 
-  it 'has an amount of 22500' do
-    expect(obj.amount).to eq 22500
+  it 'has an amount of 80000' do
+    expect(obj.amount).to eq 80000
   end
 
   it 'has a correct charge id ' do 
@@ -316,7 +316,7 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   describe "dispute" do
     subject { dispute }
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq 22500 }
+    specify { expect(subject.gross_amount).to eq 80000 }
     specify { expect(subject.status).to eq "under_review" }
     specify { expect(subject.reason).to eq 'credit_not_processed' }
     specify { expect(subject.started_at).to eq Time.at(1567603760)}
@@ -329,7 +329,7 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   describe 'has a withdrawal_transaction' do
     subject{ withdrawal_transaction }
     specify {  expect(subject).to be_persisted }
-    specify {  expect(subject.gross_amount).to eq -22500 }
+    specify {  expect(subject.gross_amount).to eq -80000 }
     specify {  expect(subject.fee_total).to eq -1500 }
     specify {  expect(subject.stripe_transaction_id).to eq 'txn_1Y75JVBCJIIhvMWmsnGK1JLD' }
     specify { expect(subject.date).to eq DateTime.new(2019,9,4,13,29,20)}
@@ -339,9 +339,9 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   describe 'has a withdrawal_payment' do
     subject { withdrawal_payment}
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq -22500}
+    specify { expect(subject.gross_amount).to eq -80000}
     specify { expect(subject.fee_total).to eq -1500}
-    specify { expect(subject.net_amount).to eq -24000}
+    specify { expect(subject.net_amount).to eq -81500}
     specify { expect(subject.kind).to eq 'Dispute'}
     specify { expect(subject.nonprofit).to eq supporter.nonprofit}
     specify { expect(subject.date).to eq DateTime.new(2019,9,4,13,29,20)}
@@ -351,9 +351,9 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   describe 'has a reinstated_transaction' do
     subject{ reinstated_transaction }
     specify {  expect(subject).to be_persisted }
-    specify {  expect(subject.gross_amount).to eq 22500 }
+    specify {  expect(subject.gross_amount).to eq 80000 }
     specify {  expect(subject.fee_total).to eq 1500 }
-    specify { expect(subject.net_amount).to eq 24000}
+    specify { expect(subject.net_amount).to eq 81500}
     specify {  expect(subject.stripe_transaction_id).to eq 'txn_1Y71X0BCJIIhvMWmMmtTY4m1' }
     specify { expect(subject.date).to eq DateTime.new(2019,11,28,21,43,10)}
     specify { expect(subject.disbursed).to eq false }
@@ -362,7 +362,7 @@ RSpec.shared_context :dispute_funds_reinstated_specs do
   describe 'has a reinstated_payment' do
     subject { reinstated_payment}
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq 22500}
+    specify { expect(subject.gross_amount).to eq 80000}
     specify { expect(subject.fee_total).to eq 1500}
     specify { expect(subject.kind).to eq 'DisputeReversed'}
     specify { expect(subject.nonprofit).to eq supporter.nonprofit}
@@ -476,7 +476,7 @@ RSpec.shared_context :dispute_won_context do
     stripe_charge_id: 'ch_1Y7zzfBCJIIhvMWmSiNWrPAC', nonprofit: nonprofit, payment:force_create(:payment,
        supporter:supporter,
       nonprofit: nonprofit,
-      gross_amount: 22500))}
+      gross_amount: 80000))}
 end
 
 RSpec.shared_context :dispute_won_specs do
@@ -499,8 +499,8 @@ RSpec.shared_context :dispute_won_specs do
     expect(obj.net_change).to eq 0
   end
 
-  it 'has an amount of 22500' do
-    expect(obj.amount).to eq 22500
+  it 'has an amount of 80000' do
+    expect(obj.amount).to eq 80000
   end
 
   it 'has a correct charge id ' do 
@@ -518,7 +518,7 @@ RSpec.shared_context :dispute_won_specs do
   describe "dispute" do
     subject { dispute }
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq 22500 }
+    specify { expect(subject.gross_amount).to eq 80000 }
     specify { expect(subject.status).to eq "won" }
     specify { expect(subject.reason).to eq 'credit_not_processed' }
     specify { expect(subject.started_at).to eq Time.at(1565008160) }
@@ -531,7 +531,7 @@ RSpec.shared_context :dispute_won_specs do
   describe 'has a withdrawal_transaction' do
     subject{ withdrawal_transaction }
     specify {  expect(subject).to be_persisted }
-    specify {  expect(subject.gross_amount).to eq -22500 }
+    specify {  expect(subject.gross_amount).to eq -80000 }
     specify {  expect(subject.fee_total).to eq -1500 }
     specify {  expect(subject.stripe_transaction_id).to eq 'txn_1Y75JVBCJIIhvMWmsnGK1JLD' }
     specify { expect(subject.date).to eq DateTime.new(2019,8,5,12,29,20)}
@@ -541,9 +541,9 @@ RSpec.shared_context :dispute_won_specs do
   describe 'has a withdrawal_payment' do
     subject { withdrawal_payment}
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq -22500}
+    specify { expect(subject.gross_amount).to eq -80000}
     specify { expect(subject.fee_total).to eq -1500}
-    specify { expect(subject.net_amount).to eq -24000 }
+    specify { expect(subject.net_amount).to eq -81500 }
     specify { expect(subject.kind).to eq 'Dispute'}
     specify { expect(subject.nonprofit).to eq supporter.nonprofit}
     specify { expect(subject.date).to eq DateTime.new(2019,8,5,12,29,20)}
@@ -553,7 +553,7 @@ RSpec.shared_context :dispute_won_specs do
   describe 'has a reinstated_transaction' do
     subject{ reinstated_transaction }
     specify {  expect(subject).to be_persisted }
-    specify {  expect(subject.gross_amount).to eq 22500 }
+    specify {  expect(subject.gross_amount).to eq 80000 }
     specify {  expect(subject.fee_total).to eq 1500 }
     specify {  expect(subject.stripe_transaction_id).to eq 'txn_1Y71X0BCJIIhvMWmMmtTY4m1' }
     specify { expect(subject.date).to eq DateTime.new(2019,10,29,20,43,10)}
@@ -563,9 +563,9 @@ RSpec.shared_context :dispute_won_specs do
   describe 'has a reinstated_payment' do
     subject { reinstated_payment}
     specify { expect(subject).to be_persisted }
-    specify { expect(subject.gross_amount).to eq 22500}
+    specify { expect(subject.gross_amount).to eq 80000}
     specify { expect(subject.fee_total).to eq 1500}
-    specify { expect(subject.net_amount).to eq 24000 }
+    specify { expect(subject.net_amount).to eq 81500 }
     specify { expect(subject.kind).to eq 'DisputeReversed'}
     specify { expect(subject.nonprofit).to eq supporter.nonprofit}
     specify { expect(subject.date).to eq DateTime.new(2019,10,29,20,43,10)}


### PR DESCRIPTION
Previously, disputes fixtures had a set of different amounts, charge IDs and dispute IDs. This PR standardizes them more.
