### PR TITLE
Rate limit resetting password

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,6 +116,18 @@ class User < ActiveRecord::Base
 		message = devise_mailer.delay.send(notification, self, *args)
 	end
 
+	# override main devise send_reset_password_instructions to limit to 1 request / 5 min
+	def send_reset_password_instructions
+		if reset_password_sent_at && Time.now < reset_password_sent_at + 5.minutes
+			errors.add(:user, "can't reset password because a request was just sent")
+			return false
+		else
+			token = set_reset_password_token
+      send_reset_password_instructions_notification(token)
+      return token
+		end
+  end
+
 	def geocode!
 		#self.geocode
 		#self.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,7 +124,7 @@ class User < ActiveRecord::Base
         recoverable.send_reset_password_instructions
 				return recoverable
 			else
-				recoverable.errors.add(:user, "can't reset password because a request was just sent")
+				recoverable.errors.add(:base, "can't reset password because a request was just sent")
 			end
 		end
     recoverable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,7 +119,7 @@ class User < ActiveRecord::Base
 	# override devise class method send_reset_password_instructions to limit to 1 request / 5 min
 	def self.send_reset_password_instructions(attributes={})
 		recoverable = find_or_initialize_with_errors(reset_password_keys, attributes, :not_found)
-		if recoverable.persisted? && (recoverable.reset_password_sent_at && Time.now > recoverable.reset_password_sent_at + 5.minutes)
+		if recoverable.persisted? && (recoverable.reset_password_sent_at.nil? || Time.now > recoverable.reset_password_sent_at + 5.minutes)
       recoverable.send_reset_password_instructions
 			return recoverable
 		end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,12 +119,15 @@ class User < ActiveRecord::Base
 	# override devise class method send_reset_password_instructions to limit to 1 request / 5 min
 	def self.send_reset_password_instructions(attributes={})
 		recoverable = find_or_initialize_with_errors(reset_password_keys, attributes, :not_found)
-		if recoverable.persisted? && (recoverable.reset_password_sent_at.nil? || Time.now > recoverable.reset_password_sent_at + 5.minutes)
-      recoverable.send_reset_password_instructions
-			return recoverable
+		if recoverable.persisted?
+			if recoverable.reset_password_sent_at.nil? || Time.now > recoverable.reset_password_sent_at + 5.minutes
+        recoverable.send_reset_password_instructions
+				return recoverable
+			else
+				recoverable.errors.add(:user, "can't reset password because a request was just sent")
+			end
 		end
-		recoverable.errors.add(:user, "can't reset password because a request was just sent")
-    return recoverable
+    recoverable
 	end
 
 	def geocode!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,17 +116,16 @@ class User < ActiveRecord::Base
 		message = devise_mailer.delay.send(notification, self, *args)
 	end
 
-	# override main devise send_reset_password_instructions to limit to 1 request / 5 min
-	def send_reset_password_instructions
-		if reset_password_sent_at && Time.now < reset_password_sent_at + 5.minutes
-			errors.add(:user, "can't reset password because a request was just sent")
-			return false
-		else
-			token = set_reset_password_token
-      send_reset_password_instructions_notification(token)
-      return token
+	# override devise class method send_reset_password_instructions to limit to 1 request / 5 min
+	def self.send_reset_password_instructions(attributes={})
+		recoverable = find_or_initialize_with_errors(reset_password_keys, attributes, :not_found)
+		if recoverable.persisted? && (recoverable.reset_password_sent_at && Time.now > recoverable.reset_password_sent_at + 5.minutes)
+      recoverable.send_reset_password_instructions
+			return recoverable
 		end
-  end
+		recoverable.errors.add(:user, "can't reset password because a request was just sent")
+    return recoverable
+	end
 
 	def geocode!
 		#self.geocode

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe User, :type => :model do
           create(:user, email: 'perilous_programmer@snap.com')
           User.send_reset_password_instructions(attributes={email: 'perilous_programmer@snap.com'})
           expect(
-            User.send_reset_password_instructions(attributes={email: 'perilous_programmer@snap.com'}).errors.messages[:user]
+            User.send_reset_password_instructions(attributes={email: 'perilous_programmer@snap.com'}).errors.messages[:base]
           ).to eq(["can't reset password because a request was just sent"])
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,4 +15,21 @@ RSpec.describe User, :type => :model do
     assert user.reload.access_locked?
   end
 
+  describe '.send_reset_password_instructions' do
+    let(:user) { create(:user) }
+
+    it 'returns a token when user hasn\'t requested a reset password token before' do
+      expect(user.send_reset_password_instructions).to be_truthy
+    end
+
+    it 'returns false when user has requested a reset password too recently' do
+      user.send_reset_password_instructions
+      expect(user.send_reset_password_instructions).to be false
+    end
+
+    it 'adds errors to user when a user has requested a reset password too recently' do
+      2.times { user.send_reset_password_instructions }
+      expect(user.errors.messages[:user]).to eq(['can\'t reset password because a request was just sent'])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,36 +17,59 @@ RSpec.describe User, :type => :model do
 
   describe '.send_reset_password_instructions' do
 
-    context 'when the user hasn\'t requested a reset password token before' do
-      it 'returns a User' do
-        create(:user, email: 'evil_hacker@netflix.io')
-        expect(User.send_reset_password_instructions(attributes={email: 'evil_hacker@netflix.io'})).to be_a User
+    context 'with a valid email address' do
+
+      context 'when the user hasn\'t requested a reset password token before' do
+        it 'returns a User' do
+          create(:user, email: 'evil_hacker@netflix.io')
+          expect(User.send_reset_password_instructions(attributes={email: 'evil_hacker@netflix.io'})).to be_a User
+        end
+
+        it 'returns the correct user' do
+          user = create(:user, email: 'sneaky_scammer@fb.net')
+          expect(User.send_reset_password_instructions(attributes={email: 'sneaky_scammer@fb.net'})).to eq(user)
+        end
+
+        it 'returns an object with no errors' do
+          create(:user, email: 'gone_phishing@twtr.gov')
+          expect(User.send_reset_password_instructions(attributes={email: 'gone_phishing@twtr.gov'}).errors.messages).to eq({})
+        end
       end
 
-      it 'returns the correct user' do
-        user = create(:user, email: 'sneaky_scammer@fb.net')
-        expect(User.send_reset_password_instructions(attributes={email: 'sneaky_scammer@fb.net'})).to eq(user)
-      end
+      context 'when a user has requested a reset password token recently (< 5 min ago)' do
+        it 'returns the correct user' do
+          user = create(:user, email: 'fraud_fool@insta.org')
+          User.send_reset_password_instructions(attributes={email: 'fraud_fool@insta.org'})
+          expect(User.send_reset_password_instructions(attributes={email: 'fraud_fool@insta.org'})).to eq(user)
+        end
 
-      it 'returns an object with no errors' do
-        create(:user, email: 'gone_phishing@twtr.gov')
-        expect(User.send_reset_password_instructions(attributes={email: 'gone_phishing@twtr.gov'}).errors.messages).to eq({})
+        it 'adds "can\'t reset password because a request was just sent" error to returned user' do
+          create(:user, email: 'perilous_programmer@snap.com')
+          User.send_reset_password_instructions(attributes={email: 'perilous_programmer@snap.com'})
+          expect(
+            User.send_reset_password_instructions(attributes={email: 'perilous_programmer@snap.com'}).errors.messages[:user]
+          ).to eq(["can't reset password because a request was just sent"])
+        end
       end
     end
 
-    context 'when a user has requested a reset password token recently (< 5 min ago)' do
-      it 'returns the correct user' do
-        user = create(:user, email: 'fraud_fool@insta.org')
-        User.send_reset_password_instructions(attributes={email: 'fraud_fool@insta.org'})
-        expect(User.send_reset_password_instructions(attributes={email: 'fraud_fool@insta.org'})).to eq(user)
+    context 'with an invalid email address' do
+      it 'returns a User' do
+        expect(
+          User.send_reset_password_instructions(attributes={email: 'unknown_goose@domain.net'})
+        ).to be_a User
       end
 
-      it 'adds errors to returned user' do
-        create(:user, email: 'perilous_programmer@snap.com')
-        User.send_reset_password_instructions(attributes={email: 'perilous_programmer@snap.com'})
+      it 'returns a blank User' do
         expect(
-          User.send_reset_password_instructions(attributes={email: 'perilous_programmer@snap.com'}).errors.messages[:user]
-        ).to eq(["can't reset password because a request was just sent"])
+          User.send_reset_password_instructions(attributes={email: 'unknown_panda@domain.net'}).id
+        ).to be_nil
+      end
+
+      it 'adds "not found" errors to email' do
+        expect(
+          User.send_reset_password_instructions(attributes={email: 'unknown_lizard@domain.net'}).errors.messages[:email]
+        ).to eq(["not found"])
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/CommitChange/tix/issues/4010

## Issue
Addresses issue https://github.com/CommitChange/tix/issues/4010

## Overrides devise method
Overrides [this devise recoverable method](https://github.com/heartcombo/devise/blob/4b72064bfcf076478c5c87818b9536b203f6584f/lib/devise/models/recoverable.rb#L123)

## Testing
Tested manually:
- Navigated to login page
- Clicked Forgot Password
- Entered my email
- Was redirected to login page
- Clicked Forgot Password again
- Entered my email again
- Got error "user can't reset password because a request was just sent"
- Entered an invalid email address
- Got error "user not found"

Updated unit tests