### PR TITLE
Added search using nonprofit ID in super admin

### DIFF
--- a/app/legacy_lib/query_nonprofits.rb
+++ b/app/legacy_lib/query_nonprofits.rb
@@ -94,7 +94,8 @@ module QueryNonprofits
         nonprofits.name ILIKE $search
         OR nonprofits.email ILIKE $search
         OR nonprofits.city ILIKE $search
-      ), search: '%' + params[:search] + '%')
+        OR nonprofits.id = $id
+      ), search: '%' + params[:search] + '%', id: params[:search].to_i)
      end
 
      results = expr.execute


### PR DESCRIPTION
Previously, it wasn't possible to search using the nonprofit's numeric ID in the super admin. This change adds that helpful feature.

Closes https://github.com/CommitChange/tix/issues/3899

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
