### PR TITLE
Correct bug when accepting ActionController::Parameters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ PATH
   remote: gems/ruby-param-validation
   specs:
     param_validation (0.0.2)
+      actionpack (>= 5)
       chronic
 
 PATH

--- a/gems/ruby-param-validation/lib/param_validation.rb
+++ b/gems/ruby-param-validation/lib/param_validation.rb
@@ -64,7 +64,7 @@ class ParamValidation
     min: lambda {|val, arg, data| val >= arg rescue false},
     max: lambda {|val, arg, data| val <= arg rescue false},
     is_array: lambda {|val, arg, data| val.is_a?(Array)},
-    is_hash: lambda {|val, arg, data| val.is_a?(Hash)},
+    is_hash: lambda {|val, arg, data| val.is_a?(Hash) || val.is_a?(ActionController::Parameters)},
     is_json: lambda {|val, arg, data| ParamValidation.is_valid_json?(val)},
     in_range: lambda {|val, arg, data| arg.cover?(val) rescue false},
     is_a: lambda {|val, arg, data| arg.kind_of?(Enumerable) ? arg.any? {|i| val.is_a?(i)} : val.is_a?(arg)},

--- a/gems/ruby-param-validation/param_validation.gemspec
+++ b/gems/ruby-param-validation/param_validation.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_runtime_dependency 'chronic'
+  s.add_runtime_dependency 'actionpack', ">= 5"
 end

--- a/spec/lib/insert/insert_donation_spec.rb
+++ b/spec/lib/insert/insert_donation_spec.rb
@@ -195,10 +195,10 @@ describe InsertDonation do
 			  nonprofit_id: nonprofit.id,
 			  supporter_id: supporter.id,
 			  date: created_time.to_s,
-				offsite_payment: {
+				offsite_payment: ActionController::Parameters.new({
 					check_number: 1234,
 					kind: "check"
-				}.with_indifferent_access
+				})
 			}.with_indifferent_access
 		  )
           Payment.find(result[:json]['payment']['id']).trx


### PR DESCRIPTION
- **Add spec that shows the bug due to ActionController::Parameters not inheriting for Hash anymore**
- **Update param_validation to use actionpack**
- **Allow is_hash to accept ActionController::Parameters**

The custom ParamValidator has a validation call `is_hash`. This checks whether a parameter is a hash or inherits from a `Hash`. In Rails 5, `ActionController::Parameters` stopped inheriting from a `Hash`. This caused validations to fail which shouldn't have. This corrects the bug and illustrates the fix in `InsertDonation.offsite`. I've also tested this manually and it seems to work.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
