### PR TITLE
Updating default amounts in Donate Wizard

### DIFF
--- a/client/js/nonprofits/donate/custom_amounts.ts
+++ b/client/js/nonprofits/donate/custom_amounts.ts
@@ -1,5 +1,5 @@
 // License: LGPL-3.0-or-later
-const defaultAmounts = [10,25,50,100,250,500,1000];
+const defaultAmounts = [25,50,100,250,500,1000,1500];
 
 /**
  * A function to allow us to get the default amounts


### PR DESCRIPTION
Default amounts in donate wizard have been updated
Previous amounts: 10, 25, 50, 100, 250, 500, 1000
New amounts: 25, 50, 100, 250, 500, 1000, 1500

- [Changing default amounts in donate wizard](https://github.com/CommitChange/tix/issues/4060)
- [Tix for updated amounts](https://github.com/orgs/CommitChange/projects/8/views/4?pane=issue&itemId=31607551)

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
