### PR TITLE
Make Users::SessionsController more similar to upstream

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -16,7 +16,8 @@ class Users::SessionsController < Devise::SessionsController
 
 		respond_to do |format|
 			format.json {  
-				warden.authenticate!(:scope => resource_name, :recall => "#{controller_path}#new")  
+				self.resource = warden.authenticate!(:scope => resource_name, :recall => "#{controller_path}#new")
+				sign_in(resource_name, resource)
 				render :status => 200, :json => { :status => "Success" }  
 			}
 		end  


### PR DESCRIPTION
We override `Users::SessionsController#create` but we don't include all of the functionality from `Devise::SessionController#create`. It hasn't caused a problem yet but looking at the Devise code, it seems like it could. This corrects those differences.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
