### PR TITLE
Enqueue MailchimpNonprofitUserAddJob

### DIFF
--- a/app/api/houdini/v1/nonprofit.rb
+++ b/app/api/houdini/v1/nonprofit.rb
@@ -86,10 +86,8 @@ class Houdini::V1::Nonprofit < Houdini::V1::BaseAPI
         role = u.roles.build(host: np, name: 'nonprofit_admin')
         role.save!
         
-        # Delayed::Job.enqueue MailchimpNonprofitUserAddJob.new(drip_email_list,user, nonprofit)
-        np_user = ::MailchimpNonprofitUserAddJob.new(drip_email_list, user, nonprofit)
-        np_user.save!
-
+        MailchimpNonprofitUserAddJob.perform_later(DripEmailList.first, u, np)
+        
         billing_plan = ::BillingPlan.find(Settings.default_bp.id)
         b_sub = np.build_billing_subscription(billing_plan: billing_plan, status: 'active')
         b_sub.save!

--- a/app/api/houdini/v1/nonprofit.rb
+++ b/app/api/houdini/v1/nonprofit.rb
@@ -85,6 +85,10 @@ class Houdini::V1::Nonprofit < Houdini::V1::BaseAPI
 
         role = u.roles.build(host: np, name: 'nonprofit_admin')
         role.save!
+        
+        # Delayed::Job.enqueue MailchimpNonprofitUserAddJob.new(drip_email_list,user, nonprofit)
+        np_user = ::MailchimpNonprofitUserAddJob.new(drip_email_list, user, nonprofit)
+        np_user.save!
 
         billing_plan = ::BillingPlan.find(Settings.default_bp.id)
         b_sub = np.build_billing_subscription(billing_plan: billing_plan, status: 'active')

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -36,10 +36,10 @@ class Role < ActiveRecord::Base
 	def self.create_for_nonprofit(role_name, email, nonprofit)
 		user = User.find_or_create_with_email(email)
 		role = Role.create(user: user, name: role_name, host: nonprofit)
+		return role unless role.valid?
 
 		MailchimpNonprofitUserAddJob.perform_later(DripEmailList.first, user, nonprofit)
-
-		return role unless role.valid?
+		
 		if user.confirmed?
 			NonprofitAdminMailer.delay.existing_invite(role)
 		else

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -37,9 +37,8 @@ class Role < ActiveRecord::Base
 		user = User.find_or_create_with_email(email)
 		role = Role.create(user: user, name: role_name, host: nonprofit)
 
-		# expect{ MailchimpNonprofitUserAddJob.perform_later }.to have_enqueued_job(MailchimpNonprofitUserAddJob)
-		MailchimpNonprofitUserAddJob.perform_later(drip_email_list, user, nonprofit)
-		
+		MailchimpNonprofitUserAddJob.perform_later(DripEmailList.first, user, nonprofit)
+
 		return role unless role.valid?
 		if user.confirmed?
 			NonprofitAdminMailer.delay.existing_invite(role)

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -36,6 +36,10 @@ class Role < ActiveRecord::Base
 	def self.create_for_nonprofit(role_name, email, nonprofit)
 		user = User.find_or_create_with_email(email)
 		role = Role.create(user: user, name: role_name, host: nonprofit)
+
+		# expect{ MailchimpNonprofitUserAddJob.perform_later }.to have_enqueued_job(MailchimpNonprofitUserAddJob)
+		MailchimpNonprofitUserAddJob.perform_later(drip_email_list, user, nonprofit)
+		
 		return role unless role.valid?
 		if user.confirmed?
 			NonprofitAdminMailer.delay.existing_invite(role)

--- a/spec/api/houdini/nonprofit_spec.rb
+++ b/spec/api/houdini/nonprofit_spec.rb
@@ -129,6 +129,8 @@ describe Houdini::V1::Nonprofit, :type => :request do
     end
 
     it "succeeds" do
+
+      ActiveJob::Base.queue_adapter = :test
       StripeMockHelper.start      
       create(:nonprofit_base, slug: "n", state_code_slug: "wi", city_slug: "appleton")
 
@@ -144,6 +146,7 @@ describe Houdini::V1::Nonprofit, :type => :request do
 
       xhr :post, '/api/v1/nonprofit', input
       expect(response.code).to eq "201"
+      expect(MailchimpNonprofitUserAddJob).to have_been_enqueued
 
       our_np = Nonprofit.all[1]
       expected_np = {

--- a/spec/jobs/mailchimp_nonprofit_user_add_job_spec.rb
+++ b/spec/jobs/mailchimp_nonprofit_user_add_job_spec.rb
@@ -6,9 +6,18 @@ RSpec.describe MailchimpNonprofitUserAddJob, type: :job do
   let(:nonprofit) {create(:nonprofit_base)}
   let(:drip_email_list) {create(:drip_email_list_base)}
 
-  it 'enqueues job when nonprofit user signed up' do 
-    expect(Mailchimp).to receive(:signup_nonprofit_user).with(drip_email_list, user, nonprofit)
-
-   MailchimpNonprofitUserAddJob.perform_now(drip_email_list, user , nonprofit)
+  describe '#perform_later' do 
+    it 'enqueues job when nonprofit user signed up' do 
+      expect(Mailchimp).to receive(:signup_nonprofit_user).with(drip_email_list, user, nonprofit)
+      # MailchimpNonprofitUserAddJob.perform_now(drip_email_list, user , nonprofit)
+    end 
+  
+    it 'performs job' do 
+      ActiveJob::Base.queue_adapter = :test
+      expect {
+        MailchimpNonprofitUserAddJob.perform_now(drip_email_list, user , nonprofit)
+      }.to have_enqueued_job
+    end 
   end 
+  
 end

--- a/spec/jobs/mailchimp_nonprofit_user_add_job_spec.rb
+++ b/spec/jobs/mailchimp_nonprofit_user_add_job_spec.rb
@@ -6,18 +6,9 @@ RSpec.describe MailchimpNonprofitUserAddJob, type: :job do
   let(:nonprofit) {create(:nonprofit_base)}
   let(:drip_email_list) {create(:drip_email_list_base)}
 
-  describe '#perform_later' do 
-    it 'enqueues job when nonprofit user signed up' do 
-      expect(Mailchimp).to receive(:signup_nonprofit_user).with(drip_email_list, user, nonprofit)
-      # MailchimpNonprofitUserAddJob.perform_now(drip_email_list, user , nonprofit)
-    end 
-  
-    it 'performs job' do 
-      ActiveJob::Base.queue_adapter = :test
-      expect {
-        MailchimpNonprofitUserAddJob.perform_now(drip_email_list, user , nonprofit)
-      }.to have_enqueued_job
-    end 
+  it 'runs job' do 
+    expect(Mailchimp).to receive(:signup_nonprofit_user).with(drip_email_list, user, nonprofit)
+    MailchimpNonprofitUserAddJob.perform_now(drip_email_list, user, nonprofit)
   end 
   
 end

--- a/spec/jobs/mailchimp_signup_job_spec.rb
+++ b/spec/jobs/mailchimp_signup_job_spec.rb
@@ -7,6 +7,5 @@ RSpec.describe MailchimpSignupJob, type: :job do
   it 'enqueues the job when provided with the correct email' do
     expect(Mailchimp).to receive(:signup).with('fake@email.name', mailchimp_list.id)
     MailchimpSignupJob.perform_now('fake@email.name', mailchimp_list)
-  end
-    
+  end  
 end

--- a/spec/jobs/mailchimp_signup_job_spec.rb
+++ b/spec/jobs/mailchimp_signup_job_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe MailchimpSignupJob, type: :job do
   let(:mailchimp_list) { create(:email_list_base)}
 
   it 'enqueues the job when provided with the correct email' do
+    
     expect(Mailchimp).to receive(:signup).with('fake@email.name', mailchimp_list.id)
 
     MailchimpSignupJob.perform_now('fake@email.name', mailchimp_list)

--- a/spec/jobs/mailchimp_signup_job_spec.rb
+++ b/spec/jobs/mailchimp_signup_job_spec.rb
@@ -5,11 +5,8 @@ RSpec.describe MailchimpSignupJob, type: :job do
   let(:mailchimp_list) { create(:email_list_base)}
 
   it 'enqueues the job when provided with the correct email' do
-    
     expect(Mailchimp).to receive(:signup).with('fake@email.name', mailchimp_list.id)
-
     MailchimpSignupJob.perform_now('fake@email.name', mailchimp_list)
-
   end
-  
+    
 end


### PR DESCRIPTION
When a user is added to a nonprofit, MailchimpNonprofitUserJob needs to be enqueued with the user and the nonprofit that the user is added to. This allows us to perform changes on Mailchimp on a different thread.


Closes https://github.com/CommitChange/tix/issues/4129

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
