### PR TITLE
Fix `NoMethodError` raised by `TagJoin::Modification.new` when `ActionController::Parameters` passed

### DIFF
--- a/app/models/tag_join/modification.rb
+++ b/app/models/tag_join/modification.rb
@@ -5,8 +5,7 @@ class TagJoin::Modification
   attr_reader :tag_master_id, :selected
 
   def initialize(opts={})
-    # TODO move the parameters further out
-    assign_attributes(ActionController::Parameters.new(opts).permit(:tag_master_id, :selected))
+    assign_attributes(opts)
   end
 
   def tag_master_id=(value)

--- a/spec/controllers/nonprofits/tag_joins_spec.rb
+++ b/spec/controllers/nonprofits/tag_joins_spec.rb
@@ -11,6 +11,53 @@ describe Nonprofits::TagJoinsController, :type => :controller do
 
     describe 'modify' do
       include_context :open_to_np_associate, :post, :modify, nonprofit_id: :__our_np, id: '1'
+
+      context 'strong params' do
+        let(:supporter) { create(:supporter_base)}
+        let(:nonprofit) { supporter.nonprofit }
+        let(:tag_master) { create(:tag_master_base, nonprofit: nonprofit) }
+
+        before(:each) do
+          sign_in create(:user_as_nonprofit_admin, nonprofit: nonprofit)
+        end
+        
+        let(:params) do
+          {
+            nonprofit_id: nonprofit.id,
+            supporter_ids: [supporter.id], 
+            tags: [
+              {
+                tag_master_id: tag_master.id,
+                selected: true,
+                supporter_id: :invalid, # proves that the permit strips this out
+                something_else: :invalid, # proves that the permit strips this out
+              }
+            ]
+        }
+        end
+
+        it 'succeeds' do
+          post :modify, params: params
+          expect(supporter.tag_joins.count).to eq 1
+        end
+
+        # The line below raises the following error. I suspect it is due to the oldness of our Rails and Ruby.
+        # We can turn this back on in newer versions and see if it works
+        #     1) Nonprofits::TagJoinsController authorization modify permitting is expected to (for POST #modify) restrict parameters on :tags to :tag_master_id
+        # Failure/Error: modify_params.require(:tags)
+        
+        # NameError:
+        #   undefined method `permit' for class `#<Class:#<Array:0x00005d12eeae6a60>>'
+        #   Did you mean?  print
+        # # ./app/controllers/nonprofits/tag_joins_controller.rb:42:in `tag_modify_params'
+        # # ./app/controllers/nonprofits/tag_joins_controller.rb:22:in `modify'
+        # # ./spec/controllers/nonprofits/tag_joins_spec.rb:45:in `block (5 levels) in <top (required)>'
+        # # ./spec/rails_helper.rb:92:in `block (3 levels) in <top (required)>'
+        # # ./spec/rails_helper.rb:91:in `block (2 levels) in <top (required)>'
+
+        # it { is_expected.to permit(:tag_master_id).for(:modify, params: params, verb: :post).on(:tags)  }
+      end
+     
     end
 
     describe 'destroy' do

--- a/spec/models/tag_join/modification_spec.rb
+++ b/spec/models/tag_join/modification_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe TagJoin::Modification, :type => :model do
       )
     end
 
+    it 'works when it receives a ActionController::Parameters that is permitted' do
+      tag_master = create(:tag_master_base)
+      params = ActionController::Parameters.new(tag_master_id: tag_master.id, selected: false).permit(:tag_master_id, :selected)
+      expect { TagJoin::Modification.new(params) }.to_not raise_error
+    end
+
     it 'works when everything needs to be casted' do
       tag_master = create(:tag_master_base)
       expect(TagJoin::Modification.new(tag_master_id: tag_master.id.to_s, selected: "false")).to have_attributes(


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

The `TagJoin::Modification` class used `ActionController::Parameters` internally in its constructor. It's constructor accepts a `Hash`. Since `ActionController::Parameters`, until 5.1, inherited from `Hash`, it was fine if we passed a `ActionController::Parameters` into `ActionController::Parameters.new`. Now you can't do that and it throws a `NoMethodError`.

Looking back, I'm not sure why `TagJoin::Modification` was written this way. I think it was an extra protection to guarantee that we actually used strong parameters but I'm not quite sure. Nonetheless, that's not the correct place to handle that nor does it make much sense. This change removes the call to `ActionController::Parameters.new` in `TagJoin::Modification` constructor. Additionally, it adds a spec to verify that strong parameters are used in `Nonprofits::TagJoinsController#modify` which is the one place we currently use `TagJoin::Modification`.
