### PR TITLE
Remove expired recurring donations from the recurring donation view

### DIFF
--- a/app/controllers/nonprofits/recurring_donations_controller.rb
+++ b/app/controllers/nonprofits/recurring_donations_controller.rb
@@ -17,7 +17,7 @@ class RecurringDonationsController < ApplicationController
 				#TODO move into javascript
 				params[:active] = true
 
-        render json: QueryRecurringDonations.full_list(params[:nonprofit_id], params)
+        render json: QueryRecurringDonations.full_list(params[:nonprofit_id], params.merge(end_date_gt_or_equal: Time.current))
       end
 		end
 	end

--- a/app/legacy_lib/query_recurring_donations.rb
+++ b/app/legacy_lib/query_recurring_donations.rb
@@ -82,6 +82,12 @@ module QueryRecurringDonations
       expr = expr.where("#{failed_or_active_clauses.join(' OR ')}")
     end
 
+  
+
+    if query.key?(:end_date_gt_or_equal)
+      expr = expr.where("recurring_donations.end_date IS NULL OR recurring_donations.end_date >= $date", date: query[:end_date_gt_or_equal])
+    end
+
     if include_last_failed_charge && query.key?(:from_date) && query.key?(:before_date)
       expr = expr.where(
         'failed_charges.created_at >= $from_date


### PR DESCRIPTION
Previously, the recurring donation view shows recurring donations which had ended because they had an end date. This change removes them from the list.
