### PR TITLE
Add darwin platforms to Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.1)
+    ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     fx (0.9.0)
@@ -332,6 +333,8 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-darwin)
       racc (~> 1.4)
@@ -527,6 +530,7 @@ GEM
     zeitwerk (2.6.18)
 
 PLATFORMS
+  arm64-darwin
   ruby
   x86_64-darwin
   x86_64-linux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,8 @@ GEM
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
     ffi (1.17.1)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     fx (0.9.0)
       activerecord (>= 7.0)
       railties (>= 7.0)
@@ -330,6 +332,8 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -524,6 +528,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
- **Add x86_64-darwin platform**
- **Add arm64-darwin platform to bundle**

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

When working on multiple platforms, Bundler [recommends](https://bundler.io/man/bundle-lock.1.html#SUPPORTING-OTHER-PLATFORMS) explicitly including the other platforms in your Gemfile.lock. This PR does that.
