### PR TITLE
Remove unused process_general_refund

### DIFF
--- a/spec/support/contexts/shared_rd_donation_value_context.rb
+++ b/spec/support/contexts/shared_rd_donation_value_context.rb
@@ -153,11 +153,6 @@ RSpec.shared_context :shared_rd_donation_value_context do
     result
   end
 
-  def generate_expected_refund(data={})
-    result = {}.with_indifferent_access
-    result
-  end
-
   def validation_unauthorized
     expect(QuerySourceToken).to receive(:get_and_increment_source_token).with(fake_uuid, nil).and_raise(AuthenticationError)
     expect {yield()}.to raise_error {|e|
@@ -477,16 +472,6 @@ RSpec.shared_context :shared_rd_donation_value_context do
     if (data[:recurring_donation])
       expect(result['recurring_donation'].attributes).to eq expected[:recurring_donation]
     end
-    return result
-  end
-
-  def process_general_refund(data = {})
-    result = yield
-
-    expected = generate_expected_refund()
-
-    expect(result['payment']).to eq expected[:payment]
-    expect(result['refund']).to eq expected[:refund]
     return result
   end
 


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

@caseyhelbling asked about a change I made and it helped me realize that the code in question wasn't used. So I removed it.
