### PR TITLE
Moves path caching into concerning blocks

### DIFF
--- a/spec/models/billing_plan_spec.rb
+++ b/spec/models/billing_plan_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BillingPlan, type: :model do
     it {is_expected.to have_many(:billing_subscriptions)}
   end
   
-  describe 'Caching' do
+  describe '::PathCaching' do
     describe '.clear_cache' do
       it 'clears the cache when an id is passed' do
         expect(Rails.cache).to receive(:delete).with("billing_plan_nonprofit_id_1")

--- a/spec/models/billing_subscription_spec.rb
+++ b/spec/models/billing_subscription_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe BillingSubscription, type: :model do
 
-  describe 'Caching' do
+  describe '::PathCaching' do
 
     describe 'after save' do
       it 'calls Nonprofit#clear_cache after create' do

--- a/spec/models/nonprofit_spec.rb
+++ b/spec/models/nonprofit_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe Nonprofit, type: :model do
     end
   end
 
-  describe 'Caching' do
+  describe '::PathCaching' do
 
     describe 'after save' do
       it 'runs clear_cache after create' do


### PR DESCRIPTION
Closes https://github.com/CommitChange/tix/issues/3915

Depends on #556

- Move all of the Nonprofit path caching functionality into a concerning block
- Move `BillingSubscription` path caching into a concerning block
- Move `BillingPlan` path caching into a concerning block

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
