### PR TITLE
Corrects bug where you'd get duplicate supporters listed in CRM when you filter by campaign

### DIFF
--- a/app/legacy_lib/query_supporters.rb
+++ b/app/legacy_lib/query_supporters.rb
@@ -285,9 +285,13 @@ module QuerySupporters
       expr = expr.and_where("tags.ids @> ARRAY[$tag_ids]", tag_ids: tag_ids)
     end
     if query[:campaign_id].present?
-      expr = expr.add_join("donations", "donations.supporter_id=supporters.id AND donations.campaign_id IN (#{QueryCampaigns
-      .get_campaign_and_children(query[:campaign_id].to_i)
-           .parse})")
+      expr = expr
+        .add_join(
+          Qx.select("donations.supporter_id").from(:donations).where("donations.campaign_id IN (#{QueryCampaigns
+          .get_campaign_and_children(query[:campaign_id].to_i)
+              .parse})").group_by(:supporter_id).as(:donations),
+          "donations.supporter_id= supporters.id"
+        )
     end
 
     if query[:event_id].present?

--- a/spec/lib/query/query_supporters_spec.rb
+++ b/spec/lib/query/query_supporters_spec.rb
@@ -221,6 +221,15 @@ describe QuerySupporters do
         expect(result[:data].count).to eq 0
       end
     end
+
+    context 'when filtering by campaign' do
+      it "finds one supporter" do
+        donation1
+        donation4 # this is the second for one of the supporters. This verifies we only get a single supporter no matter how many donations they have
+        result = QuerySupporters.full_search(np.id, { campaign_id: campaign.id.to_s})
+        expect(result[:data].count).to eq 2
+      end
+    end
   end
 
   describe '.dupes_on_name_and_phone' do


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
