### PR TITLE
only hide focus outline when not focus-visible

### DIFF
--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -15,7 +15,7 @@
 	clear: both;
 	color: white;
 	display: inline-block;
-	&:focus { outline: none; }
+	&:focus:not(:focus-visible) { outline: none; }
 	&.blue {@include setBackgroundAndHover($light-logo-blue);}
 	&.bluegreen {@include setBackgroundAndHover($bluegrass);}
 	&.bluegrey {@include setBackgroundAndHover($sea-foam);}

--- a/app/assets/stylesheets/components/inputs.scss
+++ b/app/assets/stylesheets/components/inputs.scss
@@ -162,7 +162,7 @@ input[type="file"]::-webkit-file-upload-button {
 	cursor: pointer;
 	border: none;
 	font-weight: bold;
-	&:focus {outline:none;}
+	&:focus:not(:focus-visible) {outline: none;}
 }
 
 .input--mini {

--- a/app/assets/stylesheets/resets.scss
+++ b/app/assets/stylesheets/resets.scss
@@ -4,14 +4,13 @@ body * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box; 
-  outline: none;
   -webkit-font-smoothing: antialiased;
   font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-html *:focus,
-body *:focus {  outline: none; }
+html *:focus:not(:focus-visible),
+body *:focus:not(:focus-visible) {  outline: none; }
 
 html {
 	-ms-text-size-adjust: 100%;


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

closes https://github.com/CommitChange/tix/issues/4495

hard to get video of, but on the left I'm trying to tab through the options and eventually the custom input is focused, then on the right I do the same thing but I can actually see what I'm doing. These should be the browser's native focus styles, and we should probably keep them, but we can adjust them if we want to as long as they're clearly visible.
https://github.com/user-attachments/assets/7639e6e0-922a-44ad-a40a-34b0a48546a8



