### PR TITLE
Move isCustomFieldDescription guard into the customField directory

### DIFF
--- a/client/js/nonprofits/donate/parseFields/customField/index.ts
+++ b/client/js/nonprofits/donate/parseFields/customField/index.ts
@@ -1,10 +1,19 @@
 // License: LGPL-3.0-or-later
 import { parseCustomField } from "./legacy";
+import has from 'lodash/has';
+import get from 'lodash/get';
 
 export interface CustomFieldDescription {
   name: NonNullable<string>;
   label: NonNullable<string>;
   type: 'supporter';
+}
+
+export function isCustomFieldDescription(item:unknown) : item is CustomFieldDescription {
+  return typeof item == 'object' && 
+    has(item, 'name') && 
+    has(item, 'label') && 
+    ['supporter'].includes(get(item, 'type'));
 }
 
 

--- a/client/js/nonprofits/donate/parseFields/customFields/JsonStringParser.ts
+++ b/client/js/nonprofits/donate/parseFields/customFields/JsonStringParser.ts
@@ -1,15 +1,8 @@
 // License: LGPL-3.0-or-later
-import has from 'lodash/has';
-import get from 'lodash/get';
 import { parse } from 'json5';
-import { CustomFieldDescription } from '../customField';
+import { CustomFieldDescription, isCustomFieldDescription } from '../customField';
 
-function isCustomFieldDesc(item:unknown) : item is CustomFieldDescription {
-  return typeof item == 'object' && 
-    has(item, 'name') && 
-    has(item, 'label') && 
-    ['supporter'].includes(get(item, 'type'));
-}
+
 export default class JsonStringParser {
   public errors:SyntaxError[] = [];
   public readonly results: CustomFieldDescription[] = [];
@@ -27,7 +20,7 @@ export default class JsonStringParser {
       const result = parse(this.fieldsString)
       if (result instanceof Array) {
         result.forEach((i) => {
-          if (isCustomFieldDesc(i)) {
+          if (isCustomFieldDescription(i)) {
             this.results.push({ ...i});
           }
           

--- a/client/js/nonprofits/donate/parseFields/customFields/JsonStringParser.ts
+++ b/client/js/nonprofits/donate/parseFields/customFields/JsonStringParser.ts
@@ -2,7 +2,6 @@
 import { parse } from 'json5';
 import { CustomFieldDescription, isCustomFieldDescription } from '../customField';
 
-
 export default class JsonStringParser {
   public errors:SyntaxError[] = [];
   public readonly results: CustomFieldDescription[] = [];


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Looking at the code now, it really makes more sense for the isCustomFieldDescription guard function to be properly named and to be with the definition of `CustomFieldDescription`. This PR moves that to its proper place.