### PR TITLE
Add class methods on Houidable objects

### DIFF
--- a/app/models/concerns/model/houidable.rb
+++ b/app/models/concerns/model/houidable.rb
@@ -16,9 +16,10 @@ module Model::Houidable
 		# - Adds a "before_houid_set" and "after_houid_set" callbacks in case you want do
 		#   somethings before or after that happens
 		# - Adds  "before_houid_set" and "after_houid_set" callbacks if you want to take actions around
-		# - Adds two new public methods:
+		# - Adds the following public class methods (and instance methods that delegate to this methods):
 		#    - houid_prefix - returns the prefix as a symbol
 		#    - generate_houid - creates a new HouID with given prefix
+		#		 - houid_attribute - the symbol of the attribute on this class that the Houid is assigned to.
 		# @param prefix {string|Symbol}: the prefix for the HouIDs on this model
 		# @param houid_attribute {string|Symbol}: the attribute on this model to assign the Houid to. Defaults to :id.
 		###
@@ -49,20 +50,23 @@ module Model::Houidable
 								define_model_callbacks :houid_set
 								after_initialize :add_houid
 								
+								delegate :houid_prefix, :houid_attribute, :generate_houid, to: :class
+
 								# The HouID prefix as a symbol
-								# def houid_prefix
+								# def self.houid_prefix
 								#		:supp
 								# end
-								def houid_prefix
-                    :#{prefix}
+
+								def self.houid_prefix
+									:#{prefix}
 								end
 
-								def houid_attribute
+								def self.houid_attribute
 									:#{houid_attribute} 
 								end
 								
 								# Generates a HouID using the provided houid_prefix
-								def generate_houid
+								def self.generate_houid
 									houid_prefix.to_s + "_" + SecureRandom.alphanumeric(22)
 								end
 

--- a/app/models/concerns/model/houidable.rb
+++ b/app/models/concerns/model/houidable.rb
@@ -20,6 +20,8 @@ module Model::Houidable
 		#    - houid_prefix - returns the prefix as a symbol
 		#    - generate_houid - creates a new HouID with given prefix
 		#		 - houid_attribute - the symbol of the attribute on this class that the Houid is assigned to.
+		# - Adds the following public instance method:
+		# 	 - to_houid - returns the houid for the instance regardless of what `houid_attribute` is.
 		# @param prefix {string|Symbol}: the prefix for the HouIDs on this model
 		# @param houid_attribute {string|Symbol}: the attribute on this model to assign the Houid to. Defaults to :id.
 		###

--- a/app/models/concerns/model/houidable.rb
+++ b/app/models/concerns/model/houidable.rb
@@ -8,8 +8,11 @@ module Model::Houidable
 	extend ActiveSupport::Concern
 	class_methods do
 		###
-		# @description: Simplifies using HouIDs for an ActiveRecord class. HouIDs have the format of:
-		# prefix_{22 alphanumeric characters}. Prefixes must be unique across an Houdini instance.
+		# @description: Simplifies using HouIDs for an ActiveRecord class. A Houid (pronounced "Hoo-id") is a unique 
+		# identifier for an object. Houids have the format of: prefix_{22 random alphanumeric characters}. A prefix
+		# consists of lowercase alphabetical characters. Each class must have its own unique prefix. All of the Houids
+		# generated for that class will use that prefix.
+		#
 		# Given a prefix, adds the following features to a ActiveRecord class:
 		# - Sets a HouID to the id after object initialization (on "after_initialize" callback) if
 		#		it hasn't already been set

--- a/spec/models/concerns/model/houidable_spec.rb
+++ b/spec/models/concerns/model/houidable_spec.rb
@@ -60,12 +60,40 @@ RSpec.describe Model::Houidable do
 
 		let(:already_set_houid) { test_class.new(id: preset_houid) }
 
-		it 'sets houid_prefix' do
-			expect(default_trxassign.houid_prefix).to eq prefix
+		describe '#houid_prefix' do 
+			it 'is the one passed' do
+				expect(default_trxassign.houid_prefix).to eq prefix
+			end
 		end
 
-		it 'generates a valid houid' do
-			expect(default_trxassign.generate_houid).to match_houid(prefix)
+		describe '.houid_prefix' do
+			it 'is the one passed at class level' do
+				expect(test_class.houid_prefix).to eq prefix
+			end
+		end
+
+		describe '#generate_houid' do
+			it 'generates a valid houid' do
+				expect(default_trxassign.generate_houid).to match_houid(prefix)
+			end
+		end
+
+		describe '.generate_houid' do
+			it 'generates a valid houid at class level' do
+				expect(test_class.generate_houid).to match_houid(prefix)
+			end
+		end
+
+		describe '#houid_attribute' do
+			it 'returns the default of :id' do
+				expect(default_trxassign.houid_attribute).to eq :id
+			end
+		end
+
+		describe '.houid_attribute' do
+			it 'returns the default of :id' do
+				expect(test_class.houid_attribute).to eq :id
+			end
 		end
 
 		it 'sets a valid houid as id' do
@@ -121,12 +149,40 @@ RSpec.describe Model::Houidable do
 
 		let(:already_set_houid) { test_class.new(houid_id: preset_houid) }
 
-		it 'sets houid_prefix' do
-			expect(default_trxassign.houid_prefix).to eq prefix
+		describe '#houid_prefix' do 
+			it 'is the one passed' do
+				expect(default_trxassign.houid_prefix).to eq prefix
+			end
 		end
 
-		it 'generates a valid houid' do
-			expect(default_trxassign.generate_houid).to match_houid(prefix)
+		describe '.houid_prefix' do
+			it 'is the one passed at class level' do
+				expect(test_class.houid_prefix).to eq prefix
+			end
+		end
+
+		describe '#generate_houid' do
+			it 'generates a valid houid' do
+				expect(default_trxassign.generate_houid).to match_houid(prefix)
+			end
+		end
+
+		describe '.generate_houid' do
+			it 'generates a valid houid at class level' do
+				expect(test_class.generate_houid).to match_houid(prefix)
+			end
+		end
+
+		describe '#houid_attribute' do
+			it 'returns the default of :houid_id' do
+				expect(default_trxassign.houid_attribute).to eq :houid_id
+			end
+		end
+
+		describe '.houid_attribute' do
+			it 'returns the passed value of :houid_id' do
+				expect(test_class.houid_attribute).to eq :houid_id
+			end
 		end
 
 		it 'sets a valid houid as id' do

--- a/spec/support/contexts/houidable_context.rb
+++ b/spec/support/contexts/houidable_context.rb
@@ -11,6 +11,7 @@
 #   but in some cases could be something else
 shared_examples 'an houidable entity' do |prefix, attribute|
 
+  let!(:instance) { subject }
   let(:houid_attribute) { attribute || :houid }
   
   it {
@@ -20,4 +21,14 @@ shared_examples 'an houidable entity' do |prefix, attribute|
   it {
     is_expected.to have_attributes(houid_attribute: houid_attribute.to_sym)
   }
+
+  describe 'class methods' do
+    it {
+      expect(instance.class).to have_attributes(houid_prefix: prefix.to_sym)
+    }
+  
+    it {
+      expect(instance.class).to have_attributes(houid_attribute: houid_attribute.to_sym)
+    } 
+  end
 end


### PR DESCRIPTION
Currently, given an Houidable object (an object whose class has had `setup_houid` run on it), the following methods have always been available:

* `houid_attribute`
* `houid_prefix`
* `generate_houid`

If you look at the implementations, none of those methods use any information unique to the instance. If we move those methods up to the class, we would then have a way to reuse them in places where we're not using the proper ActiveRecord code (example: `InsertPayout`). We keep the instance versions of those methods, they just delegate to the corresponding class method.

In fact, I may need this in https://github.com/CommitChange/tix/issues/4001.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
