### PR TITLE
Set CUSTOM_RUBY_VERSION in an env section of build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
+      env:
+        CUSTOM_RUBY_VERSION: ${{ matrix.ruby }}
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
@@ -62,8 +64,6 @@ jobs:
           with:
             node-version: ${{ matrix.node }}
             cache: 'yarn'
-        - name: set CUSTOM_RUBY_VERSION environment variable
-          run: echo "CUSTOM_RUBY_VERSION=${{ matrix.ruby }}" >> $GITHUB_ENV
         - uses: ruby/setup-ruby@v1
           with:
             ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We were setting CUSTOM_RUBY_VERSION in a weird place. This pulls it into the standard env portion of the workflow
