### PR TITLE
Add X-SES-CONFIGURATION-SET to outgoing email

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -99,5 +99,7 @@ module Commitchange
 		}
 
 		config.active_job.queue_adapter = :delayed_job
+
+		config.action_mailer.default = {"X-SES-CONFIGURATION-SET" => 'Admin'}
 	end
 end


### PR DESCRIPTION
Closes https://github.com/CommitChange/tix/issues/3932
Depends on #547

- Set a config set for email

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
