### PR TITLE
One-time Mac Setup Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,6 @@ brew switch postgres@12
 # To start postgres locally run:
 brew services start postgresql@12
 
-# To stop postgres locally run:
-brew services stop postgresql@12
 ```
 
 Create necessary postgres users in the `psql` console.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ All backend code and React components should be well-tested
 
 Houdini is designed and tested to run with the following:
 
-* Ruby
+* Ruby 2.6
 * Node 14
 * PostgreSQL 12
 * run on Heroku-20
@@ -97,24 +97,23 @@ rbenv install  # the app currently uses version 2.6.10
 rbenv local # rbenv local --unset reverses the action
 
 # To switch between rbenv versions installed locally, use the following command:
-rbenv shell [version number]
-example: rbenv shell 2.6.10
+rbenv shell 2.6.10
 ```
 
 Set your Node version with `NVM`.
 
 ```bash
 brew install nvm
-brew info nvm # commands that shows the remaining steps to complete to install nvm properly
+brew info nvm # command that shows the remaining steps to complete to install nvm properly
 mkdir ~/.nvm
 nvm install 14
 nvm use 14
-Add the following lines to your ~/.bashprofile or ~/.zshrc:
+# Add the following lines to your ~/.bashprofile or ~/.zshrc:
 echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.zshrc
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.zshrc
 echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.zshrc
 
-Reference Stack Overflow post: https://stackoverflow.com/questions/53118850/brew-install-nvm-nvm-command-not-found
+# Reference Stack Overflow post: https://stackoverflow.com/questions/53118850/brew-install-nvm-nvm-command-not-found
 ```
 
 Set your Postgres version with homebrew.
@@ -124,10 +123,10 @@ brew install postgresql@12
 brew switch postgres@12
 
 # To start postgres locally run:
-brew services start postgresql@ [insert version number]
+brew services start postgresql@12
 
 # To stop postgres locally run:
-brew services stop postgresql@ [insert version number]
+brew services stop postgresql@12
 ```
 
 Create necessary postgres users in the `psql` console.

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ rbenv install  # the app currently uses version 2.6.10
 rbenv local # rbenv local --unset reverses the action
 
 # To switch between rbenv versions installed locally, use the following command:
-rbenv shell [version number]
-example: rbenv shell 2.6.10
+rbenv shell 2.6.10
+
 ```
 
 Set your Node version with `NVM`.
@@ -109,12 +109,12 @@ brew info nvm # commands that shows the remaining steps to complete to install n
 mkdir ~/.nvm
 nvm install 14
 nvm use 14
-Add the following lines to your ~/.bashprofile or ~/.zshrc:
+# Add the following lines to your ~/.bashprofile or ~/.zshrc:
 echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.zshrc
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.zshrc
 echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.zshrc
 
-Reference Stack Overflow post: https://stackoverflow.com/questions/53118850/brew-install-nvm-nvm-command-not-found
+# Reference Stack Overflow post: https://stackoverflow.com/questions/53118850/brew-install-nvm-nvm-command-not-found
 ```
 
 Set your Postgres version with homebrew.
@@ -124,10 +124,10 @@ brew install postgresql@12
 brew switch postgres@12
 
 # To start postgres locally run:
-brew services start postgresql@ [insert version number]
+brew services start postgresql@12
 
 # To stop postgres locally run:
-brew services stop postgresql@ [insert version number]
+brew services stop postgresql@12
 ```
 
 Create necessary postgres users in the `psql` console.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ bin/setup
 If you don't already have access to the CommitChange 1Password vault, ask to be added. Then
 download the .env file in 1Password and place it in the root directory.
 
-NOTE: Double check that your .env file has the '.' in front of the file name.
+> *Note:* Double check that your .env file has the '.' in front of the file name.
 
 #### Startup
 ##### run foreman for development

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a Rails 4.2 app.
 
-The frontend is written in a few custom frameworks, the largest of which is called Flimflam. 
+The frontend is written in a few custom frameworks, the largest of which is called Flimflam.
 We endeavor to migrate to React as quickly as possible to increase development
 comfort and speed.
 
@@ -13,14 +13,14 @@ All backend code and React components should be well-tested
 
 Houdini is designed and tested to run with the following:
 
-* Ruby 2.6
+* Ruby
 * Node 14
 * PostgreSQL 12
 * run on Heroku-20
 
 ## Dev Setup
 
-#### Get the code  
+#### Get the code
 ```bash
 git clone https://github.com/Commitchange/houdini
 git checkout supporter_level_goal
@@ -93,19 +93,28 @@ Set your Ruby version with `rbenv`.
 ```bash
 brew install rbenv
 rbenv versions # see which ruby versions are already installed
-rbenv install 2.6 # install 2.6 if you don't have it already
-rbenv local 2.6 # rbenv local --unset reverses the action
+rbenv install  # the app currently uses version 2.6.10
+rbenv local # rbenv local --unset reverses the action
+
+# To switch between rbenv versions installed locally, use the following command:
+rbenv shell [version number]
+example: rbenv shell 2.6.10
 ```
 
 Set your Node version with `NVM`.
 
 ```bash
 brew install nvm
+brew info nvm # commands that shows the remaining steps to complete to install nvm properly
+mkdir ~/.nvm
 nvm install 14
 nvm use 14
+Add the following lines to your ~/.bashprofile or ~/.zshrc:
 echo 'export NVM_DIR="$HOME/.nvm"' >> ~/.zshrc
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' >> ~/.zshrc
 echo '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion' >> ~/.zshrc
+
+Reference Stack Overflow post: https://stackoverflow.com/questions/53118850/brew-install-nvm-nvm-command-not-found
 ```
 
 Set your Postgres version with homebrew.
@@ -113,6 +122,12 @@ Set your Postgres version with homebrew.
 ```bash
 brew install postgresql@12
 brew switch postgres@12
+
+# To start postgres locally run:
+brew services start postgresql@ [insert version number]
+
+# To start postgres locally run:
+brew services stop postgresql@ [insert version number]
 ```
 
 Create necessary postgres users in the `psql` console.
@@ -133,6 +148,8 @@ bin/setup
 ##### Get your .env file
 If you don't already have access to the CommitChange 1Password vault, ask to be added. Then
 download the .env file in 1Password and place it in the root directory.
+
+NOTE: Double check that your .env file has the '.' in front of the file name.
 
 #### Startup
 ##### run foreman for development
@@ -182,7 +199,7 @@ For this to work though, the following characteristics must be true:
 - 2 spaces for tabs
 
 #### New frontend code
-- All new front end code should be written in Typescript 
+- All new front end code should be written in Typescript
 and React (using TSX files). Please use the React Generators for creation.
 - 2 spaces for tabs
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ brew switch postgres@12
 # To start postgres locally run:
 brew services start postgresql@ [insert version number]
 
-# To start postgres locally run:
+# To stop postgres locally run:
 brew services stop postgresql@ [insert version number]
 ```
 


### PR DESCRIPTION
The one-time Mac setup instructions for CC needed to be updated.

This PR contains the following changes:

**Ruby Version changes**

- Removing version number '2.6' from 'rbnenv install' and 'rbenv local' commands
- Adding the command to switch ruby versions locally 'rbenv shell (version #)

**Node Version changes**

- Reordering the steps required to install nvm on Mac
- Adding command 'brew info nvm' for user to see which remaining steps are needed in setup process

**Postgresql Changes**

- Adding postgresql commands to start and stop services: 'brew services start postgresql@[version #]' and 'brew services stop postgresql@[version #]'


**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
