### PR TITLE
Remove puma worker killer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'kaminari'
 
 gem 'bootsnap', require: false
 gem 'rack-timeout'
-gem 'puma_worker_killer'
 
 gem 'test-unit'
 gem 'hamster'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,8 +235,6 @@ GEM
     ffi (1.11.3)
     foreman (0.87.2)
     geocoder (1.2.11)
-    get_process_mem (0.2.7)
-      ffi (~> 1.0)
     grape (1.1.0)
       activesupport
       builder
@@ -359,9 +357,6 @@ GEM
     public_suffix (4.0.6)
     puma (5.6.9)
       nio4r (~> 2.0)
-    puma_worker_killer (0.3.1)
-      get_process_mem (~> 0.2)
-      puma (>= 2.7)
     rabl (0.17.0)
       activesupport (>= 2.3.14)
     racc (1.6.2)
@@ -579,7 +574,6 @@ DEPENDENCIES
   pry
   pry-byebug
   puma (~> 5.6)
-  puma_worker_killer
   qx!
   rabl
   rack!

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,11 +21,6 @@ end
 
 before_fork do
   Barnes.start
-  require 'puma_worker_killer'
-  PumaWorkerKiller.config do |config|
-    config.ram           = 1024 # mb
-  end
-  PumaWorkerKiller.start
 end
 
 # rackup      DefaultRackup


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Before we switching to using jemalloc, the memory on the server process would occasionally increase too quickly through the day. Eventually, we'd use more than our allocated amount, heroku would get angry and some responses would fail. To work around this, we'd use puma worker killer which would kill a process every 6 hours or so.

[Switching to jemalloc](https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html#fix-2-use-jemalloc) keeps our memory stable throughout the 24 hour period between Heroku dyno restarts. That means we don't need puma worker killer anymore.


