### PR TITLE
Add TicketPurchase model

### DIFF
--- a/app/models/ticket_purchase.rb
+++ b/app/models/ticket_purchase.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+
+class TicketPurchase < ApplicationRecord
+  include Model::TrxAssignable
+  
+  setup_houid :tktpur, :houid
+
+  belongs_to :ticket
+end

--- a/db/migrate/20230424163001_create_ticket_purchases.rb
+++ b/db/migrate/20230424163001_create_ticket_purchases.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+
+class CreateTicketPurchases < ActiveRecord::Migration
+  def change
+    create_table :ticket_purchases do |t|
+      t.string "houid",  null: false
+      t.references :ticket
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1256,6 +1256,13 @@ ActiveRecord::Schema.define(version: 20230421234415) do
     t.integer  "order"
   end
 
+  create_table "ticket_purchases", force: :cascade do |t|
+    t.string   "houid",      null: false
+    t.integer  "ticket_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "tickets", force: :cascade do |t|
     t.integer  "ticket_level_id"
     t.integer  "charge_id"

--- a/spec/factories/ticket_purchases.rb
+++ b/spec/factories/ticket_purchases.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+
+FactoryBot.define do
+  factory :ticket_purchase do
+    
+  end
+end

--- a/spec/models/ticket_purchase_spec.rb
+++ b/spec/models/ticket_purchase_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+require 'rails_helper'
+
+RSpec.describe TicketPurchase, type: :model do
+  it_behaves_like 'trx assignable', :tktpur
+
+  it {
+    is_expected.to belong_to(:ticket)
+  }
+end


### PR DESCRIPTION
We need a way to associate a transaction with a ticket purchase event. This does that!

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
