### PR TITLE
Switch from raw_post

### DIFF
--- a/spec/controllers/stripe/stripe_controller_spec.rb
+++ b/spec/controllers/stripe/stripe_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Webhooks::StripeController, :type => :controller do
       end
 
       it 'returns on bad signature' do
-        raw_post :receive, {}, {}.to_json
+        post :receive, body: {}.to_json
         expect(response.body).to include('Invalid signature')
         expect(response.status).to eq 400
       end
@@ -20,7 +20,7 @@ RSpec.describe Webhooks::StripeController, :type => :controller do
       it 'returns on other error' do
         expect(JSON).to receive(:parse).and_raise(ArgumentError)
         request.headers['HTTP_STRIPE_SIGNATURE']= ""
-        raw_post :receive, {}, {}.to_json
+        post :receive, body: {}.to_json
         expect(response.body).to include("Unspecified error")
         expect(response.status).to eq 400
       end
@@ -30,7 +30,7 @@ RSpec.describe Webhooks::StripeController, :type => :controller do
       event = Object.new
       expect(Stripe::Webhook).to receive(:construct_event).and_return(event)
       expect(StripeEvent).to receive(:handle).with(event)
-      raw_post :receive, {}, {}.to_json
+      post :receive, body: {}.to_json
       expect(response.body).to eq ({}.to_json)
       expect(response.status).to eq 200
     end
@@ -55,7 +55,7 @@ RSpec.describe Webhooks::StripeController, :type => :controller do
       end
 
       it 'returns on bad signature' do
-        raw_post :receive_connect, {}, {}.to_json
+        post :receive_connect, body:{}.to_json
         expect(response.body).to include('Invalid signature')
         expect(response.status).to eq 400
       end
@@ -63,7 +63,7 @@ RSpec.describe Webhooks::StripeController, :type => :controller do
       it 'returns on other error' do
         expect(JSON).to receive(:parse).and_raise(ArgumentError)
         request.headers['HTTP_STRIPE_SIGNATURE']= ""
-        raw_post :receive_connect, {}, {}.to_json
+        post :receive_connect, body: {}.to_json
         expect(response.body).to include("Unspecified error")
         expect(response.status).to eq 400
       end
@@ -73,7 +73,7 @@ RSpec.describe Webhooks::StripeController, :type => :controller do
       event = Object.new
       expect(Stripe::Webhook).to receive(:construct_event).and_return(event)
       expect(StripeEvent).to receive(:handle).with(event)
-      raw_post :receive_connect, {}, {}.to_json
+      post :receive_connect,body:{}.to_json
       expect(response.body).to eq ({}.to_json)
       expect(response.status).to eq 200
     end

--- a/spec/controllers/stripe/stripe_controller_spec.rb
+++ b/spec/controllers/stripe/stripe_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Webhooks::StripeController, :type => :controller do
       event = Object.new
       expect(Stripe::Webhook).to receive(:construct_event).and_return(event)
       expect(StripeEvent).to receive(:handle).with(event)
-      post :receive_connect,body:{}.to_json
+      post :receive_connect, body:{}.to_json
       expect(response.body).to eq ({}.to_json)
       expect(response.status).to eq 200
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,14 +7,6 @@ require File.expand_path('../../config/environment', __FILE__)
 
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-module ActionController::TestCase::Behavior
-  def raw_post(action, params, body)
-    @request.env['RAW_POST_DATA'] = body
-    response = post(action, params)
-    @request.env.delete('RAW_POST_DATA')
-    response
-  end
-end
 
 require 'spec_helper'
 require 'rspec/rails'


### PR DESCRIPTION
- **Switch to post and body:**
- **Remove no longer needed raw_post method**

We had used a work around for not being able to send a raw body in a controller request. This became possible in [Rails 5](https://stackoverflow.com/a/43614744) so we're removing the workaround and it's one usage.


**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
