### PR TITLE
Create a not_change rspec matcher for compound expectations

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,11 @@ require 'support/mock_helpers'
 
 
 include Expect
+# did a value change? no? then expectation passes
+# Use this in compound expectations like:
+# expect { fire_error_instead_of_creating_user}.to raise_error(ExpectedError).and not_change { User.count }
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
This change makes it easy to do the following kinds of compound expectations:

```ruby
   
expect { fire_error_instead_of_creating_user}.to raise_error(ExpectedError).and not_change { User.count }
```

This means that the spec only passes if an `ExpectedError` is raised AND the value of `User.count` does not change.
