### PR TITLE
Allow more dependabot updates for bundler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,6 @@ updates:
         update-types:
           - major
         exclude-patterns:
-          - rails
+          - rails # rails is a whole other thing that we're gonna handle on our own
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,26 @@ updates:
   
   - package-ecosystem: "bundler"
     directory: "/"
-    allow:
-      - dependency-type: "development"
+    groups:
+      development-dependencies-minor:
+        dependency-type: development
+        update-types:
+          - patch
+          - minor
+      development-dependencies-major:
+        dependency-type: development
+        update-types:
+          - major
+      production-dependencies-minor:
+        dependency-type: production
+        update-types:
+          - patch
+          - minor
+      production-dependencies-major:
+        dependency-type: production
+        update-types:
+          - major
+        exclude-patterns:
+          - rails
     schedule:
       interval: "weekly"
-    groups:
-      development-dependencies:
-        dependency-type: "development"
-        update-types:
-        - "minor"
-        - "patch"


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We previously didn't have most of the bundler updates turned on for dependabot. This addresses that.
