### PR TITLE
Run db:migrate on release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec rails server
 worker: bundle exec rake jobs:work
+release: bundle exec rails db:migrate


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Historically, CommitChange did not automatically run db:migrate on release to Heroku. I don't think we knew it was a possibility even. This now automatically runs db:migrate. We'll have to adjust our way of coding slightly but it's more consistent with standard practices.