### PR TITLE
Add method to Mailchimp for signing up or updating a user for a nonprofit

### DIFF
--- a/app/legacy_lib/mailchimp.rb
+++ b/app/legacy_lib/mailchimp.rb
@@ -260,7 +260,6 @@ module Mailchimp
     result
   end
 
-  #create_nonprofit_user_subscribe_body to Mailchimp 
   def self.create_nonprofit_user_subscribe_body(nonprofit,user)
     JSON::parse(ApplicationController.render 'mailchimp/nonprofit_user_subscribe', assigns: {nonprofit: nonprofit, user: user })
   end 

--- a/app/legacy_lib/mailchimp.rb
+++ b/app/legacy_lib/mailchimp.rb
@@ -49,16 +49,10 @@ module Mailchimp
 		put("/lists/#{mailchimp_list_id}/members", @options.merge(:body => body_hash.to_json))
   end
 
-  def signup_nonprofit_user (drip_email_list, nonprofit, user)
+  def self.signup_nonprofit_user(drip_email_list, nonprofit, user)
     body_hash = @body.merge(create_nonprofit_user_subscribe_body(nonprofit, user))
     put(drip_email_list.list_members_path, @options.merge(:body => body_hash.to_json))
   end 
-
-  # second option
-  # def self.signup_nonprofit_user(drip_email_list, nonprofit, user)
-  #   body_hash = @body.merge(create_nonprofit_user_subscribe_body(nonprofit, user))
-  #   put(drip_email_list.list_members_path, @options.merge(:body => body_hash.to_json))
-  # end 
 
   def self.get_mailchimp_token(npo_id)
     mailchimp_token = QueryNonprofitKeys.get_key(npo_id, 'mailchimp_token')

--- a/app/legacy_lib/mailchimp.rb
+++ b/app/legacy_lib/mailchimp.rb
@@ -260,6 +260,12 @@ module Mailchimp
     result
   end
 
+  #create_nonprofit_user_subscribe_body to Mailchimp 
+  def self.create_nonprofit_user_subscribe_body(nonprofit,user)
+    JSON::parse(ApplicationController.render 'mailchimp/nonprofit_user_subscribe', assigns: {nonprofit: nonprofit, user: user })
+  end 
+
+
   def self.create_subscribe_body(supporter)
     JSON::parse(ApplicationController.render 'mailchimp/list', assigns: {supporter: supporter})
   end

--- a/app/legacy_lib/mailchimp.rb
+++ b/app/legacy_lib/mailchimp.rb
@@ -49,6 +49,17 @@ module Mailchimp
 		put("/lists/#{mailchimp_list_id}/members", @options.merge(:body => body_hash.to_json))
   end
 
+  def signup_nonprofit_user (drip_email_list, nonprofit, user)
+    body_hash = @body.merge(create_nonprofit_user_subscribe_body(nonprofit, user))
+    put(drip_email_list.list_members_path, @options.merge(:body => body_hash.to_json))
+  end 
+
+  # second option
+  # def self.signup_nonprofit_user(drip_email_list, nonprofit, user)
+  #   body_hash = @body.merge(create_nonprofit_user_subscribe_body(nonprofit, user))
+  #   put(drip_email_list.list_members_path, @options.merge(:body => body_hash.to_json))
+  # end 
+
   def self.get_mailchimp_token(npo_id)
     mailchimp_token = QueryNonprofitKeys.get_key(npo_id, 'mailchimp_token')
     throw RuntimeError.new("No Mailchimp connection for this nonprofit: #{npo_id}") if mailchimp_token.nil?

--- a/spec/lib/mailchimp_spec.rb
+++ b/spec/lib/mailchimp_spec.rb
@@ -84,51 +84,66 @@ describe Mailchimp do
 		end
   end
 
-	# 1st option -- drip_email_list, nonprofit, user 
-	# describe 'sign up nonprofit user' do 
-
-	# 	it 'signs up nonprofit user' do 
-
-	# 		expect(Mailchimp).to receive(:drip_email_list).with(email_list).and_return(ret_val)
-
-	# 		result = Mailchimp.create_nonprofit_user(email_list, true)
-	# 		expect(result).to match([
-	# 													{
-	# 															method: 'PUT',
-	# 															path: '',
-	# 															body: an_instance_of(String)
-	# 													}
-	# 												])
-	# 	end 
-
-	# 	it 'does not sign up nonprofit user' do 
-
-	# 		expect(Mailchimp).to receive(:drip_email_list).with(email_list).and_return(ret_val)
-
-	# 		result = Mailchimp.create_nonprofit_user(email_list, true)
-	# 		expect(result).to match([
-	# 													{
-	# 															method: 'PUT',
-	# 															path: '',
-	# 															body: an_instance_of(String)
-	# 													}
-	# 												])
-	# 	end 
-	# end 
-
-	# 2nd option
-	describe '.signs up nonprofit user' do 
+	# 1st option 
+	describe 'sign up nonprofit user' do 
 
 		it 'signs up nonprofit user' do 
-			user = create(:user, :drip_email_list_base, nonprofit: np)
-			expect(Mailchimp.get_drip_email_list(nonprofit.id, user.id)).to eq ['test_user@email.com']
-		end
+
+			expect(Mailchimp).to receive(:drip_email_list).with(email_list).and_return(ret_val)
+
+			result = Mailchimp.create_nonprofit_user(email_list, true)
+			expect(result).to match([
+														{
+																method: 'PUT',
+																path: 'list_members_path',
+																body: an_instance_of(String)
+														}
+													])
+		end 
 
 		it 'does not sign up nonprofit user' do 
-			user = create(:user, :drip_email_list_base, nonprofit: np)
-			expect(Mailchimp.get_drip_email_list(nonprofit.id, user.id)).to be_empty
-		end
+
+			expect(Mailchimp).to receive(:drip_email_list).with(email_list).and_return(ret_val)
+
+			result = Mailchimp.create_nonprofit_user(email_list, true)
+			expect(result).to match([
+														{
+																method: 'PUT',
+																path: '',
+																body: an_instance_of(String)
+														}
+													])
+		end 
 	end 
+
+	# 2nd option
+	# describe '.signs up nonprofit user' do 
+
+	# 	it 'signs up nonprofit user' do 
+	# 		user = create(:user, :drip_email_list, nonprofit: np)
+	# 		expect(Mailchimp.get_drip_email_list(nonprofit.id, user.id)).to eq ['test_user@email.com']
+	# 	end
+
+	# 	it 'does not sign up nonprofit user' do 
+	# 		user = create(:user, :drip_email_list, nonprofit: np)
+	# 		expect(Mailchimp.get_drip_email_list(nonprofit.id, user.id)).to be_empty
+	# 	end
+	# end 
+
+	describe '.create_nonprofit_user_subscribe_body' do 
+
+		it 'creates nonprofit user subscriber' do 
+			expect(Mailchimp.create_nonprofit_user_subscribe_body(nonprofit)).to match({
+				'email_address' => user.email,
+				'status' => 'subscribed',
+				'merge_fields' => {
+					
+				}
+			})
+		end 
+
+	end 
+
 
 	describe '.create_subscribe_body' do
 

--- a/spec/lib/mailchimp_spec.rb
+++ b/spec/lib/mailchimp_spec.rb
@@ -75,7 +75,11 @@ describe Mailchimp do
 																method: 'POST',
 																path: 'lists/list_id/members',
 																body: an_instance_of(String)
-														}
+														},
+														{
+															method: 'DELETE',
+															path: 'lists/list_id/members/on_mailchimp'
+														}								
 													])
 		end
   end

--- a/spec/lib/mailchimp_spec.rb
+++ b/spec/lib/mailchimp_spec.rb
@@ -4,14 +4,12 @@ require 'rails_helper'
 describe Mailchimp do
 	let(:np) { force_create(:nonprofit)}
 		let(:user) {force_create(:user)}
-		let(:user2) {force_create(:user, nonprofit: np)}
 		let(:tag_master) {force_create(:tag_master, nonprofit: np)}
 		let(:email_list) {force_create(:email_list, mailchimp_list_id: 'list_id', tag_master: tag_master, nonprofit:np, list_name: "temp")}
 		let(:drip_email_list) {force_create(:drip_email_list, nonprofit: np, user: user)}
 		let(:supporter_on_both) { force_create(:supporter, nonprofit:np, email: 'on_BOTH@email.com', name: nil)}
 		let(:supporter_on_local) { force_create(:supporter, nonprofit:np, email: 'on_local@email.com', name: 'Penelope Rebecca Schultz')}
 		let(:tag_join) {force_create(:tag_join, tag_master: tag_master, supporter: supporter_on_both)}
-
 		let(:tag_join2) {force_create(:tag_join, tag_master: tag_master, supporter: supporter_on_local)}
 	
 		let(:active_recurring_donation_1) {force_create(:recurring_donation_base, supporter_id: supporter_on_local.id, start_date: Time.new(2019, 10,12))}
@@ -49,7 +47,7 @@ describe Mailchimp do
 			active_recurring_donation_2
 			cancelled_recurring_donation_1
 
-			expect(Mailchimp).to receive(:get_list_mailchimp_subscribers).with(email_list).and_return(ret_val)
+			expect(Mailchimp).to receive(:get_list_mailchimp_subscribers).with(email_list).and_raise
 
 			result = Mailchimp.generate_batch_ops_for_hard_sync(email_list)
 
@@ -61,6 +59,24 @@ describe Mailchimp do
 					body: an_instance_of(String)
 				}])
     end
+
+		describe 'signup nonprofit user' do 
+			email_list
+			drip_email_list
+			
+			it 'signs up nonprofit user' do 
+			
+				expect(Mailchimp).to receive(:drip_email_list).with(email_list).and_return()
+				result = Mailchimp.signup_nonprofit_user(email_list)
+
+				expect(result).to match( 
+					[{
+						method: 'PUT', 
+						path: 'lists/#{mailchimp_list_id}', 
+						body: an_instance_of(String)
+					}])
+			end 
+		end 
 
 		it 'passes with delete' do
 			tag_join

--- a/spec/lib/mailchimp_spec.rb
+++ b/spec/lib/mailchimp_spec.rb
@@ -84,60 +84,15 @@ describe Mailchimp do
 		end
   end
 
-	# 1st option 
-	describe 'sign up nonprofit user' do 
-
-		it 'signs up nonprofit user' do 
-
-			expect(Mailchimp).to receive(:drip_email_list).with(email_list).and_return(ret_val)
-
-			result = Mailchimp.create_nonprofit_user(email_list, true)
-			expect(result).to match([
-														{
-																method: 'PUT',
-																path: 'list_members_path',
-																body: an_instance_of(String)
-														}
-													])
-		end 
-
-		it 'does not sign up nonprofit user' do 
-
-			expect(Mailchimp).to receive(:drip_email_list).with(email_list).and_return(ret_val)
-
-			result = Mailchimp.create_nonprofit_user(email_list, true)
-			expect(result).to match([
-														{
-																method: 'PUT',
-																path: '',
-																body: an_instance_of(String)
-														}
-													])
-		end 
-	end 
-
-	# 2nd option
-	# describe '.signs up nonprofit user' do 
-
-	# 	it 'signs up nonprofit user' do 
-	# 		user = create(:user, :drip_email_list, nonprofit: np)
-	# 		expect(Mailchimp.get_drip_email_list(nonprofit.id, user.id)).to eq ['test_user@email.com']
-	# 	end
-
-	# 	it 'does not sign up nonprofit user' do 
-	# 		user = create(:user, :drip_email_list, nonprofit: np)
-	# 		expect(Mailchimp.get_drip_email_list(nonprofit.id, user.id)).to be_empty
-	# 	end
-	# end 
-
 	describe '.create_nonprofit_user_subscribe_body' do 
+		let(:nonprofit) { create(:nonprofit)}
 
 		it 'creates nonprofit user subscriber' do 
-			expect(Mailchimp.create_nonprofit_user_subscribe_body(nonprofit)).to match({
+			expect(Mailchimp.create_nonprofit_user_subscribe_body(nonprofit, user)).to match({
 				'email_address' => user.email,
 				'status' => 'subscribed',
 				'merge_fields' => {
-					
+					'NONPROFIT_ID' => nonprofit.id
 				}
 			})
 		end 

--- a/spec/lib/mailchimp_spec.rb
+++ b/spec/lib/mailchimp_spec.rb
@@ -60,24 +60,6 @@ describe Mailchimp do
 				}])
     end
 
-		describe 'signup nonprofit user' do 
-			email_list
-			drip_email_list
-			
-			it 'signs up nonprofit user' do 
-			
-				expect(Mailchimp).to receive(:drip_email_list).with(email_list).and_return()
-				result = Mailchimp.signup_nonprofit_user(email_list)
-
-				expect(result).to match( 
-					[{
-						method: 'PUT', 
-						path: 'lists/#{mailchimp_list_id}', 
-						body: an_instance_of(String)
-					}])
-			end 
-		end 
-
 		it 'passes with delete' do
 			tag_join
 			tag_join2

--- a/spec/lib/mailchimp_spec.rb
+++ b/spec/lib/mailchimp_spec.rb
@@ -97,7 +97,6 @@ describe Mailchimp do
 
 	end 
 
-
 	describe '.create_subscribe_body' do
 
 		describe 'names' do

--- a/spec/lib/mailchimp_spec.rb
+++ b/spec/lib/mailchimp_spec.rb
@@ -47,7 +47,7 @@ describe Mailchimp do
 			active_recurring_donation_2
 			cancelled_recurring_donation_1
 
-			expect(Mailchimp).to receive(:get_list_mailchimp_subscribers).with(email_list).and_raise
+			expect(Mailchimp).to receive(:get_list_mailchimp_subscribers).with(email_list).and_return(ret_val)
 
 			result = Mailchimp.generate_batch_ops_for_hard_sync(email_list)
 

--- a/spec/lib/mailchimp_spec.rb
+++ b/spec/lib/mailchimp_spec.rb
@@ -3,12 +3,15 @@ require 'rails_helper'
 
 describe Mailchimp do
 	let(:np) { force_create(:nonprofit)}
+		let(:user) {force_create(:user)}
+		let(:user2) {force_create(:user, nonprofit: np)}
 		let(:tag_master) {force_create(:tag_master, nonprofit: np)}
 		let(:email_list) {force_create(:email_list, mailchimp_list_id: 'list_id', tag_master: tag_master, nonprofit:np, list_name: "temp")}
+		let(:drip_email_list) {force_create(:drip_email_list, nonprofit: np, user: user)}
 		let(:supporter_on_both) { force_create(:supporter, nonprofit:np, email: 'on_BOTH@email.com', name: nil)}
 		let(:supporter_on_local) { force_create(:supporter, nonprofit:np, email: 'on_local@email.com', name: 'Penelope Rebecca Schultz')}
 		let(:tag_join) {force_create(:tag_join, tag_master: tag_master, supporter: supporter_on_both)}
-	
+
 		let(:tag_join2) {force_create(:tag_join, tag_master: tag_master, supporter: supporter_on_local)}
 	
 		let(:active_recurring_donation_1) {force_create(:recurring_donation_base, supporter_id: supporter_on_local.id, start_date: Time.new(2019, 10,12))}
@@ -72,14 +75,56 @@ describe Mailchimp do
 																method: 'POST',
 																path: 'lists/list_id/members',
 																body: an_instance_of(String)
-														},
-														{
-																method: 'DELETE',
-																path: 'lists/list_id/members/on_mailchimp'
 														}
 													])
 		end
   end
+
+	# 1st option -- drip_email_list, nonprofit, user 
+	# describe 'sign up nonprofit user' do 
+
+	# 	it 'signs up nonprofit user' do 
+
+	# 		expect(Mailchimp).to receive(:drip_email_list).with(email_list).and_return(ret_val)
+
+	# 		result = Mailchimp.create_nonprofit_user(email_list, true)
+	# 		expect(result).to match([
+	# 													{
+	# 															method: 'PUT',
+	# 															path: '',
+	# 															body: an_instance_of(String)
+	# 													}
+	# 												])
+	# 	end 
+
+	# 	it 'does not sign up nonprofit user' do 
+
+	# 		expect(Mailchimp).to receive(:drip_email_list).with(email_list).and_return(ret_val)
+
+	# 		result = Mailchimp.create_nonprofit_user(email_list, true)
+	# 		expect(result).to match([
+	# 													{
+	# 															method: 'PUT',
+	# 															path: '',
+	# 															body: an_instance_of(String)
+	# 													}
+	# 												])
+	# 	end 
+	# end 
+
+	# 2nd option
+	describe '.signs up nonprofit user' do 
+
+		it 'signs up nonprofit user' do 
+			user = create(:user, :drip_email_list_base, nonprofit: np)
+			expect(Mailchimp.get_drip_email_list(nonprofit.id, user.id)).to eq ['test_user@email.com']
+		end
+
+		it 'does not sign up nonprofit user' do 
+			user = create(:user, :drip_email_list_base, nonprofit: np)
+			expect(Mailchimp.get_drip_email_list(nonprofit.id, user.id)).to be_empty
+		end
+	end 
 
 	describe '.create_subscribe_body' do
 


### PR DESCRIPTION
Closes  https://github.com/CommitChange/tix/issues/4105

We need to add an method to app/legacy_lib/mailchimp.rb for signing up and updating a user for a nonprofit. 
The method should be a class method on Mailchimp called signup_nonprofit_user. 
The method should work very similar to Mailchimp.signup.
We should test this by mocking the put call to Mailchimp in spec/lib/mailchimp_spec.rb.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
