### PR TITLE
Add space between 'Houid:' and the actual Houid in super admin

### DIFF
--- a/client/js/super-admin/nonprofits-table.js
+++ b/client/js/super-admin/nonprofits-table.js
@@ -43,7 +43,7 @@ const row = (data={}, i) => {
   , h('td.pl-0', [
       h('h5.m-0.max-width-1', [npoLink('',
         data.name + ' (' + data.state_code + ')')])
-    , h('p.m-0', '#' + data.id + " - Houid:" + data.houid)
+    , h('p.m-0', '#' + data.id + " - Houid: " + data.houid)
     , h('p.m-0', data.email || '')
     , h('p.m-0', data.created_at)
     , h('p.m-0.color-red', [


### PR DESCRIPTION
Fixes the lack of a space between "Houid:" and the actual Houid.
![Screenshot from 2023-08-07 11-07-01](https://github.com/CommitChange/houdini/assets/94169/6a68d6d0-7301-406a-a63f-097d3c9e6dce)


**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
