### PR TITLE
Replace `bin/rake` with `bin/rails`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         - continue-on-error: true
           if: steps.changes.outputs.ruby == 'true'
           name: run spec
-          run: bin/rake spec
+          run: bin/rails spec
         - continue-on-error: true
           if: steps.changes.outputs.ruby == 'true'
           run: script/compile-assets.sh

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 web: /bin/bash -c '[[ $IS_DOCKER = "true" ]] && $(bundle exec puma -p $PORT -C ./config/puma.rb) || $(bin/rails server -p $PORT)'
-worker: bin/rake jobs:work
+worker: bin/rails jobs:work
 webpack: yarn watch

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ One-time setup:
 ```bash
 touch ~/.netrc #prevents docker compose from creating it as a directory if you don't have it yet
 
-docker-compose run web bin/rake db:setup
+docker-compose run web bin/rails db:setup
 ```
 
 Running:
@@ -207,7 +207,7 @@ When you run foreman in dev, you start up the server, the job runner and webpack
 foreman start
 ```
 
-If you get `ActiveRecord::NoDatabaseError` errors, run `bin/rake db:create:all` to make sure all the databases are built.
+If you get `ActiveRecord::NoDatabaseError` errors, run `bin/rails db:create:all` to make sure all the databases are built.
 
 ## Frontend
 


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Old versions of Rails didn't make it possible to call rake tasks from `bin/rails`. But we're in the future  :artificial_satellite:  now so let's just switch that over to be more modern.