### PR TITLE
Ignore gem dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,10 @@ updates:
         update-types:
         - "minor"
         - "patch"
+
+  - package-ecosystem: "bundler"
+    directory: "/gems"
+    ignore:
+      - dependency-name: "*"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
