### PR TITLE
Update Rack::Timeout

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -374,7 +374,7 @@ GEM
       rack (< 3)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rack-timeout (0.4.2)
+    rack-timeout (0.7.0)
     rails (7.0.8.7)
       actioncable (= 7.0.8.7)
       actionmailbox (= 7.0.8.7)

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,7 +1,7 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
-timeout = Integer(ENV['WEB_TIMEOUT'] || 15)
-if ENV['RAILS_ENV'] == 'development' || ENV['IDE_PROCESS_DISPATCHER']
-  timeout = 10000
-end
 
-Rack::Timeout.timeout = timeout  # seconds
+# set the Rack timeout to 2 hours when running in development so we can use breakpoints
+# For staging and prod, you should set the RACK_TIMEOUT_SERVICE_TIMEOUT environment variable
+if Rails.env.development? || ENV["IDE_PROCESS_DISPATCHER"]
+  ENV["RACK_TIMEOUT_SERVICE_TIMEOUT"] = 2.hours.to_s
+end


### PR DESCRIPTION
- **Update rack-timeout gem to 0.7.0**
- **Update setting the Rack timeout deadline for 0.7.0**

The update to rack-timeout 0.7.0 is breaking https://github.com/CommitChange/houdini/pull/1156 because it changed its API. This changes the initializer so it continues to act the same as before but defers to the new environment variables used by rack-timeout.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
