### PR TITLE
Remove the strange default in factory bot for creating a supporter when creating a nonprofit

### DIFF
--- a/spec/factories/nonprofits.rb
+++ b/spec/factories/nonprofits.rb
@@ -18,10 +18,6 @@ FactoryBot.define do
       }
     end
 
-    after(:create) {|nonprofit, evaluator|
-      create(:supporter, nonprofit: nonprofit)
-    }
-
     factory :nonprofit_with_billing_plan_percentage_fee_of_2_5_percent_and_5_cents_flat do 
       
     end

--- a/spec/lib/mailchimp_spec.rb
+++ b/spec/lib/mailchimp_spec.rb
@@ -117,7 +117,7 @@ describe Mailchimp do
 				'status' => 'subscribed',
 				'merge_fields' => {
 					'NP_ID' => nonprofit.id,
-					'NP_SUPP' => 1,
+					'NP_SUPP' => 0,
 					'FNAME' => "",
 				}
 			})

--- a/spec/lib/query/query_supporters_spec.rb
+++ b/spec/lib/query/query_supporters_spec.rb
@@ -1159,25 +1159,25 @@ describe QuerySupporters do
       it 'when supporter has no name, just first name is blank' do
         s = create(:supporter, name: '')
         supporters = QuerySupporters.for_export_enumerable(s.nonprofit.id, {}).to_a
-        expect(supporters[2][2]).to be_blank
+        expect(supporters[1][2]).to be_blank
       end
 
       it 'when supporter has single name, just first name is filled' do
         s = create(:supporter, name: 'Penelope')
         supporters = QuerySupporters.for_export_enumerable(s.nonprofit.id, {}).to_a
-        expect(supporters[2][2]).to eq 'Penelope'
+        expect(supporters[1][2]).to eq 'Penelope'
       end
 
       it 'when supporter has a two word name, just first name is filled' do
         s = create(:supporter, name: 'Penelope Rebecca')
         supporters = QuerySupporters.for_export_enumerable(s.nonprofit.id, {}).to_a
-        expect(supporters[2][2]).to eq 'Penelope'
+        expect(supporters[1][2]).to eq 'Penelope'
       end
 
       it 'when supporter has a three word name, just first name is filled' do
         s = create(:supporter, name: 'Penelope Rebecca Schultz')
         supporters = QuerySupporters.for_export_enumerable(s.nonprofit.id, {}).to_a
-        expect(supporters[2][2]).to eq 'Penelope'
+        expect(supporters[1][2]).to eq 'Penelope'
       end
     end
   end


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

For some very baffling reason, we were always creating a new supporter every time we were creating a nonprofit through factory bot. Why? I don't have a clue but it was causing one of the specs to fail intermittently. This corrects that.
