### PR TITLE
MailchimpNonprofitUserAddJob now picks the DripEmailList on its own

### DIFF
--- a/app/api/houdini/v1/nonprofit.rb
+++ b/app/api/houdini/v1/nonprofit.rb
@@ -86,7 +86,7 @@ class Houdini::V1::Nonprofit < Houdini::V1::BaseAPI
         role = u.roles.build(host: np, name: 'nonprofit_admin')
         role.save!
         
-        MailchimpNonprofitUserAddJob.perform_later(DripEmailList.first, u, np)
+        MailchimpNonprofitUserAddJob.perform_later( u, np)
         
         billing_plan = ::BillingPlan.find(Settings.default_bp.id)
         b_sub = np.build_billing_subscription(billing_plan: billing_plan, status: 'active')

--- a/app/jobs/mailchimp_nonprofit_user_add_job.rb
+++ b/app/jobs/mailchimp_nonprofit_user_add_job.rb
@@ -3,7 +3,7 @@
 class MailchimpNonprofitUserAddJob < ActiveJob::Base
   queue_as :default
 
-  def perform(drip_email_list, user, nonprofit)
-    Mailchimp.signup_nonprofit_user(drip_email_list, user, nonprofit)
+  def perform(user, nonprofit)
+    Mailchimp.signup_nonprofit_user(DripEmailList.first, user, nonprofit)
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -38,7 +38,7 @@ class Role < ActiveRecord::Base
 		role = Role.create(user: user, name: role_name, host: nonprofit)
 		return role unless role.valid?
 
-		MailchimpNonprofitUserAddJob.perform_later(DripEmailList.first, user, nonprofit)
+		MailchimpNonprofitUserAddJob.perform_later(user, nonprofit)
 		
 		if user.confirmed?
 			NonprofitAdminMailer.delay.existing_invite(role)

--- a/spec/jobs/mailchimp_nonprofit_user_add_job_spec.rb
+++ b/spec/jobs/mailchimp_nonprofit_user_add_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MailchimpNonprofitUserAddJob, type: :job do
 
   it 'runs job' do 
     expect(Mailchimp).to receive(:signup_nonprofit_user).with(drip_email_list, user, nonprofit)
-    MailchimpNonprofitUserAddJob.perform_now(drip_email_list, user, nonprofit)
+    MailchimpNonprofitUserAddJob.perform_now(user, nonprofit)
   end 
   
 end


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
