### PR TITLE
Move `filter_parameter` setting to one place

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,9 +41,6 @@ module Commitchange
 		# Configure the default encoding used in templates for Ruby 1.9.
 		config.encoding = "utf-8"
 
-		# Configure sensitive parameters which will be filtered from the log file.
-		config.filter_parameters += [:password]
-
 		# Enable escaping HTML in JSON.
 		config.active_support.escape_html_entities_in_json = true
 


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We already handle filter_parameter setting in [`config/initializers/filter_parameter_logging.rb`](https://github.com/CommitChange/houdini/blob/b4e03f454416fd0ee48d904f9ff5582a186f1be8/config/initializers/filter_parameter_logging.rb#L1-L8) so we don't need it in `config/application.rb`
