### PR TITLE
Fix the title of the step name in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,8 @@ jobs:
             bundler-cache: true
 
         - run: bin/setup
-        - env:
+        - name: Run yarn build-all-${{ github.event.inputs.mode }}
+          env:
             mode: ${{ github.event.inputs.mode }}
             ORG_NAME: commitchange
           run: yarn build-all-${mode}


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

The yarn build step in this deploy is always shown in the action dashboard as `Run yarn build-all-${mode}`. It bugged me every time I saw it so this should give the correct name now.
