### PR TITLE
Add `Donation#campaign_purchase?` and `Donation#actual_donation?`

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -52,6 +52,14 @@ class Donation < ActiveRecord::Base
 
 	scope :anonymous, -> {where(anonymous: true)}
 
+	def campaign_gift_purchase?
+		campaign_gifts.any?
+	end
+
+	def actual_donation?
+		campaign_gifts.none?
+	end
+
 	private
 
 	def set_anonymous

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -6,4 +6,24 @@ RSpec.describe Donation, :type => :model do
   it {
     is_expected.to have_many(:modern_donations)
   }
+
+  describe "#campaign_gift_purchase?" do
+    it 'is false without any campaign_gifts' do 
+      expect(build(:donation)).to_not be_campaign_gift_purchase
+    end
+
+    it 'is true with campaign_gifts' do 
+      expect(build(:donation, campaign_gifts: [build(:campaign_gift)])).to be_campaign_gift_purchase
+    end
+  end
+
+  describe "#actual_donation?" do
+    it 'is true without any campaign_gifts' do 
+      expect(build(:donation)).to be_actual_donation
+    end
+
+    it 'is false with campaign_gifts' do 
+      expect(build(:donation, campaign_gifts: [build(:campaign_gift)])).to_not be_actual_donation
+    end
+  end
 end


### PR DESCRIPTION
Because we overload donations with campaign gift purchases, deciding if a Donation really is a donation is confusing. This adds two methods to help us know for sure whether a Donation object is a campaign gift purchase or an actual donation.
