### PR TITLE
Update to date 2.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '~> 4.0'
 
 gem 'rack', git: "https://github.com/CommitChange/rack.git", branch: "1-6-stable"
 
-gem 'date', '~> 2.0.2'
+gem 'date', '~> 2.0.3'
 
 # https://stripe.com/docs/api
 gem 'stripe', '~> 4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
     dalli (3.2.3)
     dante (0.2.0)
     database_cleaner (1.6.1)
-    date (2.0.2)
+    date (2.0.3)
     debug_inspector (0.0.2)
     deep_merge (1.2.1)
     delayed_job (4.1.10)
@@ -517,7 +517,7 @@ DEPENDENCIES
   countries
   dalli
   database_cleaner
-  date (~> 2.0.2)
+  date (~> 2.0.3)
   delayed_job_active_record
   devise (~> 4.1)
   dotenv-rails


### PR DESCRIPTION
Bundler is yelling at us because it expects date 2.0.3. Why? I don't know. Let's just fix it.


**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
