### PR TITLE
Remove unneeded rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,7 +150,6 @@ group :production, :staging do
   gem "hiredis", "~> 0.6.0"
   gem "redis", ">= 3.2.0"
   gem 'redis-actionpack'
-  gem 'rails_12factor'
 end
 
 gem 'grape', '~> 1.8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,12 +379,7 @@ GEM
     rails-i18n (5.1.3)
       i18n (>= 0.7, < 2)
       railties (>= 5.0, < 6)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
     rails_autoscale_agent (0.9.1)
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.2.8.1)
       actionpack (= 5.2.8.1)
       activesupport (= 5.2.8.1)
@@ -572,7 +567,6 @@ DEPENDENCIES
   rack-timeout
   rails (~> 5.2.8.1)
   rails-i18n
-  rails_12factor
   rails_autoscale_agent (>= 0.9.1)
   rake
   recaptcha (~> 5.8.1)


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Starting at Rails 5, you don't need need this gem. This removes it.
