### PR TITLE
Remove testing on postgres 13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           os: [ubuntu-20.04]
           node: [14.19.1, 16]
           ruby: ['2.6.10']
-          postgres: ['13', '16']
+          postgres: ['16']
         fail-fast: false
       steps:
         - uses: actions/checkout@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,7 +349,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (5.6.8)
+    puma (5.6.9)
       nio4r (~> 2.0)
     puma_worker_killer (0.3.1)
       get_process_mem (~> 0.2)


### PR DESCRIPTION
We moved fully to Postgres 16 so there's no need to test on PG 13 any more.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
