### PR TITLE
Add #supporter and #nonprofit to Refund and DisputeTransaction

### DIFF
--- a/app/models/dispute_transaction.rb
+++ b/app/models/dispute_transaction.rb
@@ -4,6 +4,9 @@ class DisputeTransaction < ActiveRecord::Base
   attr_accessible :gross_amount, :disbursed, :payment, :fee_total,
   :stripe_transaction_id, :date
 
+  has_one :nonprofit, through: :dispute
+  has_one :supporter, through: :dispute
+
   def gross_amount=(gross_amount)
     write_attribute(:gross_amount, gross_amount)
     calculate_net

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -20,6 +20,8 @@ class Refund < ActiveRecord::Base
 	belongs_to :payment
 	has_one :subtransaction_payment, through: :payment
 	has_one :misc_refund_info
+	has_one :nonprofit, through: :charge
+	has_one :supporter, through: :charge
 
 	scope :not_disbursed, ->{where(disbursed: [nil, false])}
 	scope :disbursed, ->{where(disbursed: [true])}

--- a/spec/models/dispute_transaction_spec.rb
+++ b/spec/models/dispute_transaction_spec.rb
@@ -4,4 +4,7 @@ require 'rails_helper'
 RSpec.describe DisputeTransaction, :type => :model do
   it {is_expected.to belong_to(:dispute)}
   it {is_expected.to belong_to(:payment)}
+
+  it { is_expected.to have_one(:nonprofit).through(:dispute) }
+  it { is_expected.to have_one(:supporter).through(:dispute) }
 end

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -6,4 +6,7 @@ RSpec.describe Refund, type: :model do
   it { is_expected.to belong_to(:payment) }
   it { is_expected.to have_one(:subtransaction_payment).through(:payment)}
   it { is_expected.to have_one(:misc_refund_info) }
+
+  it { is_expected.to have_one(:nonprofit).through(:charge) }
+  it { is_expected.to have_one(:supporter).through(:charge) }
 end


### PR DESCRIPTION
It's useful to be able to get these associations. This makes both of these consistent with Charge"

- Add #supporter and #nonprofit to Refund
- Add #supporter and #nonprofit to DisputeTransaction
