### PR TITLE
Volumize bundle output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ tmp
 log
 node_modules
 .bin
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ javascripts/api
 
 app/javascript/routes.js
 app/javascript/routes.d.ts
+
+vendor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     build: .
     volumes:
       - ${HOME}${USERPROFILE}/.netrc:/home/app/.netrc # for heroku credentials
+      - ./vendor/bundle:/usr/local/bundle
       - ./app:/app/app
       - ./bin:/app/bin
       - ./config:/app/config


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

This makes the  bundle output in the docker container a volume stored in ./vendor/bundle, so that it doesn't have to reinstall everything when the dockerfile is rebuilt without caching.

# Test plan
`docker-compose up --build` and verify that ./vendor/bundle is populated