### PR TITLE
Remove the sendfile-header that we get a warning about from Heroku

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
 
   # Specifies the header that your server uses for sending files
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
-  config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for nginx
+  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for nginx
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local


### PR DESCRIPTION
When publishing the last deploy, Heroku gave me the following warning:


> remote: 
> remote:        You set `config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'` in production,
> remote:        but you do not have `nginx` installed on this app. This setting will cause any assets
> remote:        being served by your application to be returned without a body.
> remote:        
> remote:        To fix this issue, please set:
> remote:        
> remote:        config.action_dispatch.x_sendfile_header = nil
> remote: 

I haven't seen a problem but it probably would be wise to fix this and make the scary warning go away.


**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
