### PR TITLE
Stop using :test as queue_adapter for tests by default

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,7 +47,5 @@ Commitchange::Application.configure do
   end
   config.middleware.use Rack::Attack
 
-  config.active_job.queue_adapter = :test
-
   NONPROFIT_VERIFICATION_SEND_EMAIL_DELAY = 2.hours
 end


### PR DESCRIPTION
There are situations where you want the queue adapter to fully run during tests. This handles that situation.


**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
