### PR TITLE
Have git blame ignore commit where @awadyas made tabs uniform

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# make tabs uniform
+2a321748229282e853bd979e7b73f16c04a0283a
+


### PR DESCRIPTION
When mass reformats happen, it sort of breaks the history because git blame no longer shows who functionally changed the code. Following the instructions at https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view, this change ignores a reformatting change for git blame.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
