### PR TITLE
Set BaseMailer as the common parent of Devise mailers

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <% if @resource.created_at.to_date == Date.today %>
-	<p>Thanks for signing up on <a href='https://commitchange.com'></a><%= Settings.general.name %></a>! We're excited to get you started.</p>
+	<p>Thanks for signing up on <a href='https://commitchange.com'><%= Settings.general.name %></a>! We're excited to get you started.</p>
 <% end %>
 
 <p>In order to verify your account, please <strong><a href='<%= confirmation_url(@user, :confirmation_token => @token) %>'>confirm your email address</a></strong></p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -226,6 +226,8 @@ Devise.setup do |config|
 	# When using omniauth, Devise cannot automatically set Omniauth path,
 	# so you need to do it manually. For the users scope, it would be:
 	# config.omniauth_path_prefix = "/my_engine/users/auth"
+
+	config.parent_mailer = 'BaseMailer'
 end
 
 ActiveSupport.on_load(:devise_failure_app) do


### PR DESCRIPTION
- Use BaseMailer as the Devise parent mailer
- Fix a typo in confirmation instructions

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
