### PR TITLE
Dependabot tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
   
   - package-ecosystem: "bundler"
     directory: "/"
+    ignore:
+      - dependency-name: rails # rails is a whole other thing that we're gonna handle on our own
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     groups:
       development-dependencies-minor:
         dependency-type: development
@@ -31,7 +36,5 @@ updates:
         dependency-type: production
         update-types:
           - major
-        exclude-patterns:
-          - rails # rails is a whole other thing that we're gonna handle on our own
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+      - dependency-name: concurrent-ruby # concurrent-ruby 1.3.5 has a regression that breaks pre-Rails 7.1
+        versions:
+          - ">=1.3.5"
     groups:
       development-dependencies-minor:
         dependency-type: development

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
       - dependency-name: concurrent-ruby # concurrent-ruby 1.3.5 has a regression that breaks pre-Rails 7.1
         versions:
           - ">=1.3.5"
+      - dependency-name: sprockets # Sprockets 4.0 stops allowing us to add a proc to the config.assets.precompile array, which we currently use
+        versions:
+          - ">=4"
     groups:
       development-dependencies-minor:
         dependency-type: development


### PR DESCRIPTION
A few tweaks to how dependabot works for this project:

First, Rails minor and major version updates have to go through the standard rails update process instead of a simple Rails gemfile update. This tells Dependabot to not suggest those updates

Secondly, concurrent-ruby 1.3.5 has a regression that breaks Rails before version 7.1. This tells dependabot to not suggest any updates to concurrent-ruby 1.3.5 or later.

Lastly, stop updating to Sprockets 4.0. We currently use a feature that was removed in Sprockets 4 so let's not have Dependabot suggest updating.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
