### PR TITLE
Trigger ruby and JS builds when workflow files have changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,12 +62,12 @@ jobs:
                 - 'Gemfile.lock'
 
         - name: Setup PostgreSQL with PostgreSQL extensions and unprivileged user
-          uses: Daniel-Marynicz/postgresql-action@1.0.0
+          uses: ikalnytskyi/action-setup-postgres@v7
           with:
-            postgres_image_tag: ${{ matrix.postgres }}-alpine
-            postgres_user: admin
-            postgres_password: password
-            postgres_db: commitchange_test
+            postgres-version: ${{ matrix.postgres }}
+            username: admin
+            password: password
+            database: commitchange_test
         - uses: actions/setup-node@v4
           with:
             node-version: ${{ matrix.node }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
                 - 'Gemfile'
                 - 'Gemfile.lock'
                 - 'Rakefile'
+                # include workflows because changes to workflows could break a build
+                - '.github/workflows/**'
               js:
                 - '**/*.js*'
                 - '**/*.es6'
@@ -60,6 +62,8 @@ jobs:
                 # include Gemfiles because some of the Gems could break yarn build
                 - 'Gemfile' 
                 - 'Gemfile.lock'
+                # include workflows because changes to workflows could break a build
+                - '.github/workflows/**'
 
         - name: Setup PostgreSQL with PostgreSQL extensions and unprivileged user
           uses: Daniel-Marynicz/postgresql-action@1.0.0


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

In order to speed up builds, we only run the rspec specs when ruby files change and only run the javascript build and tests when javascript related files change. One situation we hadn't considered was what to do when workflow files themselves change. When that happened, we weren't running any of those tests. That's a problem because changing workflow files inherently could break the builds so we should be running all of the builds and tests when that happens.

This PR runs both types of conditional workflow steps when workflow files themselves have changed.
