### PR TITLE
Add create_nonprofit_user_subscribe_body to Mailchimp

### DIFF
--- a/app/legacy_lib/mailchimp.rb
+++ b/app/legacy_lib/mailchimp.rb
@@ -255,6 +255,11 @@ module Mailchimp
     result
   end
 
+  #create_nonprofit_user_subscribe_body to Mailchimp 
+  def self.create_nonprofit_user_subscribe_body(nonprofit,user)
+    JSON::parse(ApplicationController.render 'mailchimp/nonprofit_user_subscribe', assigns: {nonprofit: nonprofit, user: user })
+  end 
+
   def self.create_subscribe_body(supporter)
     JSON::parse(ApplicationController.render 'mailchimp/list', assigns: {supporter: supporter})
   end


### PR DESCRIPTION
We need a method for creating the subscribe JSON for adding a nonprofit user to a Mailchimp list.

Closes [Github tix #4107](https://github.com/CommitChange/tix/issues/4107)

Depends on #706 