### PR TITLE
Adds user locking fields to db

### DIFF
--- a/db/migrate/20230227171719_add_lockable_to_user.rb
+++ b/db/migrate/20230227171719_add_lockable_to_user.rb
@@ -1,0 +1,7 @@
+class AddLockableToUser < ActiveRecord::Migration
+  def change
+      add_column :users, :failed_attempts, :integer, default: 0, null: false
+      add_column :users, :unlock_token, :string
+      add_column :users, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20221209224053) do
+ActiveRecord::Schema.define(version: 20230227171719) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1370,6 +1370,9 @@ ActiveRecord::Schema.define(version: 20221209224053) do
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email",      limit: 255
     t.string   "phone"
+    t.integer  "failed_attempts",                    default: 0,  null: false
+    t.string   "unlock_token"
+    t.datetime "locked_at"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
Adds user locking related fields to the db. This doesn't enforce or handle locking in any way, just adds the fields to the DB so we can in the future.