### PR TITLE
Make subtransaction optional in Transaction

### DIFF
--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -15,7 +15,7 @@ class Transaction < ApplicationRecord
 	has_many :donations, through: :transaction_assignments, source: :assignable, source_type: 'ModernDonation', inverse_of: 'trx'
 	has_many :ticket_purchases, through: :transaction_assignments, source: :assignable, source_type: 'TicketPurchase', inverse_of: 'trx'
 
-	has_one :subtransaction, required: true, inverse_of: :trx
+	has_one :subtransaction, inverse_of: :trx
 	has_many :payments, -> {  extending ModelExtensions::PaymentsExtension }, through: :subtransaction, source: :subtransaction_payments, class_name: 'SubtransactionPayment'
 
 	has_many :object_events, as: :event_entity

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Transaction, type: :model do
   }
   
   it {
-    is_expected.to(have_one(:subtransaction).required(true).inverse_of(:trx))
+    is_expected.to(have_one(:subtransaction).inverse_of(:trx))
   }
 
   it {


### PR DESCRIPTION
Depends on #661

If a transaction's value is 0, then there's no need for a subtransaction. This can happen when a supporter gets free tickets. This corrects Transaction so that works as expected.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
