### PR TITLE
Make script/restore_from_heroku work in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ README.md
 tmp
 log
 node_modules
+.bin

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ tmp
 log
 node_modules
 .bin
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ javascripts/api
 
 app/javascript/routes.js
 app/javascript/routes.d.ts
+
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,8 @@ COPY . ${RAILS_ROOT}
 FROM ${BASE}
 
 ENV LANG en_US.UTF-8
-
 RUN apt-get update -qq \
-  && apt-get install -y libjemalloc2 postgresql-client tzdata libv8-dev curl default-jre \
+  && apt-get install -y libjemalloc2 tzdata libv8-dev curl default-jre git \
   && curl -sL https://deb.nodesource.com/setup_16.x | bash \
   && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" \
@@ -57,6 +56,19 @@ RUN apt-get update -qq \
   && apt-get install -y nodejs yarn \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+ARG BASE_RELEASE=bullseye
+RUN apt-get update -qq \
+  && apt-get install -y gnupg2 wget vim \
+  && echo "deb https://apt.postgresql.org/pub/repos/apt ${BASE_RELEASE}-pgdg main" \
+  > /etc/apt/sources.list.d/pgdg.list \
+  && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg \
+  && apt-get update -qq \
+  && apt-get install -y postgresql-client-16 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://cli-assets.heroku.com/install.sh | sh
 
 RUN groupadd --gid 1000 app && \
   useradd --uid 1000 --no-log-init --create-home --gid app app
@@ -74,4 +86,5 @@ ARG RAILS_ROOT=/app/
 
 WORKDIR $RAILS_ROOT
 RUN mkdir -p tmp/pids
-CMD echo $IS_DOCKER && foreman start
+RUN touch /home/app/.netrc
+CMD foreman start

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ RUN apt-get update -qq \
 
 ARG BASE_RELEASE=bullseye
 RUN apt-get update -qq \
-  && apt-get install -y gnupg2 wget vim \
   && echo "deb https://apt.postgresql.org/pub/repos/apt ${BASE_RELEASE}-pgdg main" \
   > /etc/apt/sources.list.d/pgdg.list \
   && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc|gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg \

--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ This is a work-in-progress method of running a development environment. The stan
 
 One time setup:
 ```bash
+touch ~/.netrc #prevents docker compose from creating it as a directory if you don't have it yet
+
 docker-compose run web bin/rake db:setup
+
+# To get a copy of the Prod database as test data.
+docker-compose run web script/restore_from_heroku.sh
+# enter `password` when prompted for password
 ```
 
 Running:

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ touch ~/.netrc #prevents docker compose from creating it as a directory if you d
 docker-compose run web bin/rake db:setup
 
 # Run this to get a copy of the Prod database as test data.
-# Enter `password` when prompted for a password after the download step.
-# The restore step after that will take a very long time. Hours maybe.
-docker-compose run web script/restore_from_heroku.sh
+curl -o ./tmp/shared/latest.dump `heroku pg:backups:url -a commitchange`
+
+# Enter `password` if prompted for a password.
+# This may take up to an hour.
+docker-compose exec db pg_restore --verbose --clean --no-acl --no-owner -h localhost -U admin -d commitchange_development_legacy /tmp/shared/latest.dump
 ```
 
 Running:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Restoring the DB from Prod (Mac). The above command will work on Mac, but will t
 curl -o ./tmp/shared/latest.dump `heroku pg:backups:url -a commitchange`
 
 # Enter `password` when prompted for a password.
-docker-compose exec db -e HOUDINI_DUMP_PATH="/tmp/shared/latest.dump" script/pg_restore_local_from_production.sh
+docker-compose exec db -e CC_PROD_DUMP_PATH="/tmp/shared/latest.dump" script/pg_restore_local_from_production.sh
 ```
 
 #### One-time setup (Ubuntu)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ docker-compose run web bin/rake db:setup
 
 # Run this to get a copy of the Prod database as test data.
 # Enter `password` when prompted for a password after the download step.
-# The restore step after that will take a very long time. Hours maybe.
 docker-compose run web script/restore_from_heroku.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,9 @@ touch ~/.netrc #prevents docker compose from creating it as a directory if you d
 docker-compose run web bin/rake db:setup
 
 # Run this to get a copy of the Prod database as test data.
-curl -o ./tmp/shared/latest.dump `heroku pg:backups:url -a commitchange`
-
-# Enter `password` if prompted for a password.
-# This may take up to an hour.
-docker-compose exec db pg_restore --verbose --clean --no-acl --no-owner -h localhost -U admin -d commitchange_development_legacy /tmp/shared/latest.dump
+# Enter `password` when prompted for a password after the download step.
+# The restore step after that will take a very long time. Hours maybe.
+docker-compose run web script/restore_from_heroku.sh
 ```
 
 Running:

--- a/README.md
+++ b/README.md
@@ -42,8 +42,13 @@ touch ~/.netrc #prevents docker compose from creating it as a directory if you d
 docker-compose run web bin/rake db:setup
 
 # Run this to get a copy of the Prod database as test data.
-# Enter `password` when prompted for a password after the download step.
-docker-compose run web script/restore_from_heroku.sh
+curl -o ./tmp/shared/latest.dump `heroku pg:backups:url -a commitchange`
+
+docker-compose up
+
+# Enter `password` if prompted for a password.
+# This may take up to an hour on Mac.
+docker-compose exec db pg_restore --verbose --clean --no-acl --no-owner -h localhost -U admin -d commitchange_development_legacy /tmp/shared/latest.dump
 ```
 
 Running:

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ touch ~/.netrc #prevents docker compose from creating it as a directory if you d
 
 docker-compose run web bin/rake db:setup
 
-# To get a copy of the Prod database as test data.
+# Run this to get a copy of the Prod database as test data.
+# Enter `password` when prompted for a password after the download step.
+# The restore step after that will take a very long time. Hours maybe.
 docker-compose run web script/restore_from_heroku.sh
-# enter `password` when prompted for password
 ```
 
 Running:

--- a/README.md
+++ b/README.md
@@ -35,25 +35,32 @@ download the .env file in 1Password and place it in the root directory.
 #### Dockerized
 This is a work-in-progress method of running a development environment. The standard is still the bare metal instructions below.
 
-One time setup:
+Mac users can ignore this, but if your host machine is Linux, you might run into permission issues with the tmp files created by the postgres image. To proactively avoid this, run `cp docker-compose.override.yml.example docker-compose.override.yml` and change the values inside the newly copied file to match the output of `echo $(id -u):$(id -g)`
+
+One-time setup:
 ```bash
 touch ~/.netrc #prevents docker compose from creating it as a directory if you don't have it yet
 
 docker-compose run web bin/rake db:setup
-
-# Run this to get a copy of the Prod database as test data.
-curl -o ./tmp/shared/latest.dump `heroku pg:backups:url -a commitchange`
-
-docker-compose up
-
-# Enter `password` if prompted for a password.
-# This may take up to an hour on Mac.
-docker-compose exec db pg_restore --verbose --clean --no-acl --no-owner -h localhost -U admin -d commitchange_development_legacy /tmp/shared/latest.dump
 ```
 
 Running:
 ```bash
 docker-compose up
+```
+
+Restoring the DB from Prod (Linux):
+```bash
+# Enter `password` when prompted for a password after the download step.
+docker-compose exec web script/restore_from_heroku.sh
+```
+
+Restoring the DB from Prod (Mac). The above command will work on Mac, but will take an hour or more due to differences in how docker handles storage. Use the below to reduce how long it takes (will still take a long time).
+```bash
+curl -o ./tmp/shared/latest.dump `heroku pg:backups:url -a commitchange`
+
+# Enter `password` when prompted for a password.
+docker-compose exec db -e HOUDINI_DUMP_PATH="/tmp/shared/latest.dump" script/pg_restore_local_from_production.sh
 ```
 
 #### One-time setup (Ubuntu)

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,7 @@ development:
   pool: 5
   username: admin
   password: password
-  host: localhost
+  host: <%= ENV['DATABASE_HOST']  || 'localhost' %>
   min_messages: warning
 
 test:

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,4 @@
+version: "3.9"
+services:
+  db:
+    user: 1001:1001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
   web:
     build: .
     volumes:
+      - ${HOME}${USERPROFILE}/.netrc:/home/app/.netrc # for heroku credentials
       - ./app:/app/app
       - ./bin:/app/bin
       - ./config:/app/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./tmp/db:/var/lib/postgresql/data
+      - ./tmp/db:/var/lib/postgresql/data:delegated
+      - ./tmp/shared:/tmp/shared:cached
     environment:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,12 @@
 version: "3.9"
 services:
   db:
-    image: postgres:16
+    image: postgres:latest
     restart: always
     ports:
       - "5432:5432"
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
-      - ./tmp/shared:/tmp/shared
     environment:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     build: .
     volumes:
       - ${HOME}${USERPROFILE}/.netrc:/home/app/.netrc # for heroku credentials
+      - ./vendor/bundle:/usr/local/bundle
       - ./app:/app/app
       - ./bin:/app/bin
       - ./config:/app/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   db:
-    image: postgres:latest
+    image: postgres:16
     restart: always
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 version: "3.9"
 services:
   db:
-    image: postgres:latest
+    image: postgres:16
     restart: always
     ports:
       - "5432:5432"
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
+      - ./tmp/shared:/tmp/shared
     environment:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=password

--- a/script/pg_restore_local_from_production.sh
+++ b/script/pg_restore_local_from_production.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-pg_restore --verbose --clean --no-acl --no-owner -h ${DATABASE_HOST:-localhost} -U admin -d commitchange_development_legacy ${HOUDINI_DUMP_PATH:-"latest.dump"}
+pg_restore --verbose --clean --no-acl --no-owner -h ${DATABASE_HOST:-localhost} -U admin -d commitchange_development_legacy ${CC_PROD_DUMP_PATH:-"latest.dump"}

--- a/script/pg_restore_local_from_production.sh
+++ b/script/pg_restore_local_from_production.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-pg_restore --verbose --clean --no-acl --no-owner -h localhost -U admin -d commitchange_development_legacy latest.dump
+pg_restore --verbose --clean --no-acl --no-owner -h ${DATABASE_HOST:-localhost} -U admin -d commitchange_development_legacy latest.dump

--- a/script/pg_restore_local_from_production.sh
+++ b/script/pg_restore_local_from_production.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 set -e
-
-pg_restore --verbose --clean --no-acl --no-owner -h ${DATABASE_HOST:-localhost} -U admin -d commitchange_development_legacy latest.dump
+pg_restore --verbose --clean --no-acl --no-owner -h ${DATABASE_HOST:-localhost} -U admin -d commitchange_development_legacy ${HOUDINI_DUMP_PATH:-"latest.dump"}

--- a/script/restore_from_heroku.sh
+++ b/script/restore_from_heroku.sh
@@ -2,5 +2,5 @@
 set -e
 
 
-curl -o latest.dump `heroku pg:backups:url -a commitchange`
+curl -o ${HOUDINI_DUMP_PATH:-"latest.dump"} `heroku pg:backups:url -a commitchange`
 script/pg_restore_local_from_production.sh

--- a/script/restore_from_heroku.sh
+++ b/script/restore_from_heroku.sh
@@ -2,5 +2,5 @@
 set -e
 
 
-curl -o ${HOUDINI_DUMP_PATH:-"latest.dump"} `heroku pg:backups:url -a commitchange`
+curl -o ${CC_PROD_DUMP_PATH:-"latest.dump"} `heroku pg:backups:url -a commitchange`
 script/pg_restore_local_from_production.sh


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Makes the changes necessary for  script/restore_from_heroku  to work in the  dockerized  dev  environment.

# Test plan
`docker-compose down -v` to clear previous versions' volumes
follow  the new instructions in the readme to  run  script in docker