### PR TITLE
allow title_image_url param in widget

### DIFF
--- a/app/assets/stylesheets/nonprofits/donation_form/title_row.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/title_row.scss
@@ -6,9 +6,10 @@
 	position: relative;
 	overflow: hidden;
 	background: $fog;
+	display: flex;
+	gap: 15px;
 }
 .titleRow-info {
-	float: left;
 	max-width: 85%;
 }
 .titleRow h2 {
@@ -30,10 +31,13 @@
 	font-size: 14px;
 	color: rgba($logo-blue, 0.9);
 }
-.titleRow img {
-	float: left;
-	padding-right: 15px;
+.titleRow img.logo {
 	max-width: 15%;
+	max-height: 55px;
+	flex-shrink: 0;
+}
+.titleRow-info img {
+	max-width: 85%;
 	max-height: 55px;
 }
 #donate .closeButton {

--- a/app/assets/stylesheets/nonprofits/donation_form/title_row.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/title_row.scss
@@ -11,6 +11,9 @@
 }
 .titleRow-info {
 	max-width: 85%;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
 }
 .titleRow h2 {
 	margin: 0 0 1px 0;
@@ -35,10 +38,12 @@
 	max-width: 15%;
 	max-height: 55px;
 	flex-shrink: 0;
+	object-fit: contain;
 }
 .titleRow-info img {
 	max-width: 85%;
 	max-height: 55px;
+	object-fit: contain;
 }
 #donate .closeButton {
   z-index: 1;

--- a/client/js/nonprofits/donate/wizard.js
+++ b/client/js/nonprofits/donate/wizard.js
@@ -154,6 +154,21 @@ const postDedication = (dedication, donor, donation) => {
   }).load)
 }
 
+const titleInfo = state => {
+  if (state.params$().title_image_url) {
+    return [h('img', { props: { src: state.params$().title_image_url } })];
+  }
+
+  return [
+    h('h2', app.campaign.name || app.nonprofit.name)
+  , h('p', [
+      state.params$().designation && !state.params$().single_amount
+        ? headerDesignation(state)
+        : app.campaign.tagline || app.nonprofit.tagline || '',
+    ]),
+  ];
+}
+
 const view = state => {
   return h('div.js-donateForm', {
     class: {'is-modal': state.params$().offsite}
@@ -164,15 +179,8 @@ const view = state => {
       , class: {'u-hide': (state.params$().embedded || state.params$().mode === 'embedded') || !state.params$().offsite }
     })
   , h('div.titleRow', [
-      h('img', {props: {src: app.nonprofit.logo.normal.url}})
-    , h('div.titleRow-info', [
-        h('h2', app.campaign.name || app.nonprofit.name )
-      , h('p', [
-          state.params$().designation && !state.params$().single_amount
-          ? headerDesignation(state)
-          : app.campaign.tagline || app.nonprofit.tagline || ''
-        ])
-      ])
+      h('img.logo', {props: {src: app.nonprofit.logo.normal.url}})
+    , h('div.titleRow-info', titleInfo(state))
     ])
   , wizardWrapper(state)
   , h('footer.donateForm-footer', {

--- a/client/js/nonprofits/donate/wizard.js
+++ b/client/js/nonprofits/donate/wizard.js
@@ -156,7 +156,14 @@ const postDedication = (dedication, donor, donation) => {
 
 const titleInfo = state => {
   if (state.params$().title_image_url) {
-    return [h('img', { props: { src: state.params$().title_image_url } })];
+    return [
+      h('img', {
+        props: {
+          src: state.params$().title_image_url
+        , alt: state.params$().title_image_alt || app.campaign.tagline || app.nonprofit.tagline || ''
+        },
+      }),
+    ];
   }
 
   return [


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Closes commitchange/tix#4389

## example with long narrow logo, and very large (1764 × 1107) title image
![Screenshot 2024-10-28 at 10 20 37 AM](https://github.com/user-attachments/assets/e62ab5e5-220b-4e52-8e83-d8ab1f2f010f)

## example with very small title image, shorter than the space, showing it centers 
**note that we can't control for inherently uncentered images like the logo in this example, which has slightly more empty space at the bottom than the top of the image.**
![Screenshot 2024-10-28 at 10 37 36 AM](https://github.com/user-attachments/assets/27bda1bb-a871-4af1-ae9f-822f12b37c4f)
