### PR TITLE
Add Houids when Payouts are created via `InsertPayout`

### DIFF
--- a/app/legacy_lib/insert_payout.rb
+++ b/app/legacy_lib/insert_payout.rb
@@ -72,8 +72,9 @@ module InsertPayout
           stripe_transfer_id: stripe_transfer.id,
           user_ip: data[:user_ip],
           ach_fee: 0,
-          bank_name: data[:bank_name]}])
-        .returning('id', 'net_amount', 'nonprofit_id', 'created_at', 'updated_at', 'status', 'fee_total', 'gross_amount', 'email', 'count', 'stripe_transfer_id', 'user_ip', 'ach_fee', 'bank_name')
+          bank_name: data[:bank_name],
+          houid: Payout.generate_houid}])
+        .returning('id', 'net_amount', 'nonprofit_id', 'created_at', 'updated_at', 'status', 'fee_total', 'gross_amount', 'email', 'count', 'stripe_transfer_id', 'user_ip', 'ach_fee', 'bank_name', 'houid')
       ).first
       # Create PaymentPayout records linking all the payments to the payout
       pps = Psql.execute(Qexpr.new.insert('payment_payouts', payment_ids.map{|id| {payment_id: id.to_i}}, {common_data: {payout_id: payout['id'].to_i}}))
@@ -94,8 +95,9 @@ module InsertPayout
                                           stripe_transfer_id: nil,
                                           user_ip: data[:user_ip],
                                           ach_fee: 0,
-                                          bank_name: data[:bank_name]}])
-              .returning('id', 'net_amount', 'nonprofit_id', 'created_at', 'updated_at', 'status', 'fee_total', 'gross_amount', 'email', 'count', 'stripe_transfer_id', 'user_ip', 'ach_fee', 'bank_name')
+                                          bank_name: data[:bank_name],
+                                          houid: Payout.generate_houid}])
+              .returning('id', 'net_amount', 'nonprofit_id', 'created_at', 'updated_at', 'status', 'fee_total', 'gross_amount', 'email', 'count', 'stripe_transfer_id', 'user_ip', 'ach_fee', 'bank_name', 'houid')
       ).first
       return payout
     end

--- a/app/models/concerns/model/houidable.rb
+++ b/app/models/concerns/model/houidable.rb
@@ -16,9 +16,10 @@ module Model::Houidable
 		# - Adds a "before_houid_set" and "after_houid_set" callbacks in case you want do
 		#   somethings before or after that happens
 		# - Adds  "before_houid_set" and "after_houid_set" callbacks if you want to take actions around
-		# - Adds two new public methods:
+		# - Adds the following public class methods (and instance methods that delegate to this methods):
 		#    - houid_prefix - returns the prefix as a symbol
 		#    - generate_houid - creates a new HouID with given prefix
+		#		 - houid_attribute - the symbol of the attribute on this class that the Houid is assigned to.
 		# @param prefix {string|Symbol}: the prefix for the HouIDs on this model
 		# @param houid_attribute {string|Symbol}: the attribute on this model to assign the Houid to. Defaults to :id.
 		###
@@ -49,20 +50,23 @@ module Model::Houidable
 								define_model_callbacks :houid_set
 								after_initialize :add_houid
 								
+								delegate :houid_prefix, :houid_attribute, :generate_houid, to: :class
+
 								# The HouID prefix as a symbol
-								# def houid_prefix
+								# def self.houid_prefix
 								#		:supp
 								# end
-								def houid_prefix
-                    :#{prefix}
+
+								def self.houid_prefix
+									:#{prefix}
 								end
 
-								def houid_attribute
+								def self.houid_attribute
 									:#{houid_attribute} 
 								end
 								
 								# Generates a HouID using the provided houid_prefix
-								def generate_houid
+								def self.generate_houid
 									houid_prefix.to_s + "_" + SecureRandom.alphanumeric(22)
 								end
 

--- a/app/models/concerns/model/houidable.rb
+++ b/app/models/concerns/model/houidable.rb
@@ -20,6 +20,8 @@ module Model::Houidable
 		#    - houid_prefix - returns the prefix as a symbol
 		#    - generate_houid - creates a new HouID with given prefix
 		#		 - houid_attribute - the symbol of the attribute on this class that the Houid is assigned to.
+		# - Adds the following public instance method:
+		# 	 - to_houid - returns the houid for the instance regardless of what `houid_attribute` is.
 		# @param prefix {string|Symbol}: the prefix for the HouIDs on this model
 		# @param houid_attribute {string|Symbol}: the attribute on this model to assign the Houid to. Defaults to :id.
 		###

--- a/app/models/concerns/model/houidable.rb
+++ b/app/models/concerns/model/houidable.rb
@@ -8,8 +8,11 @@ module Model::Houidable
 	extend ActiveSupport::Concern
 	class_methods do
 		###
-		# @description: Simplifies using HouIDs for an ActiveRecord class. HouIDs have the format of:
-		# prefix_{22 alphanumeric characters}. Prefixes must be unique across an Houdini instance.
+		# @description: Simplifies using HouIDs for an ActiveRecord class. A Houid (pronounced "Hoo-id") is a unique 
+		# identifier for an object. Houids have the format of: prefix_{22 random alphanumeric characters}. A prefix
+		# consists of lowercase alphabetical characters. Each class must have its own unique prefix. All of the Houids
+		# generated for that class will use that prefix.
+		#
 		# Given a prefix, adds the following features to a ActiveRecord class:
 		# - Sets a HouID to the id after object initialization (on "after_initialize" callback) if
 		#		it hasn't already been set

--- a/spec/lib/insert/insert_payout_spec.rb
+++ b/spec/lib/insert/insert_payout_spec.rb
@@ -157,11 +157,12 @@ describe InsertPayout do
               ach_fee: 0,
               bank_name: bank_name,
               updated_at: Time.now,
-              created_at: Time.now
+              created_at: Time.now,
+              houid: match_houid(:pyout)
           }.with_indifferent_access
           expect(Payout.count).to eq 1
           resulted_payout = Payout.first
-          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id)
+          expect(result.with_indifferent_access).to include expected_result.merge(id: resulted_payout.id)
 
           empty_db_attributes = {manual: nil, scheduled: nil, failure_message: nil}
           expect(resulted_payout).to have_attributes(expected_result.merge(id: resulted_payout.id).merge(empty_db_attributes))
@@ -195,12 +196,13 @@ describe InsertPayout do
               ach_fee: 0,
               bank_name: bank_name,
               updated_at: Time.now,
-              created_at: Time.now
+              created_at: Time.now,
+              houid: match_houid(:pyout)
           }.with_indifferent_access
 
           expect(Payout.count).to eq 1
           resulted_payout = Payout.first
-          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id)
+          expect(result.with_indifferent_access).to include expected_result.merge(id: resulted_payout.id)
 
           empty_db_attributes = {manual: nil, scheduled: nil, failure_message: 'Payout failed', }
           expect(resulted_payout).to have_attributes(expected_result.merge(id: resulted_payout.id).merge(empty_db_attributes))
@@ -267,11 +269,12 @@ describe InsertPayout do
               ach_fee: 0,
               bank_name: bank_name,
               updated_at: Time.now,
-              created_at: Time.now
+              created_at: Time.now,
+              houid: match_houid(:pyout)
           }.with_indifferent_access
           expect(Payout.count).to eq 1
           resulted_payout = Payout.first
-          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id)
+          expect(result.with_indifferent_access).to include expected_result.merge(id: resulted_payout.id)
 
           empty_db_attributes = {manual: nil, scheduled: nil, failure_message: nil}
           
@@ -302,12 +305,13 @@ describe InsertPayout do
               ach_fee: 0,
               bank_name: bank_name,
               updated_at: Time.now,
-              created_at: Time.now
+              created_at: Time.now,
+              houid: match_houid(:pyout)
           }.with_indifferent_access
 
           expect(Payout.count).to eq 1
           resulted_payout = Payout.first
-          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id)
+          expect(result.with_indifferent_access).to include expected_result.merge(id: resulted_payout.id)
 
           empty_db_attributes = {manual: nil, scheduled: nil, failure_message: 'Payout failed', }
           expect(resulted_payout).to have_attributes(expected_result.merge(id: resulted_payout.id).merge(empty_db_attributes))

--- a/spec/models/concerns/model/houidable_spec.rb
+++ b/spec/models/concerns/model/houidable_spec.rb
@@ -60,12 +60,40 @@ RSpec.describe Model::Houidable do
 
 		let(:already_set_houid) { test_class.new(id: preset_houid) }
 
-		it 'sets houid_prefix' do
-			expect(default_trxassign.houid_prefix).to eq prefix
+		describe '#houid_prefix' do 
+			it 'is the one passed' do
+				expect(default_trxassign.houid_prefix).to eq prefix
+			end
 		end
 
-		it 'generates a valid houid' do
-			expect(default_trxassign.generate_houid).to match_houid(prefix)
+		describe '.houid_prefix' do
+			it 'is the one passed at class level' do
+				expect(test_class.houid_prefix).to eq prefix
+			end
+		end
+
+		describe '#generate_houid' do
+			it 'generates a valid houid' do
+				expect(default_trxassign.generate_houid).to match_houid(prefix)
+			end
+		end
+
+		describe '.generate_houid' do
+			it 'generates a valid houid at class level' do
+				expect(test_class.generate_houid).to match_houid(prefix)
+			end
+		end
+
+		describe '#houid_attribute' do
+			it 'returns the default of :id' do
+				expect(default_trxassign.houid_attribute).to eq :id
+			end
+		end
+
+		describe '.houid_attribute' do
+			it 'returns the default of :id' do
+				expect(test_class.houid_attribute).to eq :id
+			end
 		end
 
 		it 'sets a valid houid as id' do
@@ -121,12 +149,40 @@ RSpec.describe Model::Houidable do
 
 		let(:already_set_houid) { test_class.new(houid_id: preset_houid) }
 
-		it 'sets houid_prefix' do
-			expect(default_trxassign.houid_prefix).to eq prefix
+		describe '#houid_prefix' do 
+			it 'is the one passed' do
+				expect(default_trxassign.houid_prefix).to eq prefix
+			end
 		end
 
-		it 'generates a valid houid' do
-			expect(default_trxassign.generate_houid).to match_houid(prefix)
+		describe '.houid_prefix' do
+			it 'is the one passed at class level' do
+				expect(test_class.houid_prefix).to eq prefix
+			end
+		end
+
+		describe '#generate_houid' do
+			it 'generates a valid houid' do
+				expect(default_trxassign.generate_houid).to match_houid(prefix)
+			end
+		end
+
+		describe '.generate_houid' do
+			it 'generates a valid houid at class level' do
+				expect(test_class.generate_houid).to match_houid(prefix)
+			end
+		end
+
+		describe '#houid_attribute' do
+			it 'returns the default of :houid_id' do
+				expect(default_trxassign.houid_attribute).to eq :houid_id
+			end
+		end
+
+		describe '.houid_attribute' do
+			it 'returns the passed value of :houid_id' do
+				expect(test_class.houid_attribute).to eq :houid_id
+			end
 		end
 
 		it 'sets a valid houid as id' do

--- a/spec/support/contexts/houidable_context.rb
+++ b/spec/support/contexts/houidable_context.rb
@@ -11,6 +11,7 @@
 #   but in some cases could be something else
 shared_examples 'an houidable entity' do |prefix, attribute|
 
+  let!(:instance) { subject }
   let(:houid_attribute) { attribute || :houid }
   
   it {
@@ -20,4 +21,14 @@ shared_examples 'an houidable entity' do |prefix, attribute|
   it {
     is_expected.to have_attributes(houid_attribute: houid_attribute.to_sym)
   }
+
+  describe 'class methods' do
+    it {
+      expect(instance.class).to have_attributes(houid_prefix: prefix.to_sym)
+    }
+  
+    it {
+      expect(instance.class).to have_attributes(houid_attribute: houid_attribute.to_sym)
+    } 
+  end
 end


### PR DESCRIPTION
Depends on #587

Currently, Payout records are not created via standard ActiveRecord objects but, instead, are created via `Qexpr` in `InsertPayout` This is not ideal but at the same time, changing it is not a small task.

We do however need to make sure Houids are created when we use `InsertPayout`, we can't rely on autogenerated magic from `Model::Houidable`. This change both adds
houid creation to `InsertPayout` and runs specs to make sure they really do work.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
