### PR TITLE
Use a single default_url_options everywhere

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
 
   config.default_url_options = { host: 'localhost', port: 5000}
 	config.action_mailer.default_url_options = config.default_url_options
+  config.action_controller.default_url_options = config.default_url_options
 	config.action_mailer.smtp_settings = { address: Settings.mailer.address, port: Settings.mailer.port }
         config.action_mailer.smtp_settings['user_name']= Settings.mailer.username if Settings.mailer.username
         config.action_mailer.smtp_settings['password']= Settings.mailer.password if Settings.mailer.password

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,7 +52,6 @@ Rails.application.configure do
 	# 	region: 'us-east-1'
 	# )
 	# config.action_mailer.delivery_method = :ses
-	config.action_mailer.default_url_options = { host: 'localhost', port: 5000}
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,7 +38,8 @@ Rails.application.configure do
 	config.action_mailer.delivery_method = :letter_opener
 	config.action_mailer.perform_deliveries = true
 
-	config.action_mailer.default_url_options = { host: 'localhost', port: 5000}
+  config.default_url_options = { host: 'localhost', port: 5000}
+	config.action_mailer.default_url_options = config.default_url_options
 	config.action_mailer.smtp_settings = { address: Settings.mailer.address, port: Settings.mailer.port }
         config.action_mailer.smtp_settings['user_name']= Settings.mailer.username if Settings.mailer.username
         config.action_mailer.smtp_settings['password']= Settings.mailer.password if Settings.mailer.password

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,10 +88,11 @@ Rails.application.configure do
 
     config.action_mailer.perform_caching = false
 
+    config.default_url_options = { host: Settings.mailer.host }
     # Disable delivery errors, bad email addresses will be ignored
     # config.action_mailer.raise_delivery_errors = false
     config.action_mailer.delivery_method = :ses
-    config.action_mailer.default_url_options = { host: Settings.mailer.host }
+    config.action_mailer.default_url_options = config.default_url_options
           # Precompile all "page" files, it needs to be set here so the proper env is setup
           config.assets.precompile << Proc.new do |path|
       if path =~ /.*page\.(css|js)/

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,6 +93,7 @@ Rails.application.configure do
     # config.action_mailer.raise_delivery_errors = false
     config.action_mailer.delivery_method = :ses
     config.action_mailer.default_url_options = config.default_url_options
+    config.action_controller.default_url_options = config.default_url_options
           # Precompile all "page" files, it needs to be set here so the proper env is setup
           config.assets.precompile << Proc.new do |path|
       if path =~ /.*page\.(css|js)/

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -7,6 +7,7 @@ Rails.application.configure do
 	config.default_url_options = { host: 'commitchange-test.herokuapp.com' }
 	config.action_mailer.delivery_method = Settings.mailer.delivery_method.to_sym
 	config.action_mailer.default_url_options = config.default_url_options
+	config.action_controller.default_url_options = config.default_url_options
 
 	# we want to be able to show mailer previews
 	config.action_mailer.show_previews = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -4,8 +4,9 @@ require_relative './production'
 Rails.application.configure do
 	# Settings specified here will take precedence over those in config/application.rb and config/environments/production.rb
 
+	config.default_url_options = { host: 'commitchange-test.herokuapp.com' }
 	config.action_mailer.delivery_method = Settings.mailer.delivery_method.to_sym
-	config.action_mailer.default_url_options = { host: 'commitchange-test.herokuapp.com' }
+	config.action_mailer.default_url_options = config.default_url_options
 
 	# we want to be able to show mailer previews
 	config.action_mailer.show_previews = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,7 +6,6 @@
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
   config.cache_classes = true
 
   # Do not eager load code on boot. This avoids loading your whole application
@@ -43,7 +42,6 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options = { host: 'localhost:8080' }
 
 
   # Print deprecation notices to the stderr.
@@ -65,6 +63,9 @@ Rails.application.configure do
 
   config.action_controller.allow_forgery_protection = false
   config.cache_store = :memory_store
+
+  config.default_url_options = {host: "example.houdini.instance"}
+  config.action_mailer.default_url_options = config.default_url_options
 
   ENV['THROTTLE_SUPPORTER_LIMIT'] = '10'
   ENV['THROTTLE_SUPPORTER_PERIOD'] = '60'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -66,6 +66,7 @@ Rails.application.configure do
 
   config.default_url_options = {host: "example.houdini.instance"}
   config.action_mailer.default_url_options = config.default_url_options
+  config.action_controller.default_url_options = config.default_url_options
 
   ENV['THROTTLE_SUPPORTER_LIMIT'] = '10'
   ENV['THROTTLE_SUPPORTER_PERIOD'] = '60'


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Rails is weird and doesn't use the same default_url_options for everything. This sets it in one place for an environment and then reuses it for ActionMailer.