### PR TITLE
Validate behavior of mailchimp_login

### DIFF
--- a/spec/controllers/nonprofits/nonprofit_keys_spec.rb
+++ b/spec/controllers/nonprofits/nonprofit_keys_spec.rb
@@ -11,6 +11,14 @@ describe Nonprofits::NonprofitKeysController, :type => :controller do
 
     describe 'mailchimp_login' do
       include_context :open_to_np_associate, :get, :mailchimp_login, nonprofit_id: :__our_np
+
+      it 'properly redirects to a mailchimp domain' do
+        sign_in user_as_np_admin
+
+        get :mailchimp_login, params: {nonprofit_id: nonprofit.id}
+
+        expect(response).to redirect_to(%r{https://login.mailchimp.com.*})
+      end
     end
 
     describe 'mailchimp_landing' do

--- a/spec/controllers/nonprofits/nonprofit_keys_spec.rb
+++ b/spec/controllers/nonprofits/nonprofit_keys_spec.rb
@@ -17,7 +17,7 @@ describe Nonprofits::NonprofitKeysController, :type => :controller do
 
         get :mailchimp_login, params: {nonprofit_id: nonprofit.id}
 
-        expect(response).to redirect_to(%r{https://login.mailchimp.com.*})
+        expect(response).to redirect_to(%r{https://login\.mailchimp\.com.*})
       end
     end
 


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

There was no validation of the redirect of any sort for this Mailchimp login. That's not ideal given that in Rails 7, we're going to have open redirect protection turned on. This spec validates that the redirect actually works as expected.