### PR TITLE
Switch about us URL

### DIFF
--- a/config/commitchange.yml
+++ b/config/commitchange.yml
@@ -75,7 +75,7 @@ terms_and_privacy:
   help_url: "https://help.commitchange.com"
   privacy_url: "https://commitchange.com/privacy-terms/#privacy_policy"
   terms_url: "https://commitchange.com/privacy-terms/"
-  about_url: "https://commitchange.com/about-us/"
+  about_url: "https://commitchange.com/us/"
 
 
 ccs:


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

The About Us link was pointing to the wrong page.
