### PR TITLE
Add TS types to get-params

### DIFF
--- a/client/js/nonprofits/donate/amt.ts
+++ b/client/js/nonprofits/donate/amt.ts
@@ -5,7 +5,7 @@ export interface AmountButtonDesc {
   highlight: string | false;
 }
 
-type AmountButtonInput = {
+export type AmountButtonInput = {
   amount: number;
   highlight: string | boolean;
 } | number;

--- a/client/js/nonprofits/donate/get-params.d.ts
+++ b/client/js/nonprofits/donate/get-params.d.ts
@@ -1,0 +1,14 @@
+// License: LGPL-3.0-or-later
+import { AmountButtonInput } from "./amt";
+
+type GetParamsInputBase = {[prop:string]: any};
+
+export type GetParamsOutput<TInput> = TInput & {
+  custom_amounts:AmountButtonInput[],
+  tags?:string[],
+}
+
+declare const getParams: <GetParamsInput extends GetParamsInputBase>(input:GetParamsInput) => GetParamsOutput<GetParamsInput>;
+
+
+export default getParams;


### PR DESCRIPTION
Depends on #839 

- Add specs to donate/components/info-step/customFields
- Add a type property to the CustomFieldDescription
- Add type to get-params

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
