### PR TITLE
Update to es2016 lib for TS

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "target": "es5",
     "jsx": "react",
     "experimentalDecorators": true,
-    "lib": ["dom","es5", "scripthost", "ES2015"],
+    "lib": ["dom","es5", "scripthost", "es2016"],
     "paths": { "*": [ "./types/*"] },
     "typeRoots" : [
       "node_modules/@types",


### PR DESCRIPTION
We can't use Array.includes if we don't use es2016. Given that it has been supported for approximately 6 years, I'm fine turning that support on.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
