### PR TITLE
Fix for displaying `devise_error_messages!`

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,9 +1,9 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 module DeviseHelper
+  # print out all of the first devise error message
   def devise_error_messages!
-    if resource && !resource.errors.empty?
-      resource.errors.first.first.to_s + ' ' + 
-        resource.errors.first.second
+    if resource&.invalid?
+      resource.errors.first.full_message
     end
   end
 end

--- a/spec/helpers/devise_helper_spec.rb
+++ b/spec/helpers/devise_helper_spec.rb
@@ -1,0 +1,21 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+
+RSpec.describe DeviseHelper, type: :helper do
+  describe "#devise_error_messages!" do
+    let(:valid_user) { build(:user_base)}
+    let(:invalid_user) { build(:user_base, email: "invaliduser", password: "not the same as", password_confirmation: "confirmation")}
+    
+    it "returns nil when no error" do
+      assign(:resource, valid_user)
+      valid_user.save
+      expect(helper.devise_error_messages!).to eq nil
+    end
+
+    it "returns something when errored" do
+      assign(:resource, invalid_user)
+      invalid_user.save
+      expect(helper.devise_error_messages!).to eq "Email is invalid"
+    end
+  end
+end


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

There was an error in Airbrake that came up here that I noticed. The `devise_error_messages!` code was treating the individual items in `User#errors` as `Hash`es. This was the case in the past but now they are proper `ActiveModel::Error` objects. Using `#full_message` is the way to get the message from an `ActiveModel::Error`.

I've made a fix there, added some docs and a spec and simplified the call figuring out if there are any errors to display.

NOTE: this only displays a single error for some reason. I don't know why but I figured I didn't want to change the behavior until I understood fully why.
