### PR TITLE
Remove Ubuntu 20.04 testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
-          os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+          os: [ubuntu-22.04, ubuntu-24.04]
           node: [16]
           ruby: ['3.0.7']
           postgres: ['16']

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
-          os: [ubuntu-20.04]
+          os: [ubuntu-22.04]
           node: [16]
           ruby: ['3.0.7']
           postgres: ['16']


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

It turns out that our friends at Github have [removed the Ubuntu 20.04 runner today](https://github.com/actions/runner-images/issues/11101). This removes the Ubuntu 20.04 runner from our test suite.
