### PR TITLE
remove most ramda from client/js/common

### DIFF
--- a/client/js/common/ajax/check_campaign_or_event_name.js
+++ b/client/js/common/ajax/check_campaign_or_event_name.js
@@ -1,12 +1,11 @@
 // License: LGPL-3.0-or-later
-const R = require('ramda')
 const request = require('../client')
 
 module.exports = function(name, event_or_campaign, callback) {
   request.get(`/nonprofits/${app.nonprofit_id}/${event_or_campaign}s/name_and_id`)
     .end(function(err, resp){
       var names = resp.body.map(x => x.name)
-      if(R.contains(name, names)) {
+      if(names.includes(name)) {
         appl.notify(`Oops.  It looks like you already have ${event_or_campaign === 'campaign' ? 'a' : 'an'} ${event_or_campaign} named '${name}'.  Please choose a different name and try again.`)
         return
       }

--- a/client/js/common/direct-to-s3-upload.es6
+++ b/client/js/common/direct-to-s3-upload.es6
@@ -28,7 +28,7 @@ const uploadFile = R.curry(input => {
       var url = `${presignedPost.s3_direct_url}`
       var file = input.files[0]
       var fileUrl = `${url}/tmp/${presignedPost.s3_uuid}/${file.name}`
-      var payload = R.merge(JSON.parse(presignedPost.s3_presigned_post), {file})
+      var payload = { ...JSON.parse(presignedPost.s3_presigned_post), file }
 
       return flyd.map(resp => ({uri: fileUrl, file}), postFormData(url, payload))
     }

--- a/client/js/common/fundraiser_metrics.js
+++ b/client/js/common/fundraiser_metrics.js
@@ -1,15 +1,15 @@
 // License: LGPL-3.0-or-later
-const R = require('ramda')
+const clamp = require('lodash/clamp');
 const format = require('../common/format')
 require('../common/restful_resource')
 
 appl.def('ajax_metrics', {
 	index: function() {
 		appl.ajax.index('metrics').then(function(resp) {
-       appl.def('metrics.percentage_funded',  R.clamp(1,100, format.percent(
+       appl.def('metrics.percentage_funded',  clamp(format.percent(
           resp.body.goal_amount
         , resp.body.total_raised
-          ))
+          ), 1,100)
         )
 		})
 	}

--- a/client/js/common/on-change-sanitize-slug.js
+++ b/client/js/common/on-change-sanitize-slug.js
@@ -1,11 +1,14 @@
 // License: LGPL-3.0-or-later
-const R = require('ramda')
 const sanitize = require('./sanitize-slug')
 
 // Just a hacky way to automatically sanitize slug inputs when they are changed
 
 var inputs = document.querySelectorAll('.js-sanitizeSlug')
 
-R.map(
-  inp => inp.addEventListener('change', ev => ev.currentTarget.value = sanitize(ev.currentTarget.value || ev.currentTarget.getAttribute('data-slug-default')))
-, inputs )
+inputs.map((inp) =>
+  inp.addEventListener(
+    'change',
+    (ev) =>
+      (ev.currentTarget.value = sanitize(ev.currentTarget.value || ev.currentTarget.getAttribute('data-slug-default')))
+  )
+);

--- a/client/js/common/request.js
+++ b/client/js/common/request.js
@@ -1,11 +1,11 @@
 // License: LGPL-3.0-or-later
-const R = require('ramda')
 const request = require('flyd-ajax')
 
 module.exports = options => {
-  options.headers = R.merge({
-    'Content-Type': 'application/json'
-  , 'X-CSRF-Token': window._csrf
-  }, options.headers || {})
+  options.headers = {
+    'Content-Type': 'application/json',
+    'X-CSRF-Token': window._csrf,
+    ...(options.headers || {}),
+  };
   return request(options)
 }

--- a/client/js/common/search-data.js
+++ b/client/js/common/search-data.js
@@ -1,5 +1,4 @@
 // License: LGPL-3.0-or-later
-const R = require('ramda')
 const flyd = require('flimflam/flyd')
 const getValidData = require('../common/get-valid-data')
 
@@ -20,16 +19,16 @@ module.exports = (path, pageLength) => {
   const hasMoreResults$ = flyd.map(x => x && x.length >= pageLength, allResults$)
 
   const data$ = flyd.scanMerge([
-    [searchLessResults$, (data, results) => R.concat(data, results)]
+    [searchLessResults$, (data, results) => [...data, ...results]]
   , [searchResults$, (data, results) => results]
   ], [])
 
   searchLessQuery$({page: 1, page_length: pageLength, search: ''})
 
   const loading$ = flyd.mergeAll([
-    flyd.map(R.always(true), submitSearch$)
-  , flyd.map(R.always(true), searchLessQuery$)
-  , flyd.map(R.always(false), allResults$)
+    flyd.map(() => true, submitSearch$)
+  , flyd.map(() => true, searchLessQuery$)
+  , flyd.map(() => false, allResults$)
   , flyd.stream(true)
   ])
 


### PR DESCRIPTION
split out from https://github.com/CommitChange/houdini/pull/964

- try to make a new campaign or event with the name of an existing one, verify that there's a message at the bottom telling you you can't
- try importing supporters
- go to an event, click settings, edit slug field, adding spaces or capital letters, then unfocus / tab out / click elsewhere, it should go lowercase and with hyphens
- go to /admin as superadmin, make sure search works
- **note: not certain where fundraiser_metrics is used**
- **note: request.js is used all over the place, so it should be immediately obvious if it's broken**