### PR TITLE
Add has_many :object_events to Payout

### DIFF
--- a/app/models/payout.rb
+++ b/app/models/payout.rb
@@ -26,6 +26,7 @@ class Payout < ApplicationRecord
 	has_one    :bank_account, through: :nonprofit
 	has_many   :payment_payouts
 	has_many   :payments, through: :payment_payouts
+	has_many :object_events, as: :event_entity
 
 	validates :stripe_transfer_id, presence: true, uniqueness: true
 	validates :nonprofit, presence: true

--- a/spec/models/payout_spec.rb
+++ b/spec/models/payout_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Payout, :type => :model do
   it {is_expected.to have_one(:bank_account).through(:nonprofit)}
   it {is_expected.to have_many(:payment_payouts)}
   it {is_expected.to have_many(:payments).through(:payment_payouts)}
-  it {is_expected.to have_many(:object_events).as(:event_entity)}
+  it {is_expected.to have_many(:object_events)}
 
   it {is_expected.to validate_presence_of(:stripe_transfer_id)}
   it {is_expected.to validate_uniqueness_of(:stripe_transfer_id)}

--- a/spec/models/payout_spec.rb
+++ b/spec/models/payout_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Payout, :type => :model do
   it {is_expected.to have_one(:bank_account).through(:nonprofit)}
   it {is_expected.to have_many(:payment_payouts)}
   it {is_expected.to have_many(:payments).through(:payment_payouts)}
+  it {is_expected.to have_many(:object_events).as(:event_entity)}
 
   it {is_expected.to validate_presence_of(:stripe_transfer_id)}
   it {is_expected.to validate_uniqueness_of(:stripe_transfer_id)}


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**


#599 made clear that I missed adding `has_many :object_events` to `Payout`. This corrects that oversight.