### PR TITLE
Add spec for NonprofitsController#show loading

### DIFF
--- a/spec/requests/nonprofits_spec.rb
+++ b/spec/requests/nonprofits_spec.rb
@@ -21,7 +21,7 @@ describe NonprofitsController, type: :request do
   describe '#donate' do
     it 'allows being put into a frame by not setting X-Frame-Options header' do
       get "/nonprofits/#{our_np.id}/donate"
-      expect(response.status).to eq 200
+      expect(response).to have_http_status(:success)
       expect(response.headers).to_not include 'X-Frame-Options'
     end
   end
@@ -29,7 +29,7 @@ describe NonprofitsController, type: :request do
   describe '#btn' do
     it 'allows being put into a frame by not setting X-Frame-Options header' do
       get "/nonprofits/#{our_np.id}/btn"
-      expect(response.status).to eq 200
+      expect(response).to have_http_status(:success)
       expect(response.headers).to_not include 'X-Frame-Options'
     end
   end

--- a/spec/requests/nonprofits_spec.rb
+++ b/spec/requests/nonprofits_spec.rb
@@ -8,6 +8,16 @@ describe NonprofitsController, type: :request do
     nonprofit
   end
 
+  describe '#show' do
+    before(:each) do
+      nonprofit.update(published: true) # if we don't, the nonprofit is not visitable unless logged in
+    end
+    it 'loads properly' do
+      get "/nonprofits/#{our_np.id}"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
   describe '#donate' do
     it 'allows being put into a frame by not setting X-Frame-Options header' do
       get "/nonprofits/#{our_np.id}/donate"


### PR DESCRIPTION
Useful for #542

- Add spec for whether NonprofitsController#show loads
- Cleanup the specs for a few nonprofit requests

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
