### PR TITLE
Run workflows on ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
-          os: [ubuntu-20.04]
+          os: [ubuntu-latest]
           node: [16]
           ruby: ['2.6.10']
           postgres: ['16']

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
-          os: [ubuntu-20.04]
+          os: [ubuntu-latest]
           node: [16]
           ruby: ['2.6.10']
           postgres: ['16']


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

For historical reasons that I don't remember, we run our builds on ubuntu-20.04. That isn't really useful anymore so let's just update it to ubuntu-latest.
