### PR TITLE
Fix bug where donations paid without a name don't include the email in the subject line sent to nonprofit

### DIFF
--- a/app/mailers/donation_mailer.rb
+++ b/app/mailers/donation_mailer.rb
@@ -65,7 +65,7 @@ class DonationMailer < BaseMailer
       @emails = [em]
 		end
 		if @emails.any?
-			mail(to: @emails, subject: "Donation receipt for #{@donation.supporter.name}")
+			mail(to: @emails, subject: "Donation receipt for #{@donation.supporter.name || @donation.supporter.email}")
 		end
 	end
 

--- a/spec/mailers/donation_mailer_spec.rb
+++ b/spec/mailers/donation_mailer_spec.rb
@@ -194,4 +194,67 @@ RSpec.describe DonationMailer, :type => :mailer do
 
     end
   end
+
+  describe "#nonprofit_payment_notification" do
+
+    context 'when supporter name is set' do
+      before(:each) {
+        expect(QueryUsers).to receive(:nonprofit_user_emails).and_return(['anything@example.com'])
+      }
+      
+      let(:supporter) { create(:supporter_base)}
+      let(:donation) { create(:donation_base, supporter: supporter, nonprofit: supporter.nonprofit)}
+      let(:payment) { create(:payment_base, donation: donation)}
+
+      let!(:mail) { DonationMailer.nonprofit_payment_notification(
+        donation.id, 
+        payment.id
+        ) }
+      
+      it 'uses the supporter name in subject' do
+        expect(mail.subject).to include supporter.name
+      end
+    end
+
+
+    context 'when supporter name is nil' do
+      before(:each) {
+        expect(QueryUsers).to receive(:nonprofit_user_emails).and_return(['anything@example.com'])
+      }
+      
+      let(:supporter) { create(:supporter_base, email: "supporter@example.com", name: nil)}
+      let(:donation) { create(:donation_base, supporter: supporter, nonprofit: supporter.nonprofit)}
+      let(:payment) { create(:payment_base, donation: donation)}
+
+      let!(:mail) { DonationMailer.nonprofit_payment_notification(
+        donation.id, 
+        payment.id
+        ) }
+      
+      it 'uses the supporter email instead of name in subject' do
+        expect(mail.subject).to include supporter.email
+      end
+    end
+
+    context 'when supporter name is blank', pending: true do
+      before(:each) {
+        expect(QueryUsers).to receive(:nonprofit_user_emails).and_return(['anything@example.com'])
+      }
+      
+      let(:supporter) { create(:supporter_base, email: "supporter@example.com", name: "")}
+      let(:donation) { create(:donation_base, supporter: supporter, nonprofit: supporter.nonprofit)}
+      let(:payment) { create(:payment_base, donation: donation)}
+
+      let!(:mail) { DonationMailer.nonprofit_payment_notification(
+        donation.id, 
+        payment.id
+        ) }
+
+      
+      it 'uses the supporter email instead of name in subject' do
+        expect(mail.subject).to include supporter.email
+      end
+    end
+    
+  end
 end


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
Closes https://github.com/CommitChange/tix/issues/4353
