### PR TITLE
Set public_file_server.enabled on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
   config.static_cache_control = "public, max-age=#{10.minutes.seconds.to_i}"
 
   # Compress JavaScripts and CSS.


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

This corrects a bug where the public file server was incorrectly turned off on production. This caused a crash when starting on Rails 6 on production.