### PR TITLE
Remove unused `Format::Url.without_prefix` method

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,4 +3,5 @@
 c07a4aa4b61aab90a4e3927fd83574158907be27
 # cleanup route file
 77891f15aaff2826a65338edf0448625f3982295
-
+# Flatten multi-level style of module composition
+1fed30132333efa675f0c7d800691a225e9c26f8

--- a/app/controllers/campaigns/campaign_gift_options_controller.rb
+++ b/app/controllers/campaigns/campaign_gift_options_controller.rb
@@ -1,5 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-module Campaigns; class CampaignGiftOptionsController < ApplicationController
+class Campaigns::CampaignGiftOptionsController < ApplicationController
 	include Controllers::CampaignHelper
 
 	before_action :authenticate_campaign_editor!, only: [:index]
@@ -12,4 +12,4 @@ module Campaigns; class CampaignGiftOptionsController < ApplicationController
 		end
 	end
 
-end; end
+end

--- a/app/legacy_lib/format/address.rb
+++ b/app/legacy_lib/format/address.rb
@@ -1,5 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-module Format; module Address
+module Format::Address
 	
 	def self.full_address(street, city, state, zip=nil)
 		# Albuquerque | NM | Albuquerque NM | 1234 Street Ln, Albuquerque NM
@@ -19,5 +19,5 @@ module Format; module Address
 		[[s.address, s.city, s.state_code].reject(&:blank?).join(", "), s.zip_code].reject(&:blank?).join(" ")
 	end
 
-end; end
+end
 

--- a/app/legacy_lib/format/currency.rb
+++ b/app/legacy_lib/format/currency.rb
@@ -1,5 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-module Format; module Currency
+module Format::Currency
 
 
 	# Converts currency units into subunits.
@@ -18,4 +18,4 @@ module Format; module Currency
 			.gsub(/^(\d+)\.(\d)$/, '\1.\20') # add a second zero if single decimal (eg. "9.9" -> "9.90")
 	end
 
-end; end
+end

--- a/app/legacy_lib/format/date.rb
+++ b/app/legacy_lib/format/date.rb
@@ -1,7 +1,7 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 require 'chronic'
 
-module Format; module Date
+module Format::Date
 
   def self.parse(str)
     Chronic.parse(str)
@@ -55,4 +55,4 @@ module Format; module Date
     Time.new(*str.match(/(\d\d\d\d)-?(\d\d)?-?(\d\d)?/).to_a[1..-1].compact.map(&:to_i))
   end
 
-end; end
+end

--- a/app/legacy_lib/format/geography.rb
+++ b/app/legacy_lib/format/geography.rb
@@ -1,5 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-module Format; module Geography
+module Format::Geography
 
 	StateCodes = [ 'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'PR', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY' ]
 
@@ -302,4 +302,4 @@ Countries = [
 		return StateMappings[str.downcase]
 	end
 
-end; end
+end

--- a/app/legacy_lib/format/phone.rb
+++ b/app/legacy_lib/format/phone.rb
@@ -1,5 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-module Format; module Phone
+module Format::Phone
 	
 	def self.readable(number)
 		# Convert to:
@@ -18,5 +18,5 @@ module Format; module Phone
 		end
 	end
 
-end; end
+end
 

--- a/app/legacy_lib/format/url.rb
+++ b/app/legacy_lib/format/url.rb
@@ -1,10 +1,6 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 module Format; module Url
 
-	def self.without_prefix(url)
-		url.gsub(/(http(s)?:\/\/)|(www\.)|(\?.*$)|(#.*$)/, '')
-	end
-
 	# Given ["What hello", "hi! lol?"]
 	# Return ["what-hello", "hi-lol"]
 	def self.convert_to_slug(*words)

--- a/app/legacy_lib/format/url.rb
+++ b/app/legacy_lib/format/url.rb
@@ -1,5 +1,5 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-module Format; module Url
+module Format::Url
 
 	# Given ["What hello", "hi! lol?"]
 	# Return ["what-hello", "hi-lol"]
@@ -20,4 +20,4 @@ module Format; module Url
 		return urls.join('/').gsub(/([^:])\/\/+/,'\1/')
 	end
 
-end; end
+end


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

It's not used so let's remove it.