### PR TITLE
Switch from incorrect inputs.map to inputs.forEach

### DIFF
--- a/client/js/common/on-change-sanitize-slug.js
+++ b/client/js/common/on-change-sanitize-slug.js
@@ -5,7 +5,7 @@ const sanitize = require('./sanitize-slug')
 
 var inputs = document.querySelectorAll('.js-sanitizeSlug')
 
-inputs.map((inp) =>
+inputs.forEach((inp) =>
   inp.addEventListener(
     'change',
     (ev) =>


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

This is related to one of the changes you made earlier @hejkal. It only showed up in Rails 5 for some baffling reason. When you look at what the code is doing, forEach makes more sense anyways, I think.

