### PR TITLE
Creating nonprofit_personnel scope method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,8 +32,9 @@ class User < ActiveRecord::Base
 
 	attr_accessor :offsite_donation_id, :current_password
 
-	scope :nonprofit_admins, -> { includes(:roles).where("roles.name = 'nonprofit_admin'") }
-	scope :nonprofit_associates, -> { includes(:roles).where("roles.name = 'nonprofit_associate'") }
+	scope :nonprofit_admins, -> { includes(:roles).where("roles.name = 'nonprofit_admin'").references(:roles) }
+	scope :nonprofit_associates, -> { includes(:roles).where("roles.name = 'nonprofit_associate'").references(:roles) }
+	scope :nonprofit_personnel, -> {includes(:roles).where("roles.name = 'nonprofit_admin' OR roles.name='nonprofit_associate' ").references(:roles) }
 
 	validates :email,
 		presence: true,

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,12 +14,24 @@ FactoryBot.define do
     id { 540 }
   end
 
+  factory :user_as_nonprofit_admin, class: User do
+    transient do
+      nonprofit { create(:nonprofit_base) }
+    end
+
+    sequence(:email) {|i| "user_nonprofit_admin#{i}@example.string.com"}
+    password {"whocares"}
+    roles {[
+      build(:role, name: 'nonprofit_admin', host: nonprofit)
+    ]}
+  end
+
   factory :user_as_nonprofit_associate, class: User do
     transient do
       nonprofit { create(:nonprofit_base) }
     end
 
-    sequence(:email) {|i| "user#{i}@example.string.com"}
+    sequence(:email) {|i| "user_nonprofit_associate#{i}@example.string.com"}
     password {"whocares"}
     roles {[
       build(:role, name: 'nonprofit_associate', host: nonprofit)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,6 +14,26 @@ RSpec.describe User, :type => :model do
     10.times { user.valid_for_authentication?{ false } }
     assert user.reload.access_locked?
   end
+  
+  describe '.nonprofit_personnel' do 
+    let!(:user) {create(:user)}
+    let!(:user_as_nonprofit_admin) {create(:user_as_nonprofit_admin)}
+    let!(:user_as_nonprofit_associate) {create(:user_as_nonprofit_associate)}
+
+    it 'returns a user that is a nonprofit_admin' do 
+      expect(User.nonprofit_personnel).to include(user_as_nonprofit_admin)
+    end  
+
+
+    it 'returns a user that is a nonprofit_associate' do
+      expect(User.nonprofit_personnel).to include(user_as_nonprofit_associate)
+    end 
+
+    it 'DOES NOT return a user that is a nonprofit_admin OR a nonprofit_associate' do 
+      expect(User.nonprofit_personnel).to_not include(user)
+    end 
+
+  end 
 
   describe '.send_reset_password_instructions' do
 


### PR DESCRIPTION
This is an addendum to the ticket [Create a .sync_nonprofit_users method](https://github.com/CommitChange/houdini/pull/724)

In order to make the test code in the sync_nonprofit_users ticket function more smoothly, we created a scope method named 'nonprofit_personnel.' 
This scope method queries the User model for any users with the role of 'nonprofit_admin' or 'nonprofit_associate.'
