### PR TITLE
clean up widget padding, remove box around address

### DIFF
--- a/app/assets/stylesheets/nonprofits/donation_form/form.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/form.scss
@@ -103,7 +103,12 @@ $mint-milk : #E7F3ED;
 	display: flex;
 }
 
-.info-step div.address {
+.info-step section.address {
+	padding-top: 10px;
+}
+
+
+.info-step .manual-address-fields {
 	display: flex;
 	flex-wrap: wrap;
 

--- a/app/assets/stylesheets/nonprofits/donation_form/form.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/form.scss
@@ -42,9 +42,6 @@ $mint-milk : #E7F3ED;
 }
 
 // amount step
-.wizard-steps .amount-step {
-	padding: 0 5px;
-}
 .wizard-steps .amount-step button.is-selected {
 	background: darken($mint-milk, 10);
 }
@@ -93,6 +90,13 @@ $mint-milk : #E7F3ED;
 }
 .donationModal .ff-modal-body {
   padding: 0;
+}
+
+// info step
+.info-step > form {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 }
 
 .info-step section.group {

--- a/client/js/components/address-autocomplete-fields.js
+++ b/client/js/components/address-autocomplete-fields.js
@@ -36,7 +36,7 @@ function calculateToShip(state)
 }
 
 function view(state) {
-  return h('section.u-padding--5.pastelBox--grey', [
+  return h('section', [
     calculateToShip(state)
     ? h('label.u-centered.u-marginBottom--5', [
         'Shipping address (required)'

--- a/client/js/components/address-autocomplete-fields.js
+++ b/client/js/components/address-autocomplete-fields.js
@@ -36,7 +36,7 @@ function calculateToShip(state)
 }
 
 function view(state) {
-  return h('section', [
+  return h('section.address', [
     calculateToShip(state)
     ? h('label.u-centered.u-marginBottom--5', [
         'Shipping address (required)'
@@ -61,7 +61,7 @@ const autoField = state => {
 }
 
 const manualFields = state => {
-  return h('div.address', [
+  return h('div.manual-address-fields', [
     h('fieldset.u-fontSize--14', [
       h('input.u-marginBottom--0', {props: {
         type: 'text'

--- a/client/js/components/supporter-fields.js
+++ b/client/js/components/supporter-fields.js
@@ -46,7 +46,7 @@ function init(state, params$) {
 //   }
 function view(state) {
   const emailTitle = I18n.t('nonprofits.donate.info.supporter.email') + `${state.required.email ? `${I18n.t('nonprofits.donate.info.supporter.email_required')}` : ''}`
-  return h('div.u-marginY--10', [
+  return h('div', [
     h('input', { props: { type: 'hidden' , name: 'profile_id' , value: state.supporter.profile_id } })
   , h('input', { props: { type: 'hidden' , name: 'nonprofit_id' , value: state.supporter.nonprofit_id || app.nonprofit_id } })
   , h('fieldset', [
@@ -64,7 +64,7 @@ function view(state) {
     ])
   , h('section.group', [
       h('fieldset', [
-        h('input', {
+        h('input.u-marginBottom--0', {
           props: {
             type: 'text'
           , name: 'first_name'
@@ -76,7 +76,7 @@ function view(state) {
         })
       ])
     , h('fieldset', [
-        h('input', {
+        h('input.u-marginBottom--0', {
           props: {
             type: 'text'
           , name: 'last_name'
@@ -88,7 +88,7 @@ function view(state) {
         })
       ])
     , h('fieldset', [
-        h('input', {
+        h('input.u-marginBottom--0', {
           props: {
             type: 'text'
           , name: 'phone'

--- a/client/js/nonprofits/donate/info-step.js
+++ b/client/js/nonprofits/donate/info-step.js
@@ -104,7 +104,7 @@ function view(state) {
   , h('div', paymentMethodButtons(["card"], state))
   ])
 
-  return h('div.wizard-step.info-step.u-padding--10', [
+  return h('div.wizard-step.info-step', [
     form
   , h('div', {
      class: { 'u-hide': !state.showDedicationForm$() }


### PR DESCRIPTION
- remove gray padding around address fields
- remove extra padding around steps
- remove gap between info form areas

## before — amounts
![Screenshot 2024-11-11 at 11 46 41 AM](https://github.com/user-attachments/assets/b28036bb-ebd7-4dbd-88c0-c75481c557dd)

## after — amounts (slightly less horizontal padding on widget, lines up better with header)
![Screenshot 2024-11-11 at 11 47 14 AM](https://github.com/user-attachments/assets/986ed936-8898-46e3-a031-8a7ea7567dff)


## before — info
![Screenshot 2024-11-11 at 11 10 11 AM](https://github.com/user-attachments/assets/57832491-6b14-462a-90b2-905e2560dc27)

## after — info
![Screenshot 2024-11-11 at 11 15 22 AM](https://github.com/user-attachments/assets/005a65ff-ff82-42d7-93fe-e0598e51a0da)

## note that payment stays the same, and the "after" versions are more consistent with it
![Screenshot 2024-11-11 at 11 51 43 AM](https://github.com/user-attachments/assets/fda1fa98-ffec-4555-a1b6-417e375b3f76)
