### PR TITLE
Add `bin/dev`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,4 +81,4 @@ ARG RAILS_ROOT=/app/
 WORKDIR $RAILS_ROOT
 RUN touch /home/app/.netrc
 RUN mkdir -p tmp/pids
-CMD bundle check || (bundle update --bundler && bundle install -j4 --retry 3) && foreman start
+CMD bundle check || (bundle update --bundler && bundle install -j4 --retry 3) && bin/dev start

--- a/Gemfile
+++ b/Gemfile
@@ -136,10 +136,6 @@ gem 'lograge'
 gem 'config', '~> 2.0'
 gem 'dry-validation' # used only for config validation
 
-gem 'foreman'
-
-
-
 group :production do
   gem 'rails_autoscale_agent', '>= 0.9.1'
   gem 'tunemygc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,6 @@ GEM
     faker (2.2.1)
       i18n (>= 0.8)
     ffi (1.11.3)
-    foreman (0.87.2)
     geocoder (1.2.11)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -516,7 +515,6 @@ DEPENDENCIES
   factory_bot
   factory_bot_rails
   faker
-  foreman
   fx!
   geocoder
   globalid (>= 1.0.1)

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ bin/setup
 
 When you run foreman in dev, you start up the server, the job runner and webpack.
 ```sh
-foreman start
+bin/dev
 ```
 
 If you get `ActiveRecord::NoDatabaseError` errors, run `bin/rails db:create:all` to make sure all the databases are built.

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if gem list --no-installed --exact --silent foreman; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev --env /dev/null "$@"


### PR DESCRIPTION
The latest versions of Rails use `bin/dev` to get your dev environment started. Additionally, for projects that use foreman, [the recommendation](https://github.com/rails/jsbundling-rails/blob/7d5afa913bfe1c3d8f4f630ff604660d425ac830/lib/install/dev) is to not keep foreman in the Gemfile, have it installed first time you start `bin/dev` and run foreman there. That's what this does.

- **Add `bin/dev`**
- **Update instructions for starting foreman**
- **Remove foreman from the Gemfile**
- **Update Dockerfile to use `bin/dev`**
