### PR TITLE
Update bundler in Gemfile.lock to 2.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -610,4 +610,4 @@ RUBY VERSION
    ruby 2.6.10p210
 
 BUNDLED WITH
-   1.17.3
+   2.0.2


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Our bundler version was super out of date and Dependabot stopped supporting version 1. This updates us to the 2.0 branch at least.
