### PR TITLE
Remove unused traceroute gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,11 +94,6 @@ gem 'rails-i18n' # For 4.0.x
 gem 'i18n-js'
 gem 'countries'
 
-
-group :development, :ci do
-  gem 'traceroute'
-end
-
 group :development, :ci, :test do
   gem 'listen'
   gem 'letter_opener'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,8 +480,6 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.7.3)
-    traceroute (0.5.0)
-      rails (>= 3.0.0)
     tunemygc (1.0.71)
     tzinfo (1.2.11)
       thread_safe (~> 0.1)
@@ -595,7 +593,6 @@ DEPENDENCIES
   table_print
   test-unit
   timecop
-  traceroute
   tunemygc
   webmock
   yard


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We don't use the traceroute gem so let's remove it.