### PR TITLE
Move to a schema with correct backslashes for regex

### DIFF
--- a/db/functions/update_phone_index_on_supporters_v02.sql
+++ b/db/functions/update_phone_index_on_supporters_v02.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION public.update_phone_index_on_supporters() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+            BEGIN
+              new.phone_index = (regexp_replace(new.phone, '\D','', 'g'));
+              RETURN new;
+            END
+          $$;

--- a/db/migrate/20230307171832_update_function_update_phone_index_on_supporters_to_version_2.rb
+++ b/db/migrate/20230307171832_update_function_update_phone_index_on_supporters_to_version_2.rb
@@ -1,0 +1,10 @@
+class UpdateFunctionUpdatePhoneIndexOnSupportersToVersion2 < ActiveRecord::Migration
+  def change
+
+    # we need to drop trigger and then re-add, after the function update
+    drop_trigger :update_supporters_phone_index, on: :supporters, version: 1, revert_to_version: 1
+    update_function :update_phone_index_on_supporters, version: 2, revert_to_version: 1
+    # revert is required, even though we're reverting to the same version because otherwise this would not be a reversible migration
+    create_trigger :update_supporters_phone_index, on: :supporters, version: 1, revert_to_version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20221209224053) do
+ActiveRecord::Schema.define(version: 20230307171832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Previously the update_phone_index_on_supporters database function listed in schema by fx had occasional issues with backslashes being duplicated. I manually would correct them but it'd keep happening and I'd keep having to correct them. This was one of those undocumented things in the code and likely made it harder for others to work on it.