### PR TITLE
Remove straggling expire_action

### DIFF
--- a/app/controllers/nonprofits_controller.rb
+++ b/app/controllers/nonprofits_controller.rb
@@ -57,7 +57,6 @@ class NonprofitsController < ApplicationController
   def update
     flash[:notice] = "Update successful!"
     current_nonprofit.update_attributes params[:nonprofit].except(:verification_status)
-    expire_action action: :btn
     current_nonprofit.clear_cache
     json_saved current_nonprofit
   end


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

expire_action was used by the ActionPack Action Caching gem which we removed in #1123. Since it's been removed, we shouldn't have this here; it's causing a crash now.
