### PR TITLE
Remove action caching for :btn

### DIFF
--- a/app/controllers/nonprofits_controller.rb
+++ b/app/controllers/nonprofits_controller.rb
@@ -6,7 +6,6 @@
 	helper_method :current_nonprofit_user?
 	before_action :authenticate_nonprofit_user!, only: [:dashboard, :dashboard_metrics, :dashboard_todos, :payment_history, :profile_todos, :recurring_donation_stats, :update]
   before_action :authenticate_super_admin!, only: [:destroy]
-  caches_action :btn
 
   after_action :allow_framing, only: [:donate, :btn]
   


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

This bug was due to the new x-frame-options default and the btn being action cached for performance. On initial load, the x-frame-options are correct, i.e. the header is removed. On subsequent reloads, after loading from the cache, the x-frame-options  are changed back to the defaults. Those defaults are fine for everything else but not for btn since it must be put in a frame.

This removes action caching for the btn action. It's not going to be as fast to load but we can go back and figure out the action cache problem later.