### PR TITLE
Display the nonprofit's houid in the super admin view

### DIFF
--- a/app/legacy_lib/query_nonprofits.rb
+++ b/app/legacy_lib/query_nonprofits.rb
@@ -48,6 +48,7 @@ module QueryNonprofits
       'nonprofits.state_code',
       'nonprofits.created_at::date::text AS created_at',
       'nonprofits.vetted',
+      'nonprofits.houid',
       'nonprofits.stripe_account_id',
       'coalesce(events.count, 0) AS events_count', 
       'coalesce(campaigns.count, 0) AS campaigns_count', 

--- a/client/js/super-admin/nonprofits-table.js
+++ b/client/js/super-admin/nonprofits-table.js
@@ -43,7 +43,7 @@ const row = (data={}, i) => {
   , h('td.pl-0', [
       h('h5.m-0.max-width-1', [npoLink('',
         data.name + ' (' + data.state_code + ')')])
-    , h('p.m-0', '#' + data.id)
+    , h('p.m-0', '#' + data.id + " - " + data.houid)
     , h('p.m-0', data.email || '')
     , h('p.m-0', data.created_at)
     , h('p.m-0.color-red', [


### PR DESCRIPTION
We use Houid's for identification in nonprofits in the new API and Zapier. Staff will need a nonprofit's Houid for creating Zaps for specific nonprofits. This PR displays the Nonprofit's Houid in the dashboard.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
