### PR TITLE
Tighten up Stripe error creation in specs

### DIFF
--- a/spec/lib/insert/insert_card_spec.rb
+++ b/spec/lib/insert/insert_card_spec.rb
@@ -194,7 +194,7 @@ describe InsertCard do
     end
 
     it 'handle stripe errors' do
-      StripeMockHelper.prepare_error(Stripe::StripeError.new('card error'), :new_customer)
+      StripeMockHelper.prepare_error(Stripe::StripeError.new('generic stripe error'), :new_customer)
       card_data = { :holder_type => 'Nonprofit', :holder_id => nonprofit.id, :stripe_card_id => 'card_88888', :stripe_card_token => stripe_card_token, :name => "card_name" }
 
       card_ret = InsertCard::with_stripe(card_data);

--- a/spec/lib/insert/insert_card_spec.rb
+++ b/spec/lib/insert/insert_card_spec.rb
@@ -184,13 +184,7 @@ describe InsertCard do
     end
 
     it 'handle card errors' do
-      StripeMockHelper.prepare_error(
-        Stripe::CardError.new('card error', 
-          300, 
-          nil, 
-          json_body:{error: {message: 'a message'}}
-        ), 
-          :new_customer)
+      StripeMockHelper.prepare_card_error(:card_error, :new_customer)
       card_data = { :holder_type => 'Nonprofit', :holder_id => nonprofit.id, :stripe_card_id => 'card_88888', :stripe_card_token => stripe_card_token, :name => "card_name" }
 
       card_ret = InsertCard::with_stripe(card_data);


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We need to have StripeMock return errors in certain situations. For whatever reason, they specs weren't using the `stripe_card_error` helper method as they should have. It still worked but became a problem in #1041. Since the fix is really not related to the Stripe gem 5.0 update, I figured I'd just handle it here.

Additionally, since the StripeError in the next spec is a generic error, not a card error, I changed the error message to be less confusing.