### PR TITLE
Revert "Update CDN for Commitchange production"

### DIFF
--- a/config/commitchange.production.yml
+++ b/config/commitchange.production.yml
@@ -6,7 +6,7 @@ mailer:
   host: "us.commitchange.com"
 
 cdn:
-  url: "https://assets.us.commitchange.com"
+  url: "https://d2e5we1j08b82a.cloudfront.net"
 
 api_domain:
   url: 'https://us.commitchange.com'


### PR DESCRIPTION
This reverts commit 618ba086fe4e16361689536cc150a03d44d15a81.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
