### PR TITLE
fix widget dedication form layout

### DIFF
--- a/app/assets/stylesheets/nonprofits/donation_form/form.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/form.scss
@@ -87,12 +87,6 @@ $mint-milk : #E7F3ED;
 	margin: 15px 0 20px 0;
 }
 
-.dedication-form {
-  background: #fcfcfc;
-  padding: 10px;
-  border-radius: 4px;
-}
-
 .donationModal .ff-modal {
   width: 480px;
   margin-left: -240px;

--- a/client/js/nonprofits/donate/info-step.js
+++ b/client/js/nonprofits/donate/info-step.js
@@ -91,22 +91,23 @@ function recurringMessage(state){
 function view(state) {
 
   var form = h('form', {
+    class: {'u-hide': state.showDedicationForm$()},
     on: {
       submit: ev => {ev.preventDefault(); state.currentStep$(2); state.submitSupporter$(ev.currentTarget)}
     }
   }, [
-  recurringMessage(state)
+    recurringMessage(state)
   , supporterFields.view(state.supporterFields)
   , customFields(state.params$().custom_fields)
   , dedicationLink(state)
   , anonField(state)
   , h('div', paymentMethodButtons(["card"], state))
   ])
+
   return h('div.wizard-step.info-step.u-padding--10', [
     form
   , h('div', {
-      style: {background: '#f8f8f8', position: 'absolute', 'top': '0', left: '3px', height: '100%', width: '99%'}
-    , class: {'u-hide': !state.showDedicationForm$(), opacity: 0, transition: 'opacity 1s', delay: {opacity: 1}}
+     class: { 'u-hide': !state.showDedicationForm$() }
     }, [dedicationForm.view(state)] )
   ])
 }


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

This fixes both some background color issues and the scenario where the dedication form could overlap the bottom of the widget, since it was absolutely positioned. Instead of positioning it over the info form, this uses the same (but reversed) css logic to hide the info form when displaying the dedication form. The widget then adjusts to the height of the correct form, and we don't need background colors to hide the form behind it.

## before (note white gaps around edge and two different gray backgrounds)
![Screenshot 2024-11-11 at 10 24 30 AM](https://github.com/user-attachments/assets/e2259e6c-e64d-4752-a830-a3af9412a6c3)

## another before (it was possible for form to overflow widget)
![Screenshot 2024-11-11 at 10 59 56 AM](https://github.com/user-attachments/assets/cf888888-bd0e-456c-81ea-65ab5dfbf6a8)



## after (no separate backgrounds, just swaps in the right form, no extra space below form (widget adjusts))
![Screenshot 2024-11-11 at 10 24 44 AM](https://github.com/user-attachments/assets/a17bbb41-2282-422a-8453-6edbea549c06)
