### PR TITLE
widget — remove titlerow background

### DIFF
--- a/app/assets/stylesheets/nonprofits/donation_form/title_row.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/title_row.scss
@@ -5,7 +5,6 @@
 	padding: 15px 15px 10px 15px;
 	position: relative;
 	overflow: hidden;
-	background: $fog;
 	display: flex;
 	gap: 15px;
 	@include border-radius(3px 3px 0 0);


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Some orgs use images with backgrounds, and if they do, they're more likely to use a white background than this exact shade of gray, so this would minimize the number of times there's a weird background issue. It's already separated from the rest of the widget nicely by the steps/tabs section, so it doesn't need a different background to distinguish it.