### PR TITLE
Add Mac runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,12 +62,12 @@ jobs:
                 - 'Gemfile.lock'
 
         - name: Setup PostgreSQL with PostgreSQL extensions and unprivileged user
-          uses: Daniel-Marynicz/postgresql-action@1.0.0
+          uses: ikalnytskyi/action-setup-postgres@v7
           with:
-            postgres_image_tag: ${{ matrix.postgres }}-alpine
-            postgres_user: admin
-            postgres_password: password
-            postgres_db: commitchange_test
+            postgres-version: ${{ matrix.postgres }}
+            username: admin
+            password: password
+            database: commitchange_test
         - uses: actions/setup-node@v4
           with:
             node-version: ${{ matrix.node }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
-          os: [ubuntu-22.04, ubuntu-24.04, macos-latest]
+          os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-latest] # macos-13 is the last Intel mac version
           node: [16]
           ruby: ['3.1.7']
           postgres: ['16']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
                 - 'Gemfile'
                 - 'Gemfile.lock'
                 - 'Rakefile'
+                # include workflows because changes to workflows could break a build
+                - '.github/workflows'
               js:
                 - '**/*.js*'
                 - '**/*.es6'
@@ -60,6 +62,8 @@ jobs:
                 # include Gemfiles because some of the Gems could break yarn build
                 - 'Gemfile' 
                 - 'Gemfile.lock'
+                # include workflows because changes to workflows could break a build
+                - '.github/workflows'
 
         - name: Setup PostgreSQL with PostgreSQL extensions and unprivileged user
           uses: ikalnytskyi/action-setup-postgres@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
                 - 'Gemfile.lock'
                 - 'Rakefile'
                 # include workflows because changes to workflows could break a build
-                - '.github/workflows'
+                - '.github/workflows/**'
               js:
                 - '**/*.js*'
                 - '**/*.es6'
@@ -63,7 +63,7 @@ jobs:
                 - 'Gemfile' 
                 - 'Gemfile.lock'
                 # include workflows because changes to workflows could break a build
-                - '.github/workflows'
+                - '.github/workflows/**'
 
         - name: Setup PostgreSQL with PostgreSQL extensions and unprivileged user
           uses: ikalnytskyi/action-setup-postgres@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
-          os: [ubuntu-22.04, ubuntu-24.04]
+          os: [ubuntu-22.04, ubuntu-24.04, macos-latest]
           node: [16]
           ruby: ['3.1.7']
           postgres: ['16']


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We've had some issues getting CC working on some macos versions. Let's test for it!

MacOS-13 runners are used because they're the last Intel Mac runners; since we have some intel macs, we should test on that.
