### PR TITLE
Add specs to verify `Nonprofit#clear_cache` is called after a save

### DIFF
--- a/spec/models/billing_subscription_spec.rb
+++ b/spec/models/billing_subscription_spec.rb
@@ -4,6 +4,24 @@ require 'rails_helper'
 RSpec.describe BillingSubscription, type: :model do
 
   describe 'Caching' do
+
+    describe 'after save' do
+      it 'calls Nonprofit#clear_cache after create' do
+        billing_subscription = build(:billing_subscription)
+        np = billing_subscription.nonprofit
+        expect(np).to receive(:clear_cache).once
+        billing_subscription.save!
+      end
+
+
+      it 'calls Nonprofit#clear_cache after update' do
+        billing_subscription = create(:billing_subscription)
+        np = billing_subscription.nonprofit
+        expect(np).to receive(:clear_cache).once
+        billing_subscription.stripe_subscription_id = "something"
+        billing_subscription.save!
+      end
+    end
     describe '.clear_cache' do
       it 'clears the cache when an id is passed' do
         expect(Rails.cache).to receive(:delete).with("billing_subscription_nonprofit_id_1")

--- a/spec/models/nonprofit_spec.rb
+++ b/spec/models/nonprofit_spec.rb
@@ -413,6 +413,24 @@ RSpec.describe Nonprofit, type: :model do
   end
 
   describe 'Caching' do
+
+    describe 'after save' do
+      it 'runs clear_cache after create' do
+        np = build(:nonprofit)
+        expect(np).to receive(:clear_cache).at_least(:once)
+
+        np.save!
+      end
+
+      it 'runs clear_cache after update' do
+        np = create(:nonprofit)
+        expect(np).to receive(:clear_cache)
+
+        np.email = "someemail@somethingelse.com"
+        np.save!
+      end
+    end
+
     describe '#clear_cache' do
       it 'calls the .clear_caching class method' do 
         np = create(:nonprofit)


### PR DESCRIPTION
As part of adding specs for the Nonprofit slug path caching, I realized we hadn't tested that the cache is cleared after a save. This tests to make sure that happens.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
