### PR TITLE
Add QuerySupporters.dupes_on_last_name_and_address_and_email

### DIFF
--- a/app/legacy_lib/query_supporters.rb
+++ b/app/legacy_lib/query_supporters.rb
@@ -641,6 +641,19 @@ UNION DISTINCT
       .map { |arr_group| arr_group.flatten.sort }
   end
 
+  def self.dupes_on_last_name_and_address_and_email(np_id)
+    dupes_expr(np_id)
+      .and_where(
+        "name IS NOT NULL\
+         AND name != ''\
+         AND address IS NOT NULL \
+         AND address != ''"
+      )
+      .group_by(self.calculated_last_name +  " || '_____' || address || '_____' || COALESCE(email, '')")
+      .execute(format: 'csv')[1..-1]
+      .map { |arr_group| arr_group.flatten.sort }
+  end
+
   def self.dupes_on_phone_and_email(np_id, strict_mode = true)
     group_by_clause = [(strict_mode ? strict_email_match : loose_email_match), "phone_index"].join(', ')
     dupes_expr(np_id)
@@ -697,7 +710,15 @@ UNION DISTINCT
   end
 
   def self.calculated_last_name
-    "substring(trim(both from supporters.name) from '^.+ ([^\s]+)$')"
+    "
+      CASE
+            WHEN TRIM(supporters.name) LIKE '% %' THEN substring(
+              TRIM(supporters.name)
+              FROM
+                '^.+ ([^ ]+)$'
+            )
+            ELSE TRIM(supporters.name)
+          END"
   end
 
   # Create an export that lists donors with their total contributed amounts

--- a/app/legacy_lib/query_supporters.rb
+++ b/app/legacy_lib/query_supporters.rb
@@ -709,6 +709,8 @@ UNION DISTINCT
     "regexp_replace (lower(name),'[^0-9a-z]','','g')"
   end
 
+  # gets the last words in the name field. If there's a single word, it gets that. If there's multiple words, then it just gets
+  # everything but the first one
   def self.calculated_last_name
     "
       CASE

--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -121,6 +121,10 @@ class Nonprofit < ApplicationRecord
       QuerySupporters.dupes_on_last_name_and_address(proxy_association.owner.id)
     end
 
+    def dupes_on_last_name_and_address_and_email
+      QuerySupporters.dupes_on_last_name_and_address_and_email(proxy_association.owner.id)
+    end
+
     def for_export_enumerable(query, chunk_limit=15000)
       QuerySupporters.for_export_enumerable(proxy_association.owner.id, query, chunk_limit)
     end

--- a/spec/lib/query/query_supporters_spec.rb
+++ b/spec/lib/query/query_supporters_spec.rb
@@ -458,6 +458,155 @@ describe QuerySupporters do
     end
   end
 
+  describe '.dupes_on_last_name_and_address_and_email' do
+    subject { QuerySupporters.dupes_on_last_name_and_address_and_email(np.id) }
+
+    it 'finds supporters with the same last name and address and email' do
+      supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'Clear Waters Avenue', email: "email@example.com")
+      supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Penelope Borges', address: 'Clear Waters Avenue', email: "email@example.com")
+
+      expect(subject).to eq([[supporter_1.id, supporter_2.id]])
+    end
+
+    context 'when different names' do
+      it 'does not find' do
+        supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'Clear Waters Avenue', email: "email@example.com")
+        supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Penelope Schultz', address: 'Clear Waters Avenue', email: "email@example.com")
+
+        expect(subject).to match_array([])
+      end
+    end
+
+    context 'when different addresses' do
+      it 'does not find' do
+        supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau', address: 'Clear Waters Avenue', email: "email@example.com")
+        supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau', address: 'Clear.Waters.Avenue')
+
+        expect(subject).to match_array([])
+      end
+    end
+
+    context 'when the name is empty' do
+      it 'does not find' do
+        supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: '', address: 'Clear Waters Avenue', email: "email@example.com")
+        supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: '', address: 'Clear Waters Avenue', email: "email@example.com")
+
+        expect(subject).to eq([])
+      end
+    end
+
+    context 'when the name is nil' do
+      it 'does not find' do
+        supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: nil, address: 'Clear Waters Avenue', email: "email@example.com")
+        supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: nil, address: 'Clear Waters Avenue', email: "email@example.com")
+
+        expect(subject).to eq([])
+      end
+    end
+
+    context 'when the email is nil' do
+      it 'finds' do
+        supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau', address: 'Clear Waters Avenue', email: nil)
+        supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau', address: 'Clear Waters Avenue', email: nil)
+
+        expect(subject).to eq([[supporter_1.id, supporter_2.id]])
+      end
+    end
+
+    context 'when not on strict mode' do
+      subject { QuerySupporters.dupes_on_name_and_address(np.id, false) }
+      context 'when names are the same but with different casing' do
+        it 'finds' do
+          supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'cacau', address: 'Clear Waters Avenue', email: "email@example.com")
+          supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'CACAU', address: 'Clear Waters Avenue', email: "email@example.com")
+
+          expect(subject).to eq([[supporter_1.id, supporter_2.id]])
+        end
+      end
+
+      context 'when names are the same but with different spacing' do
+        it 'finds' do
+          supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'cacauborges', address: 'Clear Waters Avenue', email: "email@example.com")
+          supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'Clear Waters Avenue', email: "email@example.com")
+
+          expect(subject).to eq([[supporter_1.id, supporter_2.id]])
+        end
+      end
+
+      context 'when names are the same but with special characters' do
+        it 'finds' do
+          supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'cacau-borges', address: 'Clear Waters Avenue', email: "email@example.com")
+          supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau.Borges', address: 'Clear Waters Avenue', email: "email@example.com")
+
+          expect(subject).to eq([[supporter_1.id, supporter_2.id]])
+        end
+      end
+
+      context 'when the names are not the same' do
+        it 'does not find' do
+          supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'cacau', address: 'Clear Waters Avenue', email: "email@example.com")
+          supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'cacau borges', address: 'Clear Waters Avenue', email: "email@example.com")
+
+          expect(subject).to match_array([])
+        end
+      end
+
+      context 'when the name is empty' do
+        it 'does not find' do
+          supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: '', address: 'Clear Waters Avenue', email: "email@example.com")
+          supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: '', address: 'Clear Waters Avenue', email: "email@example.com")
+
+          expect(subject).to eq([])
+        end
+      end
+
+      context 'when the name is nil' do
+        it 'does not find' do
+          supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: nil, address: 'Clear Waters Avenue', email: "email@example.com")
+          supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: nil, address: 'Clear Waters Avenue', email: "email@example.com")
+
+          expect(subject).to eq([])
+        end
+      end
+
+      context 'when addresses are the same but with different casing' do
+        it 'finds' do
+          supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'Clear Waters Avenue', email: "email@example.com")
+          supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'clear waters avenue', email: "email@example.com")
+
+          expect(subject).to eq([[supporter_1.id, supporter_2.id]])
+        end
+      end
+
+      context 'when addresses are the same but with different spacing' do
+        it 'finds' do
+          supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'Clear Waters Avenue', email: "email@example.com")
+          supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'ClearWatersAvenue', email: "email@example.com")
+
+          expect(subject).to eq([[supporter_1.id, supporter_2.id]])
+        end
+      end
+
+      context 'when addresses are the same but with special characters' do
+        it 'finds' do
+          supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'Clear Waters . Avenue', email: "email@example.com")
+          supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'Clear Waters - Avenue', email: "email@example.com")
+
+          expect(subject).to eq([[supporter_1.id, supporter_2.id]])
+        end
+      end
+
+      context 'when the addresses are not the same' do
+        it 'does not find' do
+          supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'Clear Waters Avenue', email: "email@example.com")
+          supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'Avenue, Clear Waters', email: "email@example.com")
+
+          expect(subject).to match_array([])
+        end
+      end
+    end
+  end
+
   describe '.dupes_on_phone_and_email' do
     subject { QuerySupporters.dupes_on_phone_and_email(np.id) }
 

--- a/spec/lib/query/query_supporters_spec.rb
+++ b/spec/lib/query/query_supporters_spec.rb
@@ -464,7 +464,8 @@ describe QuerySupporters do
     it 'finds supporters with the same last name and address and email' do
       supporter_1 = force_create(:supporter, nonprofit_id: np.id, name: 'Cacau Borges', address: 'Clear Waters Avenue', email: "email@example.com")
       supporter_2 = force_create(:supporter, nonprofit_id: np.id, name: 'Penelope Borges', address: 'Clear Waters Avenue', email: "email@example.com")
-
+      supporter_3 = force_create(:supporter, nonprofit_id: np.id, name: 'Penelope Schultz', address: 'Clear Waters Avenue', email: "email@example.com")
+ 
       expect(subject).to eq([[supporter_1.id, supporter_2.id]])
     end
 


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Needed for https://github.com/CommitChange/tix/issues/4414

A client requested the ability to find dupes based on last name, address and email. We didn't have that query so this adds it.