### PR TITLE
Run js builds when Gemfiles change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,10 @@ jobs:
                 - '.babelrc'
                 - '.bootstraprc'
                 - '.browserlistrc'
-              
+                # include Gemfiles because some of the Gems could break yarn build
+                - 'Gemfile' 
+                - 'Gemfile.lock'
+
         - name: Setup PostgreSQL with PostgreSQL extensions and unprivileged user
           uses: Daniel-Marynicz/postgresql-action@1.0.0
           with:


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

When Gems change, it's possible for the Javascript to stop building. This changes the build rules so changes to Gems makes the build workflow attempt to build the Javascript.