### PR TITLE
Creation of drip_email_list model

### DIFF
--- a/app/models/drip_email_list.rb
+++ b/app/models/drip_email_list.rb
@@ -1,0 +1,15 @@
+class Dripemaillist < ActiveRecord::Base
+  has_one :mailchimp_list_id 
+
+  validates :mailchimp_list_id, :presence => true 
+
+   # the path on the Mailchimp api for the list
+   def list_path
+    "lists/#{mailchimp_list_id}"
+   end
+   
+   # the path on the Mailchimp api for the list's members
+   def list_members_path
+     list_path + "/members"
+   end
+end

--- a/app/models/drip_email_list.rb
+++ b/app/models/drip_email_list.rb
@@ -1,5 +1,6 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+
 class DripEmailList < ActiveRecord::Base
-  has_one :mailchimp_list_id 
 
   validates :mailchimp_list_id, :presence => true 
 

--- a/app/models/drip_email_list.rb
+++ b/app/models/drip_email_list.rb
@@ -1,4 +1,4 @@
-class Dripemaillist < ActiveRecord::Base
+class DripEmailList < ActiveRecord::Base
   has_one :mailchimp_list_id 
 
   validates :mailchimp_list_id, :presence => true 

--- a/db/migrate/20230711150901_create_drip_email_lists.rb
+++ b/db/migrate/20230711150901_create_drip_email_lists.rb
@@ -1,3 +1,4 @@
+
 class CreateDripEmailLists < ActiveRecord::Migration
   def change
     create_table :drip_email_lists do |t|

--- a/db/migrate/20230711150901_create_drip_email_lists.rb
+++ b/db/migrate/20230711150901_create_drip_email_lists.rb
@@ -1,0 +1,7 @@
+class CreateDripEmailLists < ActiveRecord::Migration
+  def change
+    create_table :drip_email_lists do |t|
+      t.string :mailchimp_list_id, required:true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20230427003235) do
+ActiveRecord::Schema.define(version: 20230711150901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -323,6 +323,10 @@ ActiveRecord::Schema.define(version: 20230427003235) do
   create_table "donations_payment_imports", id: false, force: :cascade do |t|
     t.integer "donation_id"
     t.integer "payment_import_id"
+  end
+
+  create_table "drip_email_lists", force: :cascade do |t|
+    t.string "mailchimp_list_id"
   end
 
   create_table "e_tap_import_contacts", force: :cascade do |t|

--- a/spec/factories/drip_email_lists.rb
+++ b/spec/factories/drip_email_lists.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :drip_email_list do
+  end
+
+  factory :drip_email_list_base, class: 'DripEmailList' do 
+    sequence(:list_name) {|i|"list_name#{i}"}
+    sequence(:mailchimp_list_id) {|i| "mailchimp_list_id#{i}"}
+  end 
+end

--- a/spec/factories/drip_email_lists.rb
+++ b/spec/factories/drip_email_lists.rb
@@ -1,9 +1,10 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+
 FactoryBot.define do
   factory :drip_email_list do
   end
 
   factory :drip_email_list_base, class: 'DripEmailList' do 
-    sequence(:list_name) {|i|"list_name#{i}"}
     sequence(:mailchimp_list_id) {|i| "mailchimp_list_id#{i}"}
   end 
 end

--- a/spec/models/drip_email_list_spec.rb
+++ b/spec/models/drip_email_list_spec.rb
@@ -1,7 +1,7 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 require 'rails_helper'
 
-RSpec.describe Dripemaillist, type: :model do
+RSpec.describe DripEmailList, type: => :model do
 
   describe '#list_path' do
     it 'is correctly generated' do

--- a/spec/models/drip_email_list_spec.rb
+++ b/spec/models/drip_email_list_spec.rb
@@ -1,7 +1,7 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 require 'rails_helper'
 
-RSpec.describe DripEmailList, type: => :model do
+RSpec.describe DripEmailList, type: :model do
 
   describe '#list_path' do
     it 'is correctly generated' do

--- a/spec/models/drip_email_list_spec.rb
+++ b/spec/models/drip_email_list_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe DripEmailList, type: :model do
 
   describe '#list_path' do
     it 'is correctly generated' do
-      email_list = build_stubbed(:email_list_base)
+      email_list = build_stubbed(:drip_email_list_base)
       expect(email_list.list_path).to eq "lists/"+ email_list.mailchimp_list_id
     end
   end
 
   describe '#list_members_path' do
     it 'is correctly generated' do
-      email_list = build_stubbed(:email_list_base)
+      email_list = build_stubbed(:drip_email_list_base)
       expect(email_list.list_members_path).to eq "lists/"+ email_list.mailchimp_list_id + "/members"
     end
   end

--- a/spec/models/drip_email_list_spec.rb
+++ b/spec/models/drip_email_list_spec.rb
@@ -1,0 +1,19 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require 'rails_helper'
+
+RSpec.describe Dripemaillist, type: :model do
+
+  describe '#list_path' do
+    it 'is correctly generated' do
+      email_list = build_stubbed(:email_list_base)
+      expect(email_list.list_path).to eq "lists/"+ email_list.mailchimp_list_id
+    end
+  end
+
+  describe '#list_members_path' do
+    it 'is correctly generated' do
+      email_list = build_stubbed(:email_list_base)
+      expect(email_list.list_members_path).to eq "lists/"+ email_list.mailchimp_list_id + "/members"
+    end
+  end
+end


### PR DESCRIPTION
Create a new DripEmailList ActiveRecord model (using the Rails model generator) and corresponding table with the following field:

mailchimp_list_id - id (as a string) of your mailchimp audience (required, please validate that it's filled)
DripEmailList has the following methods:

list_path - copy from EmailList
list_members_path - copy from EmailList

Please fill out the spec in spec/models/drip_email_list_spec.rb appropriately.


[Drip Email list model ticket](https://github.com/CommitChange/tix/issues/4100)


**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
