### PR TITLE
Add houid to payout in InsertPayout

### DIFF
--- a/app/legacy_lib/insert_payout.rb
+++ b/app/legacy_lib/insert_payout.rb
@@ -72,8 +72,9 @@ module InsertPayout
           stripe_transfer_id: stripe_transfer.id,
           user_ip: data[:user_ip],
           ach_fee: 0,
-          bank_name: data[:bank_name]}])
-        .returning('id', 'net_amount', 'nonprofit_id', 'created_at', 'updated_at', 'status', 'fee_total', 'gross_amount', 'email', 'count', 'stripe_transfer_id', 'user_ip', 'ach_fee', 'bank_name')
+          bank_name: data[:bank_name],
+          houid: Payout.generate_houid}])
+        .returning('id', 'net_amount', 'nonprofit_id', 'created_at', 'updated_at', 'status', 'fee_total', 'gross_amount', 'email', 'count', 'stripe_transfer_id', 'user_ip', 'ach_fee', 'bank_name', 'houid')
       ).first
       # Create PaymentPayout records linking all the payments to the payout
       pps = Psql.execute(Qexpr.new.insert('payment_payouts', payment_ids.map{|id| {payment_id: id.to_i}}, {common_data: {payout_id: payout['id'].to_i}}))
@@ -94,8 +95,10 @@ module InsertPayout
                                           stripe_transfer_id: nil,
                                           user_ip: data[:user_ip],
                                           ach_fee: 0,
-                                          bank_name: data[:bank_name]}])
-              .returning('id', 'net_amount', 'nonprofit_id', 'created_at', 'updated_at', 'status', 'fee_total', 'gross_amount', 'email', 'count', 'stripe_transfer_id', 'user_ip', 'ach_fee', 'bank_name')
+                                          bank_name: data[:bank_name],
+                                          houid: Payout.generate_houid
+                                          }])
+              .returning('id', 'net_amount', 'nonprofit_id', 'created_at', 'updated_at', 'status', 'fee_total', 'gross_amount', 'email', 'count', 'stripe_transfer_id', 'user_ip', 'ach_fee', 'bank_name',  'houid')
       ).first
       return payout
     end

--- a/spec/lib/insert/insert_payout_spec.rb
+++ b/spec/lib/insert/insert_payout_spec.rb
@@ -161,11 +161,11 @@ describe InsertPayout do
           }.with_indifferent_access
           expect(Payout.count).to eq 1
           resulted_payout = Payout.first
-          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id)
+          expect(result.with_indifferent_access).to eq(expected_result.merge(id: resulted_payout.id, houid: resulted_payout.houid))
 
           empty_db_attributes = {manual: nil, scheduled: nil, failure_message: nil}
           expect(resulted_payout).to have_attributes(expected_result.merge(id: resulted_payout.id).merge(empty_db_attributes))
-
+          expect(resulted_payout.houid).to match_houid(:pyout)
           expect(resulted_payout.payments.pluck('payments.id')).to match_array(expected_payments.map{|i| i.id})
         end
 
@@ -200,7 +200,7 @@ describe InsertPayout do
 
           expect(Payout.count).to eq 1
           resulted_payout = Payout.first
-          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id)
+          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id, houid: resulted_payout.houid)
 
           empty_db_attributes = {manual: nil, scheduled: nil, failure_message: 'Payout failed', }
           expect(resulted_payout).to have_attributes(expected_result.merge(id: resulted_payout.id).merge(empty_db_attributes))
@@ -271,11 +271,12 @@ describe InsertPayout do
           }.with_indifferent_access
           expect(Payout.count).to eq 1
           resulted_payout = Payout.first
-          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id)
+          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id, houid: resulted_payout.houid)
 
           empty_db_attributes = {manual: nil, scheduled: nil, failure_message: nil}
           
           expect(resulted_payout).to have_attributes(expected_result.merge(id: resulted_payout.id).merge(empty_db_attributes))
+          expect(resulted_payout.houid).to match_houid(:pyout)
 
           expect(resulted_payout.payments.pluck('payments.id')).to match_array(expected_payments.map{|i| i.id})
         end
@@ -307,11 +308,11 @@ describe InsertPayout do
 
           expect(Payout.count).to eq 1
           resulted_payout = Payout.first
-          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id)
+          expect(result.with_indifferent_access).to eq expected_result.merge(id: resulted_payout.id, houid: resulted_payout.houid)
 
           empty_db_attributes = {manual: nil, scheduled: nil, failure_message: 'Payout failed', }
           expect(resulted_payout).to have_attributes(expected_result.merge(id: resulted_payout.id).merge(empty_db_attributes))
-        
+          expect(resulted_payout.houid).to match_houid(:pyout)
           expect(eb_two_days_ago.available_payments.map{|i| i.id}).to match_array(expected_payments.map{|i| i.id})
           # validate payment payout records
 


### PR DESCRIPTION
The houid for payouts wasn't being added in InsertPayout and this corrects that.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
