### PR TITLE
Move to Customizable Highlights for Button Amounts

### DIFF
--- a/client/js/nonprofits/donate/amount-step.js
+++ b/client/js/nonprofits/donate/amount-step.js
@@ -9,6 +9,7 @@ const getAmt = require('./amt').default;
 const getSustainingAmount = require('./sustaining_amount').default;
 const getPostfixElement = require('./postfix_element').default;
 const {dollarsToCentsSafe} = require('../../../../javascripts/src/lib/format');
+const { default: amount_button_contents } = require('./amount_button_contents')
 
 function init(donationDefaults, params$) {
     var state = {
@@ -162,13 +163,7 @@ function amountFields(state) {
               state.buttonAmountSelected$(true)
               state.currentStep$(1) // immediately advance steps when selecting an amount button
             } }
-          }, [
-            h('span.dollar', app.currency_symbol)
-          , String(amt.amount),
-          ...(amt.highlight ? [
-               h('i.fa.fa-star',  {style: {lineHeight: '.85em', marginLeft: '3px'}})
-            ] : [])
-          ])
+          }, amount_button_contents(app.currency_symbol, amt))
         ])
     , (state.params$().custom_amounts || []).map((a) => getAmt(a)) )
     )

--- a/client/js/nonprofits/donate/amount_button_contents.spec.ts
+++ b/client/js/nonprofits/donate/amount_button_contents.spec.ts
@@ -1,0 +1,12 @@
+// License: LGPL-3.0-or-later
+import amount_button_contents from "./amount_button_contents";
+
+describe('.amount_button_contents', () => {
+  it('does not include a highlight when highlight is false', () => {
+    expect(amount_button_contents("$", {amount: 100, highlight: false})).toHaveLength(2);
+  });
+
+  it('does include a highlight when highlight is a string', () => {
+    expect(amount_button_contents("$", {amount: 100, highlight: 'house'})).toHaveLength(3);
+  });
+});

--- a/client/js/nonprofits/donate/amount_button_contents.ts
+++ b/client/js/nonprofits/donate/amount_button_contents.ts
@@ -1,0 +1,16 @@
+// License: LGPL-3.0-or-later
+import { AmountButtonDesc } from "./amt";
+const h = require('snabbdom/h') as Function;
+
+
+
+export default function amount_button_contents(currency_symbol: string, amt: AmountButtonDesc): any[] {
+
+  return [
+    h('span.dollar', currency_symbol),
+    String(amt.amount),
+    ...(amt.highlight ? [
+      h('i.fa.fa-star', { style: { lineHeight: '.85em', marginLeft: '3px' } })
+    ] : [])
+  ]
+}

--- a/client/js/nonprofits/donate/amount_button_contents.ts
+++ b/client/js/nonprofits/donate/amount_button_contents.ts
@@ -10,7 +10,7 @@ export default function amount_button_contents(currency_symbol: string, amt: Amo
     h('span.dollar', currency_symbol),
     String(amt.amount),
     ...(amt.highlight ? [
-      h('i.fa.fa-star', { style: { lineHeight: '.85em', marginLeft: '3px' } })
+      h(`i.fa.fa-${amt.highlight}`, { style: { lineHeight: '.85em', marginLeft: '3px' } })
     ] : [])
   ]
 }

--- a/client/js/nonprofits/donate/amt.spec.ts
+++ b/client/js/nonprofits/donate/amt.spec.ts
@@ -6,8 +6,12 @@ describe('.getAmt', () => {
     expect(getAmt(500)).toStrictEqual({ amount: 500, highlight: false });
   });
 
-  it('returns {amount:, highlight: true} when passed {amount:, highlight: true}', () => {
-    expect(getAmt({ amount: 500, highlight: true })).toStrictEqual({ amount: 500, highlight: true });
+  it('returns {amount:, highlight:\'star\'} when passed {amount:, highlight: true}', () => {
+    expect(getAmt({ amount: 500, highlight: true })).toStrictEqual({ amount: 500, highlight: 'star' });
+  });
+
+  it('returns {amount:, highlight:str} when passed {amount:, highlight: str}', () => {
+    expect(getAmt({ amount: 500, highlight: 'house' })).toStrictEqual({ amount: 500, highlight: 'house' });
   });
 
   it('returns {amount:, highlight:false} when passed {amount:, highlight: false}', () => {

--- a/client/js/nonprofits/donate/amt.ts
+++ b/client/js/nonprofits/donate/amt.ts
@@ -2,10 +2,13 @@
 
 export interface AmountButtonDesc {
   amount: number;
-  highlight: boolean
+  highlight: string | false;
 }
 
-type AmountButtonInput = AmountButtonDesc | number;
+type AmountButtonInput = {
+  amount: number;
+  highlight: string | boolean;
+} | number;
 
 
 export default function getAmt(amt:AmountButtonInput) : AmountButtonDesc {
@@ -13,7 +16,8 @@ export default function getAmt(amt:AmountButtonInput) : AmountButtonDesc {
   if (typeof amt === 'number'){
     return {amount: amt, highlight: false}
   }
-  else
-    return amt;
+  else {
+    return {amount:amt.amount, highlight: amt.highlight === true ? 'star' : amt.highlight}
+  }
 
 }


### PR DESCRIPTION
Depends on #752
Depends on #753
Depends on #754

- Create AmountButtonDesc type
- Migrate out amount_button_contents into its own file
- Add spec for getAmt
- Add support for custom highlight icons

NOTE: this requires further testing

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
