### PR TITLE
Fix db:create

### DIFF
--- a/config/initializers/pg_type_map.rb
+++ b/config/initializers/pg_type_map.rb
@@ -1,7 +1,6 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-require 'active_record'
-require 'qx'
-require 'pg'
-Qx.config(type_map: PG::BasicTypeMapForResults.new(ActiveRecord::Base.connection.raw_connection))
-Qx.execute("SET TIME ZONE utc")
+ActiveSupport.on_load(:active_record_base) do 
+  Qx.config(type_map: PG::BasicTypeMapForResults.new(ActiveRecord::Base.connection.raw_connection))
+  Qx.execute("SET TIME ZONE utc")
+end
 


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

I noticed a strange behavior. If you run `db:drop` and then run `db:create` then Rails says it can't find the database when it's trying to create the DB. Which it shouldn't even be looking for :smile: 

After looking into the error more, I realized that the issue is that the Qx initializer uses the ActiveRecord::Base connection. In the case of the db:create, that's bad because it's trying to find a connection on a db that doesn't yet exist. I corrected the problem by only running the Qx initializer code in an `on_load(:active_record_base)` hook which means it won't be triggered on a `db:create`.