### PR TITLE
Remove second_image and third_image from Nonprofit

### DIFF
--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -13,8 +13,6 @@ class Nonprofit < ActiveRecord::Base
     :email, # str: public organization contact email
     :phone, # str: public org contact phone
     :main_image, # str: url of featured image - first image in profile carousel
-    :second_image, # str: url of 2nd image in carousel
-    :third_image, # str: url of 3rd image in carousel
     :background_image,  # str: url of large profile background
     :remove_background_image, #bool carrierwave
     :logo, # str: small logo image url for searching
@@ -104,8 +102,6 @@ class Nonprofit < ActiveRecord::Base
   scope :published, -> {where(published: true)}
 
   mount_uploader :main_image, NonprofitUploader
-  mount_uploader :second_image, NonprofitUploader
-  mount_uploader :third_image, NonprofitUploader
   mount_uploader :background_image, NonprofitBackgroundUploader
   mount_uploader :logo, NonprofitLogoUploader
 

--- a/db/migrate/20220822211046_remove_second_and_third_images_from_nonprofit.rb
+++ b/db/migrate/20220822211046_remove_second_and_third_images_from_nonprofit.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+class RemoveSecondAndThirdImagesFromNonprofit < ActiveRecord::Migration
+  def change
+    remove_column :nonprofits, :second_image
+    remove_column :nonprofits, :third_image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220713204114) do
+ActiveRecord::Schema.define(version: 20220822211046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -696,8 +696,6 @@ ActiveRecord::Schema.define(version: 20220713204114) do
     t.string   "phone",                                       limit: 255
     t.string   "email",                                       limit: 255
     t.string   "main_image",                                  limit: 255
-    t.string   "second_image",                                limit: 255
-    t.string   "third_image",                                 limit: 255
     t.string   "website",                                     limit: 255
     t.string   "background_image",                            limit: 255
     t.string   "logo",                                        limit: 255


### PR DESCRIPTION
second_image and third_image were used by the legacy carousel. Since we don't use that, we should remove the fields.

Closes https://github.com/CommitChange/tix/issues/3828
