### PR TITLE
Remove heroku-deflater

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -146,7 +146,6 @@ end
 
 
 group :production, :staging do
-  gem 'heroku-deflater'
   gem "hiredis", "~> 0.6.0"
   gem "redis", ">= 3.2.0"
   gem 'redis-actionpack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,7 +263,6 @@ GEM
       actionpack (>= 4.1)
       activesupport (>= 4.1)
     hashie (4.0.0)
-    heroku-deflater (0.7.0)
     hiredis (0.6.3)
     htmlentities (4.3.4)
     http-accept (1.7.0)
@@ -559,7 +558,6 @@ DEPENDENCIES
   hamster
   has_scope
   hashie
-  heroku-deflater
   hiredis (~> 0.6.0)
   httparty
   i18n-js (~> 3.8)


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

According to https://github.com/romanbsd/heroku-deflater/issues/54, heroku-deflater isn't needed on Rails 6.1 and is causing 500 errors. That's fixes that.