### PR TITLE
Load svgs and pngs as data-urls for webpack and use it

### DIFF
--- a/client/js/nonprofits/button/appearance.js
+++ b/client/js/nonprofits/button/appearance.js
@@ -4,7 +4,8 @@ var h = require("virtual-dom/h")
 
 var footer = require('./footer')
 var radioAndLabelWrapper = require('../../components/radio-and-label-wrapper')
-
+const miniAmountStepSrc = require('../../../../app/assets/images/graphics/mini-amount-step.png');
+const donateElephantSrc = require('../../../../app/assets/images/graphics/donate-elephant.png');
 var appearanceStream = flyd.stream()
 
 module.exports = {
@@ -67,14 +68,14 @@ function fixedButton(){
 
 function embeddedButton(){
 	var title = 'Embed directly on page'
-	var content = [ h('img', {src: app.asset_path + "/graphics/mini-amount-step.png", title: title})]
+	var content = [ h('img', {src: miniAmountStepSrc, title: title})]
 	return h('td', [radioAndLabelWrapper('radio-embedded', namePrefix + 'name', {'value': 'embedded'},
 		contentWrapper(title, content), appearanceStream)])
 }
 
 function imageButton(state){
 	var title = 'Custom image'
-	var defaultImg = app.asset_path + "/graphics/donate-elephant.png"
+	var defaultImg = donateElephantSrc
 	var imgUrl = state.settings.appearance.customImg ? state.settings.appearance.customImg : defaultImg
 	var content = [ h('img', {src: imgUrl, title: title}),
 		h('input', {type: 'text', name: namePrefix + 'customImg', placeholder: 'Add your image URL here', onkeyup: appearanceStream})]

--- a/client/js/nonprofits/button/type.js
+++ b/client/js/nonprofits/button/type.js
@@ -5,6 +5,9 @@ var footer = require('./footer')
 var radioAndLabelWrapper = require('../../components/radio-and-label-wrapper')
 
 var namePrefix = 'settings.type.'
+const recurringImgSrc = require('../../../../app/assets/images/graphics/recurring.svg')
+const oneTimeImgSrc = require('../../../../app/assets/images/graphics/one-time.svg')
+
 
 var nameStream = flyd.stream()
 
@@ -25,8 +28,8 @@ function body(){
 }
 
 function menu() {
-	var recurringImg = h('img', {src: app.asset_path + "/graphics/recurring.svg"})
-	var oneTimeImg = h('img', {src: app.asset_path + "/graphics/one-time.svg"})
+	var recurringImg = h('img', {src: recurringImgSrc})
+	var oneTimeImg = h('img', {src: oneTimeImgSrc})
 	var message = "We highly recommend that you accept recurring donations whenever possible. They are a great source of recurring revenue!"
 
 	return h('section',[

--- a/client/js/nonprofits/donate/wizard.js
+++ b/client/js/nonprofits/donate/wizard.js
@@ -21,6 +21,8 @@ const format = require('../../common/format')
 const brandedWizard = require('../../components/styles/branded-wizard')
 const renderStyles = require('../../components/styles/render-styles')
 
+const closeButton = require('../../../../app/assets/images/ui_components/close.svg')
+
 renderStyles()(brandedWizard(null))
 
 // pass in a stream of configuration parameters
@@ -181,7 +183,7 @@ const view = state => {
     class: {'is-modal': state.params$().offsite}
   }, [
     h('img.closeButton', {
-      props: {src: '/assets/ui_components/close.svg'}
+      props: {src: closeButton}
       , on: {click: ev => state.params$().offsite && !state.params$().embedded ? parent.postMessage('commitchange:close', '*') : null}
       , class: {'u-hide': (state.params$().embedded || state.params$().mode === 'embedded') || !state.params$().offsite }
     })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,7 +57,8 @@ let common_rules= [
         { test: /\.tsx?$/, loader:"ts-loader"},
         { test: /\.js$/, exclude: /node_modules|froala/, loader: "babel-loader" },
         { test: /\.es6$/, exclude: /node_modules/, loader: "babel-loader" },
-        { test: /\.svg$/, loader: 'url-loader'}
+        { test: /\.svg$/, loader: 'url-loader'},
+        { test: /\.png$/, loader: 'url-loader'}
 ]
 
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,8 @@ let common_rules= [
         },
         { test: /\.tsx?$/, loader:"ts-loader"},
         { test: /\.js$/, exclude: /node_modules|froala/, loader: "babel-loader" },
-        { test: /\.es6$/, exclude: /node_modules/, loader: "babel-loader" }
+        { test: /\.es6$/, exclude: /node_modules/, loader: "babel-loader" },
+        { test: /\.svg$/, loader: 'url-loader'}
 ]
 
 


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We have a few small svgs and pngs referenced webpacked files that we were referencing based on brittle urls. Since they're tiny, we're just using url-loader to pull them in directly.
