### PR TITLE
Feature/jbuilder view for nonprofit sub

### DIFF
--- a/app/views/mailchimp/nonprofit_user_subscribe.json.jbuilder
+++ b/app/views/mailchimp/nonprofit_user_subscribe.json.jbuilder
@@ -1,0 +1,8 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later 
+
+json.email_address @user.email
+json.status 'subscribed'
+
+json.merge_fields do
+  json.nonprofit_id  @user.nonprofit
+end 

--- a/app/views/mailchimp/nonprofit_user_subscribe.json.jbuilder
+++ b/app/views/mailchimp/nonprofit_user_subscribe.json.jbuilder
@@ -4,5 +4,6 @@ json.email_address @user.email
 json.status 'subscribed'
 
 json.merge_fields do
-  json.nonprofit_id  @user.nonprofit
+  json.NONPROFIT_ID  @nonprofit.id
+  
 end 

--- a/app/views/mailchimp/nonprofit_user_subscribe.json.jbuilder
+++ b/app/views/mailchimp/nonprofit_user_subscribe.json.jbuilder
@@ -4,6 +4,5 @@ json.email_address @user.email
 json.status 'subscribed'
 
 json.merge_fields do
-  json.NONPROFIT_ID  @nonprofit.id
-  
+  json.NONPROFIT_ID  @nonprofit.id 
 end 

--- a/spec/views/mailchimp/list.json.jbuilder_spec.rb
+++ b/spec/views/mailchimp/list.json.jbuilder_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe '/mailchimp/list.json.jbuilder', type: :view do
 		}
   end
 
+  # TODO: Fix this spec 
   describe 'supporter with active recurring donations', skip: 'TODO' do
 
   end

--- a/spec/views/mailchimp/nonprofit_user_subscribe.json.jbuilder_spec.rb
+++ b/spec/views/mailchimp/nonprofit_user_subscribe.json.jbuilder_spec.rb
@@ -28,9 +28,5 @@ RSpec.describe '/mailchimp/nonprofit_user_subscribe.json.jbuilder', type: :view 
     }
   end 
 
-  # TODO: Fix this spec 
-  describe 'not adding new subscriber to nonprofit list', skip: 'TODO' do 
-  end 
-
 end 
 

--- a/spec/views/mailchimp/nonprofit_user_subscribe.json.jbuilder_spec.rb
+++ b/spec/views/mailchimp/nonprofit_user_subscribe.json.jbuilder_spec.rb
@@ -4,7 +4,7 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
 require 'rails_helper'
 
-Rspec.describe '/mailchimp/nonprofit_user_subscribe.json.jbuilder', type: :view do
+RSpec.describe '/mailchimp/nonprofit_user_subscribe.json.jbuilder', type: :view do
   
   describe 'adding new subscriber to nonprofit list' do 
 
@@ -12,15 +12,17 @@ Rspec.describe '/mailchimp/nonprofit_user_subscribe.json.jbuilder', type: :view 
       # do I need this line specifically? If so, what is it doing?
       # where would i find these methods defined? In jbuilder docs? 
       # view.lookup_context.prefixes = view.lookup_context.prefixes.drop(1)
-      assign(:user), create(:user, nonprofit_id: '123456')
+      assign(:user, create(:user, NONPROFIT_ID: '123456'))
+      render
+      rendered
     end 
 
     it {
       is_expected.to include_json(
-        email_address: User.email.,
+        email_address: User.email,
         status: 'subscribed',
         merge_fields: {
-          nonprofit_id: '123456'
+          NONPROFIT_ID: '123456'
         }
       )
     }

--- a/spec/views/mailchimp/nonprofit_user_subscribe.json.jbuilder_spec.rb
+++ b/spec/views/mailchimp/nonprofit_user_subscribe.json.jbuilder_spec.rb
@@ -9,26 +9,26 @@ RSpec.describe '/mailchimp/nonprofit_user_subscribe.json.jbuilder', type: :view 
   describe 'adding new subscriber to nonprofit list' do 
 
     subject(:json) do 
-      # do I need this line specifically? If so, what is it doing?
-      # where would i find these methods defined? In jbuilder docs? 
-      # view.lookup_context.prefixes = view.lookup_context.prefixes.drop(1)
-      assign(:user, create(:user, NONPROFIT_ID: '123456'))
+      view.lookup_context.prefixes = view.lookup_context.prefixes.drop(1)
+      user = create(:user_as_nonprofit_associate) 
+      assign(:user, user)
+      assign(:nonprofit, user.roles.first.host)
       render
       rendered
     end 
 
     it {
       is_expected.to include_json(
-        email_address: User.email,
+        email_address: User.first.email,
         status: 'subscribed',
         merge_fields: {
-          NONPROFIT_ID: '123456'
+          NONPROFIT_ID: User.first.roles.first.host.id
         }
       )
     }
   end 
 
-  # Does this need to be skipped like in list.json.jbuilder.spec?
+  # TODO: Fix this spec 
   describe 'not adding new subscriber to nonprofit list', skip: 'TODO' do 
   end 
 

--- a/spec/views/mailchimp/nonprofit_user_subscribe.json.jbuilder_spec.rb
+++ b/spec/views/mailchimp/nonprofit_user_subscribe.json.jbuilder_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later 
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+require 'rails_helper'
+
+Rspec.describe '/mailchimp/nonprofit_user_subscribe.json.jbuilder', type: :view do
+  
+  describe 'adding new subscriber to nonprofit list' do 
+
+    subject(:json) do 
+      # do I need this line specifically? If so, what is it doing?
+      # where would i find these methods defined? In jbuilder docs? 
+      # view.lookup_context.prefixes = view.lookup_context.prefixes.drop(1)
+      assign(:user), create(:user, nonprofit_id: '123456')
+    end 
+
+    it {
+      is_expected.to include_json(
+        email_address: User.email.,
+        status: 'subscribed',
+        merge_fields: {
+          nonprofit_id: '123456'
+        }
+      )
+    }
+  end 
+
+  # Does this need to be skipped like in list.json.jbuilder.spec?
+  describe 'not adding new subscriber to nonprofit list', skip: 'TODO' do 
+  end 
+
+end 
+


### PR DESCRIPTION
The jbuilder file should be at app/views/mailchimp/nonprofit_user_subscribe.json.jbuilder. It will have two class variables available:

@nonprofit: the Nonprofit of the nonprofit user to be added
@user: the User to be added
The output should include the following fields:

status: 'subscribed'
email_address: @user.email
merge_fields: an object with the following fields:
NONPROFIT_ID: @nonprofit.id


Closes [Github ticket](https://github.com/CommitChange/tix/issues/4106)
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
