### PR TITLE
Add MultipleConditionSearch

### DIFF
--- a/app/legacy_lib/multiple_condition_search.rb
+++ b/app/legacy_lib/multiple_condition_search.rb
@@ -1,0 +1,77 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+#
+# This class assists in searches where you know you want to try a search with list of conditions and stop when your query
+# returns a single object.
+# For example, let's say you want to search for a single Supporter by name and then, if you still have multiple records, then by name and email.
+#
+# Assumption: the searches start from the least complex and go up. Probably won't work another way.
+
+# A multiple condition search like that can end in a few different ways: 
+# * we get to a condition and there are no records
+# * we get to the last condition and there are mulitiple records left
+# * we get to a condition where there is a single record (success!)
+
+# @example Search for all supporters for a particular Nonprofit using name and then name and email
+# search = MultipleConditionSearch.new([
+#  ['name = ?', "Penelope Schultz"], # you can use any of the styles used by `#where`
+#  {name: "Penelope Schultz", email: 'penelope@schultz.household'}
+# ]) 
+# result = search.find(Nonprofit.find(12356).supporters) # result is nil if there was an error otherwise, we get the result
+# 
+# puts 'There were no records found' if search.error == :none
+# puts 'There were multiple records on the last condition' if search.error == :multiple_values
+#
+# if search.error == :multiple_values
+#   puts search.result.pluck(:id).join(',') # prints the ids of the records found by the last condition when multiple values were found
+# end
+#
+# if result
+#   puts result.id
+# end
+# 
+
+class MultipleConditionSearch
+  @subconditions = []
+
+  # @!attribute [r] error the error from getting to either, getting to a condition where no record can be found by the condition or
+  #   we get to the last condition and there are still multiple records left
+  # 	@return [Symbol,nil] nil if a single result was found at one point. :none if a condition returned no values, :multiple_values if
+  #   we got to the last condition and there were multiple records
+  attr_reader :error
+  
+  # @!attribute result the result of the last condition attempted in the find. 
+  # 	@return [nil,ActiveRecord::Base,ActiveRecord::Relation] nil if the last condition attempted returned no records, 
+  #     ActiveRecord::Base if the last query attempted had a single record and ActiveRecord::Relation if the last condition
+  #     attempted had multiple records
+  attr_reader :result
+
+  # Important note: you MUST wrap all of your conditions into an array
+  # @param [Array[string,Array,Hash]] args the subconditions attempted. Each of these correspond to the values you would pass into
+  # the method of where. For example, you could
+  
+  def initialize(args=[])
+    @subconditions = args
+    @error = nil
+    @result = nil
+  end
+
+  # @param [ActiveRecord::Relation] relation something to run these conditions against
+  # @return [nil,ActiveRecord::Base] the single record returned from one of the conditions, otherwise nil
+  def find(relation)
+    @subconditions.each_with_index do |condition, index|
+      temp_result = relation.where(condition)
+      if temp_result.none?
+        @error = :none
+        return nil
+      elsif temp_result.count == 1
+        @result = temp_result.first
+        return @result
+      elsif index == @subconditions.count - 1 && temp_result.count > 1
+        @error = :multiple_values
+        @result = temp_result
+        return nil
+      end
+    end
+    raise "should never happen"
+  end
+end

--- a/spec/lib/multiple_condition_search_spec.rb
+++ b/spec/lib/multiple_condition_search_spec.rb
@@ -1,0 +1,144 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+
+describe MultipleConditionSearch do
+  describe ".find" do
+    let!(:parent) { create(:simple_object)}
+    let!(:child_obj_1) { create(:simple_object, parent: parent)}
+    let!(:child_obj_2) { create(:simple_object, parent: parent)}
+    context 'on the first condition' do
+      
+      
+      context 'no record is found' do
+        let(:search_obj) { MultipleConditionSearch.new([{houid:'some fake houid'}])}
+        let!(:result) {search_obj.find(SimpleObject.all)} 
+
+        it "will return nil" do
+          expect(result).to be_nil
+        end
+
+        it "will have a result of nil" do
+          expect(search_obj.result).to be_nil
+        end
+
+        it "will have an error of none" do
+          expect(search_obj.error).to eq :none
+        end
+      end
+
+      context 'the correct record is found' do
+        let(:search_obj) { MultipleConditionSearch.new([{houid: parent.houid}])}
+        let!(:result) {search_obj.find(SimpleObject.all)} 
+
+        it "will return parent" do
+          expect(result).to eq parent
+        end
+
+        it "will have a result of parent" do
+          expect(search_obj.result).to eq parent
+        end
+
+        it "will have an error of nil" do
+          expect(search_obj.error).to be_nil
+        end
+      end
+
+      context 'multiple records are found' do
+
+        let(:search_obj) { MultipleConditionSearch.new([["parent_id = ?", parent.id]])}
+        let!(:result) {search_obj.find(SimpleObject.all)} 
+
+        it "will return nil" do
+          expect(result).to eq nil
+        end
+
+        it "will have a result of  two child objects" do
+          expect(search_obj.result).to match_array([child_obj_1, child_obj_2])
+        end
+
+        it "will have an error of multiple_values" do
+          expect(search_obj.error).to eq :multiple_values
+        end
+
+      end
+
+    end
+
+    context 'on multiple conditions' do
+      context 'no record is found' do
+        let(:search_obj) { MultipleConditionSearch.new([
+          ["houid = ?", 'some fake houid'],
+          "houid = 'another fake houid'"])}
+        let!(:result) {search_obj.find(SimpleObject.all)} 
+
+        it "will return nil" do
+          expect(result).to be_nil
+        end
+
+        it "will have a result of nil" do
+          expect(search_obj.result).to be_nil
+        end
+
+        it "will have an error of none" do
+          expect(search_obj.error).to eq :none
+        end
+      end
+
+      context 'the correct record is found' do
+        let(:search_obj) { MultipleConditionSearch.new([
+          {parent_id: parent.id},
+          ['houid = ?', child_obj_2.houid]
+        ])}
+        let!(:result) {search_obj.find(SimpleObject.all)} 
+
+        it "will return child_obj_2" do
+          expect(result).to eq child_obj_2
+        end
+
+        it "will have a result of child_obj_2" do
+          expect(search_obj.result).to eq child_obj_2
+        end
+
+        it "will have an error of nil" do
+          expect(search_obj.error).to be_nil
+        end
+      end
+
+      context 'multiple records are found' do
+        let(:search_obj) { MultipleConditionSearch.new([
+          "parent_id = #{parent.id}", 
+          ["houid = ? OR houid = ?", child_obj_1.houid, child_obj_2.houid]
+        ])}
+        let!(:result) {search_obj.find(SimpleObject.all)} 
+
+        it "will return nil" do
+          expect(result).to be_nil
+        end
+
+        it "will have a result of child_obj_2" do
+          expect(search_obj.result).to match_array([child_obj_1, child_obj_2])
+        end
+
+        it "will have an error of nil" do
+          expect(search_obj.error).to eq :multiple_values
+        end
+      end
+
+    end
+
+    context 'does not crash with quotes' do
+      let(:search_obj) { 
+        fake_houid = "O'Leary"
+        MultipleConditionSearch.new([
+          houid: fake_houid
+        ])
+      }
+        
+
+      it 'doesnt raise an error' do
+        expect {search_obj.find(SimpleObject.all)}.to_not raise_error
+      end
+
+    end
+  end
+end

--- a/spec/lib/multiple_condition_search_spec.rb
+++ b/spec/lib/multiple_condition_search_spec.rb
@@ -68,7 +68,8 @@ describe MultipleConditionSearch do
       context 'no record is found' do
         let(:search_obj) { MultipleConditionSearch.new([
           ["houid = ?", 'some fake houid'],
-          "houid = 'another fake houid'"])}
+          ["houid = ? or houid = 'another fake houid'", 'some_fake_houid']
+        ])}
         let!(:result) {search_obj.find(SimpleObject.all)} 
 
         it "will return nil" do
@@ -87,7 +88,7 @@ describe MultipleConditionSearch do
       context 'the correct record is found' do
         let(:search_obj) { MultipleConditionSearch.new([
           {parent_id: parent.id},
-          ['houid = ?', child_obj_2.houid]
+          ['parent_id = ? AND houid = ?', parent.id, child_obj_2.houid]
         ])}
         let!(:result) {search_obj.find(SimpleObject.all)} 
 
@@ -107,7 +108,7 @@ describe MultipleConditionSearch do
       context 'multiple records are found' do
         let(:search_obj) { MultipleConditionSearch.new([
           "parent_id = #{parent.id}", 
-          ["houid = ? OR houid = ?", child_obj_1.houid, child_obj_2.houid]
+          ["parent_id = ? AND (houid = ? OR houid = ?)", parent.id, child_obj_1.houid, child_obj_2.houid]
         ])}
         let!(:result) {search_obj.find(SimpleObject.all)} 
 


### PR DESCRIPTION
Currently, there's no good way to do the following set of search based on these conditions:

* Find supporter by name
* If there are still multiple supporters, after finding by name, find within a subset of that query, i.e. name and and email
* If at any point, there is one Supporter, stop and return it
* If at any point, there is no supporters, stop and report that error
* If, after the last query, there's still multiple Supporters, report that as an error

`MultipleConditionSearch` addresses this issue.

NOTE: I don't know this is the best design, but it does work.
