### PR TITLE
Add an OffsitePayment spec

### DIFF
--- a/spec/models/offsite_payment_spec.rb
+++ b/spec/models/offsite_payment_spec.rb
@@ -2,5 +2,13 @@
 require 'rails_helper'
 
 RSpec.describe OffsitePayment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it {is_expected.to have_db_column(:gross_amount).of_type(:integer)}
+  it {is_expected.to have_db_column(:kind).of_type(:string)}
+  it {is_expected.to have_db_column(:date).of_type(:datetime)}
+  it {is_expected.to have_db_column(:check_number).of_type(:string)}
+
+  it { is_expected.to belong_to(:payment) }
+  it { is_expected.to belong_to(:donation) }
+  it { is_expected.to belong_to(:nonprofit) }
+  it { is_expected.to belong_to(:supporter) }
 end

--- a/spec/models/offsite_payment_spec.rb
+++ b/spec/models/offsite_payment_spec.rb
@@ -1,0 +1,6 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require 'rails_helper'
+
+RSpec.describe OffsitePayment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
During review of #612, I realized we didn't have an OffsitePayment spec. Decided I'd create it!

The file was created using `bin/rails g rspec:model OffsitePayment` (answered no to overwriting the OffsitePayment factory that already exists).

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
