### PR TITLE
Rename CCOrgError to HoudiniError like in upstream

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ protected
       logger.info "422: #{e}".red.bold
       #logger.info ">>".bold.red + " #{{'Failed key name' => e.data[:key], 'Value' => e.data[:val], 'Failed validator' => e.data[:name]}}".red
       result = {status: 422, json: {error: e.message}}
-		rescue CCOrgError => e
+		rescue HoudiniError => e
 			logger.info "422: #{e}".red.bold
 			result = {status: 422, json: {error: e.message}}
     rescue ActiveRecord::RecordNotFound => e

--- a/app/legacy_lib/houdini_error.rb
+++ b/app/legacy_lib/houdini_error.rb
@@ -1,3 +1,3 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-class CCOrgError < RuntimeError
+class HoudiniError < RuntimeError
 end

--- a/app/legacy_lib/not_enough_quantity_error.rb
+++ b/app/legacy_lib/not_enough_quantity_error.rb
@@ -1,5 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-class NotEnoughQuantityError < CCOrgError
+class NotEnoughQuantityError < HoudiniError
   attr_accessor :klass, :id, :requested
   def initialize(klass, id, requested, msg)
     @klass = klass

--- a/app/legacy_lib/temp_block_error.rb
+++ b/app/legacy_lib/temp_block_error.rb
@@ -1,3 +1,3 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-class TempBlockError < CCOrgError
+class TempBlockError < HoudiniError
 end


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We have some custom errors that we use in a few places. That have inherited from CCOrgError. That name was based upon Houdini's original proposed name of CommitChange.org. In upstream, these have been renamed to HoudiniError. Since Zeitwerk doesn't like the name `CCOrg` in a class name, I think it makes sense to just switch to HoudiniError now.