### PR TITLE
Switch to using the ikalnytskyi/action-setup-postgres github action for setting up PG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,12 +62,12 @@ jobs:
                 - 'Gemfile.lock'
 
         - name: Setup PostgreSQL with PostgreSQL extensions and unprivileged user
-          uses: Daniel-Marynicz/postgresql-action@1.0.0
+          uses: ikalnytskyi/action-setup-postgres@v7
           with:
-            postgres_image_tag: ${{ matrix.postgres }}-alpine
-            postgres_user: admin
-            postgres_password: password
-            postgres_db: commitchange_test
+            postgres-version: ${{ matrix.postgres }}
+            username: admin
+            password: password
+            database: commitchange_test
         - uses: actions/setup-node@v4
           with:
             node-version: ${{ matrix.node }}


### PR DESCRIPTION
While trying to get #1125 working, I found out that the github action we were using for setting up Postgres on the runner only works on Linux. The new action I'm using works on all supported Github runner operating systems.