### PR TITLE
Move redundant `:password` from filter_parameters

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,6 +2,8 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
+
+# NOTE: this filters any parameter whose key includes one of the following as a substring
 Rails.application.config.filter_parameters += [
   :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
 ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,6 +3,5 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 Rails.application.config.filter_parameters += [
-  :password,
   :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
 ]


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

The strings and symbols used in filter parameter logging will filter the values of any parameter with a name that includes one of the given substrings. Therefore, `:passw`, which is already included, would filter out the values of parameters like `password` or `current_password`. This means adding `:password` to the list of values is redundant and can be removed.