### PR TITLE
Remove rack-freeze

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,9 +37,6 @@ gem "yaaf" # form objects
 # for blocking ip addressses
 gem "rack-attack"
 
-# to find middleware thread safety bugs
-gem "rack-freeze"
-
 # Database (postgres)
 gem "pg", "~> 1.5.9"
 gem "qx", path: "gems/ruby-qx"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,6 @@ GEM
       rack (>= 1.0, < 3)
     rack-cors (1.0.6)
       rack (>= 1.6.0)
-    rack-freeze (1.0.0)
     rack-session (1.0.2)
       rack (< 3)
     rack-test (2.2.0)
@@ -644,7 +643,6 @@ DEPENDENCIES
   rack (~> 2.2.14)
   rack-attack
   rack-cors
-  rack-freeze
   rack-timeout
   rails (~> 7.0.8.7)
   rails-i18n


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

After looking into the bug in #1174, I tracked down the issue to [rack-freeze](https://github.com/ioquatix/rack-freeze). The goal of rack-freeze is to raise an error when a rack middleware tries to modify internal state; since there's multi-threading going on you can get hard to debug race conditions. Instead of allowing those modifications to happen, rack-freeze simply raises an exception to prevent it.

The problem seems to be due to a change in how rack-freeze works in its latest version: rack-freeze freezes the middleware stack at a different point than previously. The new version is more complete but it has a problem: Rails intentionally creates a new middleware stack on each request. This is causing rack-freeze to raise an error on every request. We don't have to worry much about Rails itself having multi-threading issues here; it has synchronization primitives to prevent a race condition; they're just not the same as the newest rack-freeze expects.

Additionally, rack-freeze is abandoned. It's last release was in 2020 and the README says it's not required anymore because Rack 2.1+ has the ability to freeze the middleware stack. Unfortunately, I think the mechanism for the freezing built-in into Rack is the same as rack-freeze; it would also lead to the same error.

I think all of this means: we should just remove rack-freeze. There's probably a cool way to work around this in Rails and freeze middleware at the exact point we want to, I couldn't find it and it seems like too much work for something that is a nice protection but not vital.

We'll just have to be slightly more careful to make sure the middleware we use doesn't have race conditions.
