### PR TITLE
Remove unused ruby-prof

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,6 @@ group :development, :ci, :test do
 	gem 'rspec-rails', "~> 4"
 	gem 'database_cleaner'
   gem 'dotenv-rails'
-  gem 'ruby-prof', '0.15.9'
 	gem 'stripe-ruby-mock', '~> 2.5.1', :require => 'stripe_mock'
   gem 'factory_bot'
 	gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,7 +443,6 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.12.0)
-    ruby-prof (0.15.9)
     ruby2_keywords (0.0.5)
     safe_yaml (1.0.4)
     sassc (2.4.0)
@@ -590,7 +589,6 @@ DEPENDENCIES
   rspec (~> 3)
   rspec-json_expectations
   rspec-rails (~> 4)
-  ruby-prof (= 0.15.9)
   ruby2_keywords
   sassc
   sassc-rails


### PR DESCRIPTION
We don't use ruby-prof so let's remove it

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
