### PR TITLE
Friendly linting PR

### DIFF
--- a/app/forms/register_nonprofit_form.rb
+++ b/app/forms/register_nonprofit_form.rb
@@ -7,14 +7,14 @@ class RegisterNonprofitForm < ApplicationForm
 
   after_validation :cleanup_the_errors
 
-  def initialize(attributes={})
-    super(attributes)
+  def initialize(attributes = {})
+    super
     @models = [
       nonprofit_form,
       user_form,
       role,
       billing_subscription,
-      stripe_account_form,
+      stripe_account_form
     ]
   end
 
@@ -23,7 +23,7 @@ class RegisterNonprofitForm < ApplicationForm
   end
 
   def billing_subscription
-    @billing_subscription ||= nonprofit.build_billing_subscription(billing_plan: billing_plan, status: 'active')
+    @billing_subscription ||= nonprofit.build_billing_subscription(billing_plan: billing_plan, status: "active")
   end
 
   def id
@@ -33,13 +33,13 @@ class RegisterNonprofitForm < ApplicationForm
   def nonprofit
     nonprofit_form.nonprofit
   end
-  
+
   def nonprofit_form
     @nonprofit_form ||= NonprofitForm.new(nonprofit_attributes)
   end
 
   def role
-    @role ||= user.roles.build(host: nonprofit, name: 'nonprofit_admin')
+    @role ||= user.roles.build(host: nonprofit, name: "nonprofit_admin")
   end
 
   def stripe_account_form
@@ -55,7 +55,7 @@ class RegisterNonprofitForm < ApplicationForm
   end
 
   def add_nonprofit_user_mailchimp
-    MailchimpNonprofitUserAddJob.perform_later( user, nonprofit)
+    MailchimpNonprofitUserAddJob.perform_later(user, nonprofit)
   end
 
   def handle_nonprofit_create_job
@@ -67,11 +67,10 @@ class RegisterNonprofitForm < ApplicationForm
 
     properties = [:nonprofit, :user]
     properties.each do |property_key|
-      property = self.send((property_key.to_s + "_form").to_sym)
+      property = send((property_key.to_s + "_form").to_sym)
       property.errors.each do |error|
-        errors.import(error, attribute: "#{property_key.to_s}[#{error.attribute}]")
+        errors.import(error, attribute: "#{property_key}[#{error.attribute}]")
       end
     end
   end
-  
 end

--- a/app/forms/register_nonprofit_form/nonprofit_form.rb
+++ b/app/forms/register_nonprofit_form/nonprofit_form.rb
@@ -11,7 +11,7 @@ class RegisterNonprofitForm::NonprofitForm < ApplicationForm
     :zip_code
 
   validates :zip_code, presence: true
-  validates :website, format: {with: URI::RFC2396_Parser.make_regexp}, if: proc { |form| form.website.present? }
+  validates :website, format: {with: URI.regexp}, if: proc { |form| form.website.present? }
   # validates :email, format: {with:  URI::MailTo::EMAIL_REGEXP }, if: Proc.new { |form| form.email.present? }
 
   def initialize(attributes = {})

--- a/app/forms/register_nonprofit_form/nonprofit_form.rb
+++ b/app/forms/register_nonprofit_form/nonprofit_form.rb
@@ -1,22 +1,19 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+
 class RegisterNonprofitForm::NonprofitForm < ApplicationForm
   attribute :name, :string, default: "" # needed because OnboardAccounts is goofy
 
-  attr_accessor :city, 
-    :email,
-    :state_code,
-    :phone,
-    :website,
-    :zip_code
+  attr_reader :website
+  attr_accessor :city, :email, :state_code, :phone, :zip_code
 
   validates :zip_code, presence: true
-  validates :website, format: { with: URI.regexp }, if: Proc.new { |form| form.website.present? }
+  validates :website, format: {with: URI::RFC2396_PARSER.make_regexp}, if: proc { |form| form.website.present? }
   # validates :email, format: {with:  URI::MailTo::EMAIL_REGEXP }, if: Proc.new { |form| form.email.present? }
 
-  def initialize(attributes={})
-    super(attributes)
+  def initialize(attributes = {})
+    super
     @models = [
-      nonprofit,
+      nonprofit
     ]
   end
 
@@ -24,31 +21,31 @@ class RegisterNonprofitForm::NonprofitForm < ApplicationForm
     @nonprofit ||= Nonprofit.new(OnboardAccounts.set_nonprofit_defaults(
       city: city,
       email: email,
-      name: name, 
+      name: name,
       phone: phone,
-      state_code: state_code, 
-      website: website, 
-      zip_code: zip_code,
+      state_code: state_code,
+      website: website,
+      zip_code: zip_code
     ))
   end
 
   def website=(url)
     nudged_url = url
-    unless (url =~ /\Ahttp:\/\/.*/i || url =~ /\Ahttps:\/\/.*/i)
-      nudged_url = 'http://'+ url
+    unless url =~ /\Ahttp:\/\/.*/i || url =~ /\Ahttps:\/\/.*/i
+      nudged_url = "http://" + url
     end
     @website = nudged_url
   end
 
   def valid?(context = nil)
-    result = super(context)
+    result = super
     unless result
       if nonprofit.errors.of_kind?(:slug, :taken)
         begin
           slug = ::SlugNonprofitNamingAlgorithm.new(nonprofit.state_code_slug, nonprofit.city_slug).create_copy_name(nonprofit.slug)
           nonprofit.slug = slug
           errors.delete(:slug, :taken)
-          result = super(context) # try again!
+          result = super # try again!
         rescue UnableToCreateNameCopyError
           errors.delete(:slug, :taken)
           errors.add(:name, :invalid, message: "has an invalid slug. Contact support for help.")

--- a/app/forms/register_nonprofit_form/nonprofit_form.rb
+++ b/app/forms/register_nonprofit_form/nonprofit_form.rb
@@ -4,7 +4,11 @@ class RegisterNonprofitForm::NonprofitForm < ApplicationForm
   attribute :name, :string, default: "" # needed because OnboardAccounts is goofy
 
   attr_reader :website
-  attr_accessor :city, :email, :state_code, :phone, :zip_code
+  attr_accessor :city,
+    :email,
+    :state_code,
+    :phone,
+    :zip_code
 
   validates :zip_code, presence: true
   validates :website, format: {with: URI::RFC2396_Parser.make_regexp}, if: proc { |form| form.website.present? }

--- a/app/forms/register_nonprofit_form/nonprofit_form.rb
+++ b/app/forms/register_nonprofit_form/nonprofit_form.rb
@@ -7,7 +7,7 @@ class RegisterNonprofitForm::NonprofitForm < ApplicationForm
   attr_accessor :city, :email, :state_code, :phone, :zip_code
 
   validates :zip_code, presence: true
-  validates :website, format: {with: URI::RFC2396_PARSER.make_regexp}, if: proc { |form| form.website.present? }
+  validates :website, format: {with: URI::RFC2396_Parser.make_regexp}, if: proc { |form| form.website.present? }
   # validates :email, format: {with:  URI::MailTo::EMAIL_REGEXP }, if: Proc.new { |form| form.email.present? }
 
   def initialize(attributes = {})

--- a/app/forms/register_nonprofit_form/stripe_account_form.rb
+++ b/app/forms/register_nonprofit_form/stripe_account_form.rb
@@ -1,12 +1,11 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 class RegisterNonprofitForm::StripeAccountForm < ApplicationForm
-
   attr_accessor :nonprofit
 
   validate :nonprofit_is_a_nonprofit
 
-  def initialize(attributes={})
-    super(attributes)
+  def initialize(attributes = {})
+    super
     @models = []
   end
 
@@ -15,18 +14,18 @@ class RegisterNonprofitForm::StripeAccountForm < ApplicationForm
     save!(options)
     true
   rescue ActiveRecord::RecordInvalid,
-        ActiveRecord::RecordNotSaved,
-        ActiveModel::ValidationError
+    ActiveRecord::RecordNotSaved,
+    ActiveModel::ValidationError
 
     false
   end
 
   def save!(options = {})
-    super(options)
+    super
 
-    if nonprofit.persisted? &&  nonprofit.stripe_account_id.blank?
+    if nonprofit.persisted? && nonprofit.stripe_account_id.blank?
       stripe_account_id = StripeAccountUtils.create(nonprofit)
-      unless stripe_account_id.present?
+      if stripe_account_id.blank?
         add_couldnt_create_stripe_error
         raise ActiveModel::ValidationError, self
       end
@@ -36,7 +35,6 @@ class RegisterNonprofitForm::StripeAccountForm < ApplicationForm
       raise ActiveModel::ValidationError, self
     end
   end
-
 
   private
 

--- a/app/forms/register_nonprofit_form/user_form.rb
+++ b/app/forms/register_nonprofit_form/user_form.rb
@@ -7,10 +7,10 @@ class RegisterNonprofitForm::UserForm < ApplicationForm
 
   validates :name, :password_confirmation, presence: true
 
-  def initialize(attributes={})
-    super(attributes)
+  def initialize(attributes = {})
+    super
     @models = [
-      user,
+      user
     ]
   end
 
@@ -19,7 +19,7 @@ class RegisterNonprofitForm::UserForm < ApplicationForm
       email: email,
       name: name,
       password: password,
-      password_confirmation: password_confirmation,
+      password_confirmation: password_confirmation
     )
   end
 end

--- a/spec/forms/register_nonprofit_form/nonprofit_form_spec.rb
+++ b/spec/forms/register_nonprofit_form/nonprofit_form_spec.rb
@@ -1,80 +1,77 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 require "rails_helper"
 
-RSpec.describe RegisterNonprofitForm::NonprofitForm, :type => :model do
-
+RSpec.describe RegisterNonprofitForm::NonprofitForm, type: :model do
   describe "#website" do
     it { is_expected.to allow_value("www.exa.cs").for(:website) }
-    it "normalizes with http" do
 
+    it "normalizes with http" do
       form = described_class.new(website: "www.exa.cs")
 
       expect(form.website).to eq "http://www.exa.cs"
     end
-
   end
 
   it "validates email" do
     form = described_class.new({
-              email: "noemeila",
-              phone: "notphone",
-              website: ""
-          })
+      email: "noemeila",
+      phone: "notphone",
+      website: ""
+    })
     form.valid?
 
     # we should have the email validation from User model
     expect(form.errors.messages_for(:email)).to be_one
   end
 
-  context 'slug management' do
+  describe "slug management" do
     let(:nonprofit_attributes) do
       attributes_for(
         :nonprofit_base,
         slug: nil,
         zip_code: 51455
       ).slice(
-          :name,
-          :city,
-          :email,
-          :state_code,
-          :phone,
-          :website,
-          :zip_code
-        )
-        
+        :name,
+        :city,
+        :email,
+        :state_code,
+        :phone,
+        :website,
+        :zip_code
+      )
     end
 
-    it 'creates slug when easy' do
+    it "creates slug when easy" do
       form = described_class.new(nonprofit_attributes) # nil so it autocreates the slug
-      
-      expect(form.valid?).to eq true
-      
+
+      expect(form.valid?).to be true
+
       expect(form.nonprofit.slug).to eq "ending-poverty-in-the-fox-valley-inc"
     end
 
-    it 'generates a new slug when the slug is already taken' do
-      saved = create(:nonprofit_base, slug: nil) # so the slug is already taken
+    it "generates a new slug when the slug is already taken" do
+      create(:nonprofit_base, slug: nil) # so the slug is already taken
 
       form = described_class.new(nonprofit_attributes) # nil so it autocreates the slug
 
-      expect(form.valid?).to eq true
-      
+      expect(form.valid?).to be true
+
       expect(form.nonprofit.slug).to eq "ending-poverty-in-the-fox-valley-inc-00"
     end
 
-    it 'fails at creating a new slug' do
-      expect_any_instance_of(SlugNonprofitNamingAlgorithm).to receive(:create_copy_name).and_raise(UnableToCreateNameCopyError.new)
-      force_create(:nonprofit, slug: "n", state_code_slug: "wi", city_slug: "appleton")
-      
+    it "fails at creating a new slug" do
+      allow_any_instance_of(SlugNonprofitNamingAlgorithm)
+        .to receive(:create_copy_name)
+        .and_raise(UnableToCreateNameCopyError.new)
 
+      force_create(:nonprofit, slug: "n", state_code_slug: "wi", city_slug: "appleton")
       form = described_class.new({name: "n", state_code: "WI", city: "appleton", zip_code: 54915}) # nil so it autocreates the slug
 
-      expect(form.valid?).to eq false
+      expect(form.valid?).to be false
 
       errors = form.errors.to_hash
-     
+
       expect(errors).to eq({name: ["has an invalid slug. Contact support for help."]})
     end
-    
   end
 end

--- a/spec/forms/register_nonprofit_form/nonprofit_form_spec.rb
+++ b/spec/forms/register_nonprofit_form/nonprofit_form_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe RegisterNonprofitForm::NonprofitForm, type: :model do
     it "creates slug when easy" do
       form = described_class.new(nonprofit_attributes) # nil so it autocreates the slug
 
-      expect(form.valid?).to be true
-
+      expect(form).to be_valid
       expect(form.nonprofit.slug).to eq "ending-poverty-in-the-fox-valley-inc"
     end
 
@@ -54,8 +53,7 @@ RSpec.describe RegisterNonprofitForm::NonprofitForm, type: :model do
 
       form = described_class.new(nonprofit_attributes) # nil so it autocreates the slug
 
-      expect(form.valid?).to be true
-
+      expect(form).to be_valid
       expect(form.nonprofit.slug).to eq "ending-poverty-in-the-fox-valley-inc-00"
     end
 
@@ -67,7 +65,7 @@ RSpec.describe RegisterNonprofitForm::NonprofitForm, type: :model do
       force_create(:nonprofit, slug: "n", state_code_slug: "wi", city_slug: "appleton")
       form = described_class.new({name: "n", state_code: "WI", city: "appleton", zip_code: 54915}) # nil so it autocreates the slug
 
-      expect(form.valid?).to be false
+      expect(form).not_to be_valid
 
       errors = form.errors.to_hash
 

--- a/spec/forms/register_nonprofit_form/nonprofit_form_spec.rb
+++ b/spec/forms/register_nonprofit_form/nonprofit_form_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe RegisterNonprofitForm::NonprofitForm, type: :model do
     end
 
     it "fails at creating a new slug" do
-      allow_any_instance_of(SlugNonprofitNamingAlgorithm)
+      expect_any_instance_of(SlugNonprofitNamingAlgorithm)
         .to receive(:create_copy_name)
         .and_raise(UnableToCreateNameCopyError.new)
 

--- a/spec/forms/register_nonprofit_form/stripe_account_form_spec.rb
+++ b/spec/forms/register_nonprofit_form/stripe_account_form_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RegisterNonprofitForm::StripeAccountForm, type: :model do
 
     it "sets error when StripeAccountUtils.create returns a nil" do
       form = described_class.new(nonprofit: create(:nonprofit))
-      allow(StripeAccountUtils).to receive(:create).and_return nil
+      expect(StripeAccountUtils).to receive(:create).and_return nil
       expect(form.save).to be false
 
       expect(form.errors).not_to be_empty

--- a/spec/forms/register_nonprofit_form/stripe_account_form_spec.rb
+++ b/spec/forms/register_nonprofit_form/stripe_account_form_spec.rb
@@ -1,61 +1,54 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 require "rails_helper"
 
-RSpec.describe RegisterNonprofitForm::StripeAccountForm, :type => :model do
-
-  around(:each) do |ex|
+RSpec.describe RegisterNonprofitForm::StripeAccountForm, type: :model do
+  around do |ex|
     StripeMockHelper.mock do
       ex.run
     end
   end
 
-  context 'validation' do
-    it 'accepts a nonprofit' do
+  describe "validation" do
+    it "accepts a nonprofit" do
       form = described_class.new(nonprofit: build(:nonprofit))
       expect(form).to be_valid
     end
 
-    it 'rejects a string' do
+    it "rejects nil" do
       form = described_class.new(nonprofit: nil)
-      expect(form).to_not be_valid
+      expect(form).not_to be_valid
     end
 
-    it 'rejects a string' do
+    it "rejects a string" do
       form = described_class.new(nonprofit: "a string")
-      expect(form).to_not be_valid
+      expect(form).not_to be_valid
     end
   end
 
-
-  describe "#save" do 
+  describe "#save" do
     it "sets error when nonprofit is not persisted" do
       form = described_class.new(nonprofit: build(:nonprofit))
       expect(form.save).to be false
 
-      expect(form.errors).to_not be_empty
+      expect(form.errors).not_to be_empty
     end
 
-    it 'sets error when StripeAccountUtils.create returns a nil' do
-      
-
+    it "sets error when StripeAccountUtils.create returns a nil" do
       form = described_class.new(nonprofit: create(:nonprofit))
-      expect(StripeAccountUtils).to receive(:create).and_return nil
+      allow(StripeAccountUtils).to receive(:create).and_return nil
       expect(form.save).to be false
 
-      expect(form.errors).to_not be_empty
+      expect(form.errors).not_to be_empty
     end
 
-
-    it 'sets when StripeAccountUtils.create returns an id' do
+    it "sets when StripeAccountUtils.create returns an id" do
       nonprofit = create(:nonprofit)
       form = described_class.new(nonprofit: nonprofit)
-      
+
       expect(form.save).to be true
 
       expect(form.errors).to be_empty
-
       expect(nonprofit).to be_persisted
-
       expect(nonprofit.stripe_account_id).to be_present
     end
   end

--- a/spec/forms/register_nonprofit_form_spec.rb
+++ b/spec/forms/register_nonprofit_form_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RegisterNonprofitForm, type: :model do
     form = described_class.new(input)
 
     # we just need one of the catchable errors
-    allow(form.stripe_account_form).to receive(:save!).and_raise(ActiveRecord::RecordNotSaved)
+    expect(form.stripe_account_form).to receive(:save!).and_raise(ActiveRecord::RecordNotSaved)
 
     form.save
 

--- a/spec/forms/register_nonprofit_form_spec.rb
+++ b/spec/forms/register_nonprofit_form_spec.rb
@@ -1,122 +1,115 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 require "rails_helper"
 
-RSpec.describe RegisterNonprofitForm, :type => :model do
-
+RSpec.describe RegisterNonprofitForm, type: :model do
   around do |e|
     StripeMockHelper.mock do
-      old_bp =Settings.default_bp
-      
+      old_bp = Settings.default_bp
       Settings.default_bp.id = bp.id
-      
       e.run
-     
       Settings.default_bp = old_bp
     end
   end
 
   let(:bp) { force_create(:billing_plan) }
 
-  it 'validates email' do
+  it "validates email" do
     input = {
       nonprofit_attributes: {
-          email: "noemeila",
-          phone: "notphone",
-          website: ""
+        email: "noemeila",
+        phone: "notphone",
+        website: ""
       }
     }
 
-    form = RegisterNonprofitForm.new(input)
+    form = described_class.new(input)
 
-    expect(form.save).to eq false
+    expect(form.save).to be false
 
     expect(form.errors.of_kind?("nonprofit[email]", :invalid)).to be true
-end
+  end
 
-  it 'should reject unmatching passwords ' do
+  it "rejects unmatching passwords" do
     input = {
-        nonprofit_attributes: {},
-        user_attributes: {
-            email: "wmeil@email.com",
-            name: "name",
-            password: 'password',
-            password_confirmation: 'doesn\'t match'
-        }
+      nonprofit_attributes: {},
+      user_attributes: {
+        email: "wmeil@email.com",
+        name: "name",
+        password: "password",
+        password_confirmation: "doesn't match"
+      }
     }
-    form = RegisterNonprofitForm.new(input)
+    form = described_class.new(input)
 
-    expect(form.save).to eq false
-    errors = form.errors.to_hash
+    expect(form.save).to be false
+    form.errors.to_hash
     expect(form.errors.of_kind?("user[password_confirmation]", "doesn't match Password")).to be true
   end
 
-  it 'attempts to make a slug copy and returns the proper errors' do
+  it "attempts to make a slug copy and returns the proper errors" do
     force_create(:nonprofit, slug: "n", state_code_slug: "wi", city_slug: "appleton")
     input = {
-        nonprofit_attributes: {name: "n", state_code: "WI", city: "appleton", zip_code: 54915},
-        user_attributes: {name: "Name", email: "em@em.com", password: "12345678", password_confirmation: "12345678"}
+      nonprofit_attributes: {name: "n", state_code: "WI", city: "appleton", zip_code: 54915},
+      user_attributes: {name: "Name", email: "em@em.com", password: "12345678", password_confirmation: "12345678"}
     }
 
-    expect_any_instance_of(SlugNonprofitNamingAlgorithm).to receive(:create_copy_name).and_raise(UnableToCreateNameCopyError.new)
+    allow_any_instance_of(SlugNonprofitNamingAlgorithm)
+      .to receive(:create_copy_name)
+      .and_raise(UnableToCreateNameCopyError.new)
 
-    form = RegisterNonprofitForm.new(input)
+    form = described_class.new(input)
 
-    expect(form.save).to eq false
+    expect(form.save).to be false
     errors = form.errors.to_hash
-    
+
     expect(errors).to eq "nonprofit[name]": ["has an invalid slug. Contact support for help."]
   end
 
-  it 'errors on attempt to add user with email that already exists' do
-    force_create(:user, email: 'em@em.com')
+  it "errors on attempt to add user with email that already exists" do
+    force_create(:user, email: "em@em.com")
 
     input = {
-        nonprofit_attributes: {name: "n", state_code: "WI", city: "appleton", zip_code: 54915},
-        user_attributes: {name: "Name", email: "em@em.com", password: "12345678", password_confirmation: "12345678"}
+      nonprofit_attributes: {name: "n", state_code: "WI", city: "appleton", zip_code: 54915},
+      user_attributes: {name: "Name", email: "em@em.com", password: "12345678", password_confirmation: "12345678"}
     }
 
-    form = RegisterNonprofitForm.new(input)
+    form = described_class.new(input)
 
-    expect(form.save).to eq false
+    expect(form.save).to be false
 
     errors = form.errors.to_hash
-
 
     expect(errors).to eq "user[email]": ["has already been taken"]
   end
 
-  it 'validate rollback' do
-
-    ActiveJob::Base.queue_adapter = :test 
+  it "validate rollback" do
+    ActiveJob::Base.queue_adapter = :test
     input = {
-      nonprofit_attributes: {name: "n", state_code: "WI", city: "appleton", zip_code: 54915, website: 'www.cs.c'},
+      nonprofit_attributes: {name: "n", state_code: "WI", city: "appleton", zip_code: 54915, website: "www.cs.c"},
       user_attributes: {name: "Name", email: "em@em.com", password: "12345678", password_confirmation: "12345678"}
     }
 
+    form = described_class.new(input)
 
-    form = RegisterNonprofitForm.new(input)
-
-    expect(form.stripe_account_form).to receive(:save!).and_raise(ActiveRecord::RecordNotSaved) # we just need one of the catchable errors
+    # we just need one of the catchable errors
+    allow(form.stripe_account_form).to receive(:save!).and_raise(ActiveRecord::RecordNotSaved)
 
     form.save
 
-    expect(form.nonprofit).to_not be_persisted
-    expect(form.user).to_not be_persisted
-    
+    expect(form.nonprofit).not_to be_persisted
+    expect(form.user).not_to be_persisted
   end
 
   it "succeeds" do
-
-    ActiveJob::Base.queue_adapter = :test 
-    create(:nonprofit_base, name:"not-something", slug: "n", state_code_slug: "wi", city_slug: "appleton")
+    ActiveJob::Base.queue_adapter = :test
+    create(:nonprofit_base, name: "not-something", slug: "n", state_code_slug: "wi", city_slug: "appleton")
 
     input = {
-        nonprofit_attributes: {name: "n", state_code: "WI", city: "appleton", zip_code: 54915, website: 'www.cs.c'},
-        user_attributes: {name: "Name", email: "em@em.com", password: "12345678", password_confirmation: "12345678"}
+      nonprofit_attributes: {name: "n", state_code: "WI", city: "appleton", zip_code: 54915, website: "www.cs.c"},
+      user_attributes: {name: "Name", email: "em@em.com", password: "12345678", password_confirmation: "12345678"}
     }
 
-
-    form = RegisterNonprofitForm.new(input)
+    form = described_class.new(input)
 
     result = form.save
     expect(result).to be true
@@ -125,14 +118,14 @@ end
 
     our_np = form.nonprofit
     expected_np = {
-        name: "n",
-        state_code: "WI",
-        city: "appleton",
-        zip_code: "54915",
-        state_code_slug: "wi",
-        city_slug: "appleton",
-        slug: "n-00",
-        website: 'http://www.cs.c'
+      name: "n",
+      state_code: "WI",
+      city: "appleton",
+      zip_code: "54915",
+      state_code_slug: "wi",
+      city_slug: "appleton",
+      slug: "n-00",
+      website: "http://www.cs.c"
     }.with_indifferent_access
 
     expected_np = our_np.attributes.with_indifferent_access.merge(expected_np)
@@ -140,7 +133,7 @@ end
 
     expect(our_np.billing_subscription.billing_plan).to eq bp
 
-    expect(our_np.stripe_account_id).to_not be_nil
+    expect(our_np.stripe_account_id).not_to be_nil
 
     expect(form.id).to eq our_np.id
 


### PR DESCRIPTION
I ran standrdrb on the new form classes and specs in an attempt to preemptively standardize them. 

As it was, the extra whitespace and linting things were distracting and making it hard to review the substance of the PR.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
