### PR TITLE
Remove unused actionpack-action_caching gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,8 +155,6 @@ gem "barnes"
 
 gem 'protected_attributes_continued' # because we upgraded from 3 and then 4
 
-gem 'actionpack-action_caching' # because we use action caching
-
 gem 'rack-cors'
 
 gem 'fx'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionpack-action_caching (1.2.2)
-      actionpack (>= 4.0.0)
     actiontext (7.0.8.7)
       actionpack (= 7.0.8.7)
       activerecord (= 7.0.8.7)
@@ -522,7 +520,6 @@ PLATFORMS
 
 DEPENDENCIES
   action_mailer_matchers (~> 1.2.0)
-  actionpack-action_caching
   airbrake
   aws-sdk-rails
   aws-sdk-s3


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Action caching caused us some issues in the one place we were using it: `NonprofitsController#btn`. We fixed that in #1123 by removing the action caching. Since performance seems acceptable, there doesn't seem to be a need to turn it back on so let's just remove the gem.
