### PR TITLE
Fix an place where we were using tick marks ` instead of single quotes '

### DIFF
--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AdminMailer, :type => :mailer do
     let!(:donation)  {force_create(:donation, nonprofit_id: np.id, supporter_id: s.id, card_id: oldcard.id, amount:999)}
     let!(:charge) { create(:charge, :donation => donation, :nonprofit => np, amount: 100, created_at: Time.now)}
     let(:campaign) {force_create(:campaign, nonprofit: np)}
-    let!(:campaign_gift_option_with_desc)  {force_create(:campaign_gift_option, description: 'desc', amount_one_time: ``, campaign: campaign)}
+    let!(:campaign_gift_option_with_desc)  {force_create(:campaign_gift_option, description: 'desc', amount_one_time: '', campaign: campaign)}
     let!(:campaign_gift_option)  {force_create(:campaign_gift_option, campaign: campaign)}
     let(:mail) { AdminMailer.notify_failed_gift(donation, payment, campaign_gift_option) }
     let(:mail_with_desc) { AdminMailer.notify_failed_gift(donation, payment, campaign_gift_option_with_desc) }


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We were using tickmarks in a spec where we intended to use single quotes. While this has been a bug forever, it wasn't breaking the specs until Rails 6 apparently. This corrects that boo-boo
