### PR TITLE
Search nonprofits payments during NP year

### DIFF
--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -66,6 +66,12 @@ class Nonprofit < ActiveRecord::Base
       net, gross = pending.pluck('SUM("payments"."net_amount") AS net, SUM("payments"."gross_amount") AS gross').first
       {'net' => net, 'gross' => gross}
     end
+
+    def during_np_year(year)
+      proxy_association.owner.use_zone do
+        where('date >= ? and date < ?', Time.zone.local(year), Time.zone.local(year + 1))
+      end
+    end
   end
   has_many :transactions, through: :supporters
   has_many :supporters, dependent: :destroy


### PR DESCRIPTION
- Add Nonprofit#use_zone
- Add a query to a supporters that gets all of the payments during a given year based on the NPs timezone
- Add ability for nonprofits to search payments during their NP year

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
