### PR TITLE
add type to custom field description

### DIFF
--- a/client/js/nonprofits/donate/components/info-step/customFields/__snapshots__/index.spec.ts.snap
+++ b/client/js/nonprofits/donate/components/info-step/customFields/__snapshots__/index.spec.ts.snap
@@ -37,3 +37,117 @@ Object {
   "text": undefined,
 }
 `;
+
+exports[`customFields with index sets the the field correctly 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": undefined,
+      "data": Object {
+        "props": Object {
+          "name": "customFields[Name of Field]",
+          "placeholder": "Field Label",
+        },
+      },
+      "elm": undefined,
+      "key": undefined,
+      "sel": "input",
+      "text": undefined,
+    },
+    Object {
+      "children": undefined,
+      "data": Object {
+        "props": Object {
+          "name": "customFields[Another Field Name]",
+          "placeholder": "Label2",
+        },
+      },
+      "elm": undefined,
+      "key": undefined,
+      "sel": "input",
+      "text": undefined,
+    },
+  ],
+  "data": Object {},
+  "elm": undefined,
+  "key": undefined,
+  "sel": "div",
+  "text": undefined,
+}
+`;
+
+exports[`customFields with legacy sets the the field correctly 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": undefined,
+      "data": Object {
+        "props": Object {
+          "name": "customFields[Name of Field]",
+          "placeholder": "Field Label",
+        },
+      },
+      "elm": undefined,
+      "key": undefined,
+      "sel": "input",
+      "text": undefined,
+    },
+    Object {
+      "children": undefined,
+      "data": Object {
+        "props": Object {
+          "name": "customFields[Another Field Name]",
+          "placeholder": "Label2",
+        },
+      },
+      "elm": undefined,
+      "key": undefined,
+      "sel": "input",
+      "text": undefined,
+    },
+  ],
+  "data": Object {},
+  "elm": undefined,
+  "key": undefined,
+  "sel": "div",
+  "text": undefined,
+}
+`;
+
+exports[`customFields with new sets the the field correctly 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": undefined,
+      "data": Object {
+        "props": Object {
+          "name": "customFields[Name of Field]",
+          "placeholder": "Field Label",
+        },
+      },
+      "elm": undefined,
+      "key": undefined,
+      "sel": "input",
+      "text": undefined,
+    },
+    Object {
+      "children": undefined,
+      "data": Object {
+        "props": Object {
+          "name": "customFields[Another Field Name]",
+          "placeholder": "Label2",
+        },
+      },
+      "elm": undefined,
+      "key": undefined,
+      "sel": "input",
+      "text": undefined,
+    },
+  ],
+  "data": Object {},
+  "elm": undefined,
+  "key": undefined,
+  "sel": "div",
+  "text": undefined,
+}
+`;

--- a/client/js/nonprofits/donate/components/info-step/customFields/__snapshots__/index.spec.ts.snap
+++ b/client/js/nonprofits/donate/components/info-step/customFields/__snapshots__/index.spec.ts.snap
@@ -1,43 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`customFields sets the the field correctly 1`] = `
-Object {
-  "children": Array [
-    Object {
-      "children": undefined,
-      "data": Object {
-        "props": Object {
-          "name": "customFields[Name of Field]",
-          "placeholder": "Field Label",
-        },
-      },
-      "elm": undefined,
-      "key": undefined,
-      "sel": "input",
-      "text": undefined,
-    },
-    Object {
-      "children": undefined,
-      "data": Object {
-        "props": Object {
-          "name": "customFields[Another Field Name]",
-          "placeholder": "Label2",
-        },
-      },
-      "elm": undefined,
-      "key": undefined,
-      "sel": "input",
-      "text": undefined,
-    },
-  ],
-  "data": Object {},
-  "elm": undefined,
-  "key": undefined,
-  "sel": "div",
-  "text": undefined,
-}
-`;
-
 exports[`customFields with index sets the the field correctly 1`] = `
 Object {
   "children": Array [

--- a/client/js/nonprofits/donate/components/info-step/customFields/customField.spec.ts
+++ b/client/js/nonprofits/donate/components/info-step/customFields/customField.spec.ts
@@ -3,6 +3,6 @@ import customField from "./customField"
 
 describe('customField', () => { 
   it('sets the the field correctly', () => {
-    expect(customField({name: "Name of Field", label: "Field Label"})).toMatchSnapshot();
+    expect(customField({name: "Name of Field", label: "Field Label", type: 'supporter'})).toMatchSnapshot();
   })
 });

--- a/client/js/nonprofits/donate/components/info-step/customFields/index.spec.ts
+++ b/client/js/nonprofits/donate/components/info-step/customFields/index.spec.ts
@@ -1,20 +1,29 @@
 // License: LGPL-3.0-or-later
 import customFields from "."
+import {customFields as legacyCustomFields} from './legacy';
+import {customFields as newCustomFields} from './new';
 
-describe('customFields', () => { 
-  it('sets the the field correctly', () => {
-    expect(customFields([
-      {name: "Name of Field", label: "Field Label"},
-      {name: "Another Field Name", label: "Label2"}
-    ])).toMatchSnapshot();
-  });
 
-  it('returns blank string correctly with nothing passed', () => {
-    expect(customFields()).toBe("");
-  });
 
-  it('returns blank string correctly with null passed', () => {
-    expect(customFields(null)).toBe("");
-  });
+describe.each([
+  ['with index', customFields],
+  ['with legacy', legacyCustomFields],
+  ['with new', newCustomFields]
+])('customFields', (name, method) => {
+  describe(name, () => {
+    it('sets the the field correctly', () => {
+      expect(method([
+        {name: "Name of Field", label: "Field Label"},
+        {name: "Another Field Name", label: "Label2"}
+      ])).toMatchSnapshot();
+    });
   
+    it('returns blank string correctly with nothing passed', () => {
+      expect(method()).toBe("");
+    });
+  
+    it('returns blank string correctly with null passed', () => {
+      expect(method(null)).toBe("");
+    });
+  });
 });

--- a/client/js/nonprofits/donate/components/info-step/customFields/index.spec.ts
+++ b/client/js/nonprofits/donate/components/info-step/customFields/index.spec.ts
@@ -13,8 +13,8 @@ describe.each([
   describe(name, () => {
     it('sets the the field correctly', () => {
       expect(method([
-        {name: "Name of Field", label: "Field Label"},
-        {name: "Another Field Name", label: "Label2"}
+        {name: "Name of Field", label: "Field Label", type: 'supporter'},
+        {name: "Another Field Name", label: "Label2", type: 'supporter'}
       ])).toMatchSnapshot();
     });
   

--- a/client/js/nonprofits/donate/components/info-step/customFields/index.ts
+++ b/client/js/nonprofits/donate/components/info-step/customFields/index.ts
@@ -1,11 +1,4 @@
 // License: LGPL-3.0-or-later
-import {map as Rmap} from 'ramda';
-import { CustomFieldDescription } from '../../../types';
-import customField from './customField';
-const h = require('snabbdom/h');
+import {customFields} from './legacy';
 
-export default function customFields(fields?:CustomFieldDescription[]|null): ReturnType<typeof h> | '' {
-  if (!fields) return '';
-  
-  return h('div', Rmap(customField, fields));
-}
+export default customFields;

--- a/client/js/nonprofits/donate/components/info-step/customFields/legacy.ts
+++ b/client/js/nonprofits/donate/components/info-step/customFields/legacy.ts
@@ -1,0 +1,11 @@
+// License: LGPL-3.0-or-later
+import {map as Rmap} from 'ramda';
+import { CustomFieldDescription } from '../../../types';
+import customField from './customField';
+const h = require('snabbdom/h');
+
+export function customFields(fields?:CustomFieldDescription[]|null): ReturnType<typeof h> | '' {
+  if (!fields) return '';
+  
+  return h('div', Rmap(customField, fields));
+}

--- a/client/js/nonprofits/donate/components/info-step/customFields/new.ts
+++ b/client/js/nonprofits/donate/components/info-step/customFields/new.ts
@@ -1,0 +1,10 @@
+// License: LGPL-3.0-or-later
+import { CustomFieldDescription } from '../../../types';
+import customField from './customField';
+const h = require('snabbdom/h');
+
+export function customFields(fields?:CustomFieldDescription[]|null): ReturnType<typeof h> | '' {
+  if (!fields) return '';
+  
+  return h('div', fields.map(customField));
+}

--- a/client/js/nonprofits/donate/get-params.spec.js
+++ b/client/js/nonprofits/donate/get-params.spec.js
@@ -28,15 +28,15 @@ describe('.getParams', () => {
     });
 
     it('creates custom fields from just a name', () => {
-      expect(getParams({custom_fields: "name"})).toHaveProperty('custom_fields', [{name: 'name', label: 'name'}]);
+      expect(getParams({custom_fields: "name"})).toHaveProperty('custom_fields', [{name: 'name', label: 'name', type: 'supporter'}]);
     });
 
     it('creates custom fields from name and label', () => {
-      expect(getParams({custom_fields: "name: Label with Spaces"})).toHaveProperty('custom_fields', [{name: 'name', label: 'Label with Spaces'}]);
+      expect(getParams({custom_fields: "name: Label with Spaces"})).toHaveProperty('custom_fields', [{name: 'name', label: 'Label with Spaces', type: 'supporter'}]);
     });
 
     it('creates custom fields from JSON', () => {
-      expect(getParams({custom_fields: "[{name: 'name', label: 'Label with Spaces'}]"})).toHaveProperty('custom_fields', [{name: 'name', label: 'Label with Spaces'}]);
+      expect(getParams({custom_fields: "[{name: 'name', label: 'Label with Spaces', type: 'supporter'}]"})).toHaveProperty('custom_fields', [{name: 'name', label: 'Label with Spaces', type: 'supporter'}]);
     });
   });
 

--- a/client/js/nonprofits/donate/parseFields/customField/index.spec.ts
+++ b/client/js/nonprofits/donate/parseFields/customField/index.spec.ts
@@ -10,11 +10,11 @@ describe.each([
 ])('parseCustomField', (name, method) => {
   describe(name, () => {
     it('when only name provided, label is name', () => {
-      expect(method("  Supporter Tier ")).toStrictEqual({ name: "Supporter Tier", label: "Supporter Tier" });
+      expect(method("  Supporter Tier ")).toStrictEqual({ name: "Supporter Tier", label: "Supporter Tier", type: 'supporter'});
     });
 
     it('when label provided, label is set too', () => {
-      expect(method(" Custom Supp Level  :     Supporter Tier ")).toStrictEqual({ name: "Custom Supp Level", label: "Supporter Tier" });
+      expect(method(" Custom Supp Level  :     Supporter Tier ")).toStrictEqual({ name: "Custom Supp Level", label: "Supporter Tier", type: 'supporter' });
     });
   });
 });

--- a/client/js/nonprofits/donate/parseFields/customField/index.ts
+++ b/client/js/nonprofits/donate/parseFields/customField/index.ts
@@ -4,6 +4,7 @@ import { parseCustomField } from "./legacy";
 export interface CustomFieldDescription {
   name: NonNullable<string>;
   label: NonNullable<string>;
+  type: 'supporter';
 }
 
 

--- a/client/js/nonprofits/donate/parseFields/customField/legacy.ts
+++ b/client/js/nonprofits/donate/parseFields/customField/legacy.ts
@@ -4,5 +4,5 @@ import { CustomFieldDescription } from '.';
 
 export function parseCustomField(f:string) :CustomFieldDescription {
   const [name, label] = Rmap(Rtrim, Rsplit(':', f))
-  return {name, label: label || name}
+  return {name, label: label || name, type: 'supporter'};
 }

--- a/client/js/nonprofits/donate/parseFields/customField/new.ts
+++ b/client/js/nonprofits/donate/parseFields/customField/new.ts
@@ -5,5 +5,5 @@ export function parseCustomField(input:string) : CustomFieldDescription {
   const [name, ...rest] = input.split(":").map((s) => s.trim())
   const label = rest.length > 0 ? rest[0] : null;
 
-  return {name, label: label || name } as CustomFieldDescription;
+  return {name, label: label || name, type: 'supporter' } as CustomFieldDescription;
 };

--- a/client/js/nonprofits/donate/parseFields/customFields/JsonStringParser.spec.ts
+++ b/client/js/nonprofits/donate/parseFields/customFields/JsonStringParser.spec.ts
@@ -6,7 +6,9 @@ describe('JsonStringParser', () => {
   describe.each([
     ["with bracket", "["],
     ["with brace", "[{]"],
-    ["with non-custom-field-description", "[{name:'name'}]"]
+    ["with non-custom-field-description", "[{name:'name'}]"],
+    ["with no type given", "[{name:'name', label: 'LABEL'}]"],
+    ["with type given but wrong value", "[{name:'name', label: 'LABEL', type: 'something else'}]"]
   ])("when invalid %s", (_n, input)=> {
     const parser = new JsonStringParser(input)
     it('has correct result', () => {
@@ -23,8 +25,8 @@ describe('JsonStringParser', () => {
   });
 
   describe.each([
-    ['with non-custom-field-description', "[{name:'name', label: 'another'}]", [{name: 'name', label: 'another'}]],
-    ['with different json quote', '[{name:"name", label: "another"}]', [{name: 'name', label: 'another'}]],
+    ['with non-custom-field-description', "[{name:'name', label: 'another', type: 'supporter'}]", [{name: 'name', label: 'another', type: 'supporter'}]],
+    ['with different json quote', '[{name:"name", label: "another", type: "supporter"}]', [{name: 'name', label: 'another', type: 'supporter'}]],
     ['when an empty array', '[]', []],
   ])("when valid %s", (_name, input, result) => {
       const parser = new JsonStringParser(input);

--- a/client/js/nonprofits/donate/parseFields/customFields/JsonStringParser.ts
+++ b/client/js/nonprofits/donate/parseFields/customFields/JsonStringParser.ts
@@ -1,10 +1,14 @@
 // License: LGPL-3.0-or-later
 import has from 'lodash/has';
+import get from 'lodash/get';
 import { parse } from 'json5';
 import { CustomFieldDescription } from '../customField';
 
 function isCustomFieldDesc(item:unknown) : item is CustomFieldDescription {
-  return typeof item == 'object' && has(item, 'name') && has(item, 'label');
+  return typeof item == 'object' && 
+    has(item, 'name') && 
+    has(item, 'label') && 
+    ['supporter'].includes(get(item, 'type'));
 }
 export default class JsonStringParser {
   public errors:SyntaxError[] = [];

--- a/client/js/nonprofits/donate/parseFields/customFields/index.spec.ts
+++ b/client/js/nonprofits/donate/parseFields/customFields/index.spec.ts
@@ -5,7 +5,7 @@ import {parseCustomFields as newParse} from './new';
 
 describe('.parseCustomFields', () => {
   it('when passed an array of json, it parses it', () => {
-    expect(parseCustomFields("[{name: 'name', label: 'labeled'}] ")).toStrictEqual([{name: "name", label: "labeled"}]);
+    expect(parseCustomFields("[{name: 'name', label: 'labeled', type:'supporter'}] ")).toStrictEqual([{name: "name", label: "labeled", type: 'supporter'}]);
   });
 });
 
@@ -17,15 +17,15 @@ describe.each([
 )('parse with simple custom fields', (name, method) => {
     describe(name, () => {
       it('when only name provided, label is name', () => {
-        expect(method("  Supporter Tier ")).toStrictEqual([{name: "Supporter Tier", label: "Supporter Tier"}]);
+        expect(method("  Supporter Tier ")).toStrictEqual([{name: "Supporter Tier", label: "Supporter Tier", type: 'supporter'}]);
       });
 
       it('when label provided, label is set too', () => {
-        expect(method(" Custom Supp Level  :     Supporter Tier ")).toStrictEqual([{name: "Custom Supp Level", label: "Supporter Tier"}]);
+        expect(method(" Custom Supp Level  :     Supporter Tier ")).toStrictEqual([{name: "Custom Supp Level", label: "Supporter Tier", type: 'supporter'}]);
       });
 
       it('when passed an array looking thing, it treats a standard label', () => {
-        expect(method(" [Custom Supp Level]  :     Supporter Tier ")).toStrictEqual([{name: "[Custom Supp Level]", label: "Supporter Tier"}]);
+        expect(method(" [Custom Supp Level]  :     Supporter Tier ")).toStrictEqual([{name: "[Custom Supp Level]", label: "Supporter Tier", type: 'supporter'}]);
       });
   });
 });


### PR DESCRIPTION
- Add specs to donate/components/info-step/customFields
- Add a type property to the CustomFieldDescription

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
