### PR TITLE
Remove unused react generators in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,21 +95,6 @@ foreman start
 
 Assets get compiled from `/client` to `/public/client`
 
-## React Generators
-If creating new React or Typescript code,  please use the Rails generators with the 'react:' prefix. This include:
-
-### react:packroot
-This generator creates a new entry for Webpack. This is a place where Webpack will start
-when packing a new javascript output file. It also creates a corresponding component for the entry.
-Usually, you will have one of these per page.
-
-### react:component
-This generator creates a React component along with a test file for testing with Jest. 
-Each component should have its own file. 
-
-### react:lib
-This generator creates a basic Typescript module along with a test file.
-
 ## Documentation
 
 You can get generate documentation for the Ruby source by running:


### PR DESCRIPTION
- Correct the documentation for building a staging build
- Remove unused react generators

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
