### PR TITLE
Remove explicit securerandom

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -181,8 +181,6 @@ gem 'rack-cors'
 
 gem 'ruby2_keywords' # needed because we're backporting code from Rails 6.2
 
-gem 'securerandom' # needed becuase we're on a pre-2.5 Ruby version
-
 gem 'fx',  git: 'https://github.com/teoljungberg/fx.git', ref: '946cdccbd12333deb8f4566c9852b49c0231a618'
 
 gem 'has_scope'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,7 +448,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    securerandom (0.1.1)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     simplecov (0.16.1)
@@ -588,7 +587,6 @@ DEPENDENCIES
   ruby2_keywords
   sassc
   sassc-rails
-  securerandom
   shoulda-matchers
   simplecov (~> 0.16.1)
   sprockets (~> 3.7)


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Earlier versions of Ruby require securerandom to be added to Gemfile to use. The version we're using right now doesn't.
