### PR TITLE
Cleanup the Callback documentation and simplify property types

### DIFF
--- a/app/javascript/common/Callbacks/Callback.ts
+++ b/app/javascript/common/Callbacks/Callback.ts
@@ -9,7 +9,8 @@ export default class Callback<T> {
 	}
 
 	/**
-   * A boolean property deciding whether .run should be called.
+   * A boolean method deciding whether .run should be called. By default it's true but can be overriden in subclasses.
+	 * @returns true if this callback should be run, false if it should not.
    */
 	canRun(): boolean {
 		return true;
@@ -26,10 +27,10 @@ export default class Callback<T> {
 	}
 
 	/**
-   * Runs the callback
+   * Runs the callback itself. Must be implemented in a child class.
    * @return a Promise<void> or void
    */
 	run(): Promise<void> | void {
-		throw new Error("You need to implement this in a child class");
+		throw new Error("You need to implement 'run' in your child class");
 	}
 }

--- a/app/javascript/common/Callbacks/run.ts
+++ b/app/javascript/common/Callbacks/run.ts
@@ -1,13 +1,15 @@
 // License: LGPL-3.0-or-later
-import Callback from "./Callback";
+import type { CallbackClass } from "./types";
 
 
 /**
  * A very simple function for conditionally running callbacks. Move into own file because we can mock it for CallbackController
  * @param input The input properties to every callback
- * @param callbacks callbacks to be run
+ * @param callbacks callbacks as classes to be run
+ * @template TCallbackProps the properties to be passed into the constructor of each Callback
+ * @returns {Promise<void>} a promise resolving on completion of all of the callbacks. Doesn't currently ever reject.
  */
-export default async function run<TCallbackInput>(input: TCallbackInput, callbacks: ReadonlyArray<{ new(input: TCallbackInput): Callback<TCallbackInput> }>): Promise<void> {
+export default async function run<TCallbackProps>(input: TCallbackProps, callbacks: readonly CallbackClass<TCallbackProps>[]): Promise<void> {
 	try {
 		for (const callback of callbacks) {
 			const obj = new callback(input);


### PR DESCRIPTION
Based on https://github.com/houdiniproject/houdini/pull/1382

- Improve documentation on Callback.ts
- Improve documentation and simplify the property types in Callbacks/run.ts

