### PR TITLE
Speed up specs

### DIFF
--- a/spec/lib/format/indefinitize_spec.rb
+++ b/spec/lib/format/indefinitize_spec.rb
@@ -1,5 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-require 'rails_helper'
+require_relative '../../../app/legacy_lib/format/indefinitize'
 describe Format::Indefinitize do
   describe '#article' do
     it "returns an for string starting with vowel" do

--- a/spec/lib/format/url_spec.rb
+++ b/spec/lib/format/url_spec.rb
@@ -1,5 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-require 'rails_helper'
+require_relative '../../../app/legacy_lib/format/url'
 describe Format::Url do
 
 	describe '.concat' do

--- a/spec/lib/uuid_spec.rb
+++ b/spec/lib/uuid_spec.rb
@@ -1,5 +1,7 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-require 'rails_helper'
+require 'securerandom'
+require_relative '../../app/legacy_lib/uuid'
+
 describe UUID do
   describe '::Regex' do
     it 'rejects nil' do


### PR DESCRIPTION
If you don't have to use rails_helper, a spec runs a lot quicker. In this case, we can do that by hard coding the require paths.

- Speed up uuid_spec by removing rails_helper
- Speed up indefinitize_spec by removing rails_helper
- Speed up url_spec by removing rails_helper

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
