### PR TITLE
Build when pushed to supporter_level_goal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Main build
 on: 
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
+    branches: ["supporter_level_goal"]
 concurrency: 
   group: build--${{ github.head_ref }}
   cancel-in-progress: true


### PR DESCRIPTION
If we build on supporter_level_goal, that means PRs will have access to the cache for supporter_level_goal. That should improve build speeds a lot.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
