### PR TITLE
Validate arrays are being returned properly from Qx

### DIFF
--- a/config/initializers/pg_type_map.rb
+++ b/config/initializers/pg_type_map.rb
@@ -1,5 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-ActiveSupport.on_load(:active_record_base) do 
+ActiveSupport.on_load(:active_record) do
   Qx.config(type_map: PG::BasicTypeMapForResults.new(ActiveRecord::Base.connection.raw_connection))
   Qx.execute("SET TIME ZONE utc")
 end

--- a/spec/lib/query/query_supporters_spec.rb
+++ b/spec/lib/query/query_supporters_spec.rb
@@ -132,9 +132,15 @@ describe QuerySupporters do
   end
 
   describe '.full_search' do
+
+    let(:tag_master1) { create(:tag_master_base, nonprofit: supporter1.nonprofit)}
+    let(:tag_master2) { create(:tag_master_base, nonprofit: supporter1.nonprofit)}
     before do
       supporter1.payments = [payment1, payment4]
       supporter2.payments = [payment5]
+
+      supporter1.tag_joins.create(tag_master: tag_master1)
+      supporter1.tag_joins.create(tag_master: tag_master2)
     end
     it 'returns the UTC date when the timezone is not specified' do
       result = QuerySupporters.full_search(np.id, { search: 'Cacau' })
@@ -157,6 +163,20 @@ describe QuerySupporters do
       np.update_attributes(timezone: 'America/New_York')
       result = QuerySupporters.full_search(np.id, { last_payment_before: payment_utc_time.to_s })
       expect(result[:data].count).to eq 2
+    end
+
+    it 'includes tags as an array on supporter with tags' do
+      result = QuerySupporters.full_search(np.id, {})
+
+      expect(result[:data][0]["tags"]).to be_a Array
+      
+    end
+
+    it 'includes tags as null on supporter without a tag' do
+      result = QuerySupporters.full_search(np.id, {})
+
+      expect(result[:data][1]["tags"]).to eq nil
+      
     end
 
     context 'when searching by "at least" contributed' do


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Fixes https://github.com/CommitChange/tix/issues/4517

As it turns out my Qx pg type map fix didn't quite work as expected. A few things happened:

* using `:active_record_base` for the `on_load` hook was not correct. It was supposed to be `:active_record`
* we didn't have a good tests for times when an array was returned from the output of a Qx query so we never caught the issue.

This corrects both problems.


This illustrates that it works correctly on the sample supporter dashboard: 

https://github.com/user-attachments/assets/94d5f117-7af2-4662-a040-175f3dd5a741

