### PR TITLE
Update Rack to 2.1.13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '= 5.0.7.2'
 gem 'mail', '= 2.7.1' # 2.8.1 on Rails 5.0 and Ruby 2.6 raises a `an superclass mismatch for class InternetMessageIO` error
 gem 'sprockets', '~> 3.7' # Sprockets 4.0 stops allowing us to add a proc to the config.assets.precompile array, which we currently use
 
-gem 'rack', '~> 2.2.12'
+gem 'rack', '~> 2.2.13'
 
 gem 'date', '~> 2.0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,7 +346,7 @@ GEM
     rabl (0.17.0)
       activesupport (>= 2.3.14)
     racc (1.7.1)
-    rack (2.2.12)
+    rack (2.2.13)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-attack (6.5.0)
@@ -567,7 +567,7 @@ DEPENDENCIES
   puma (~> 5.6)
   qx!
   rabl
-  rack (~> 2.2.12)
+  rack (~> 2.2.13)
   rack-attack
   rack-cors
   rack-freeze


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Fix for CVE-2025-27610