### PR TITLE
Add initial standard code scanning workflow

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -1,6 +1,6 @@
 # License: LGPL-3.0-or-later
 # based on the Rubocop code scanning template from GithubS
-name: "Run Standard"
+name: "Run Standardrb"
 
 on:
   push:
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: bundle install
 
-    - name: Rubocop run
+    - name: Standardrb run
       run: |
         bash -c "
           bin/standardrb --require code_scanning --format CodeScanning::SarifFormatter -o standard.sarif

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -1,0 +1,44 @@
+# License: LGPL-3.0-or-later
+# based on the Rubocop code scanning template from GithubS
+name: "Run Standard"
+
+on:
+  push:
+    branches: [ "supporter_level_goal" ]
+  pull_request:
+  schedule:
+    - cron: '19 23 * * 1'
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+    # This step is not necessary if you add the gem to your Gemfile
+    - name: Install Code Scanning integration
+      run: bundle add code-scanning-rubocop --version 0.6.1 --skip-install
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Rubocop run
+      run: |
+        bash -c "
+          bin/standardrb --require code_scanning --format CodeScanning::SarifFormatter -o standard.sarif
+          [[ $? -ne 2 ]]
+        "
+
+    - name: Upload Sarif output
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: standard.sarif


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

This will run standardrb as part of the build and integrates it with the code-scanning tools in Github. Is it better than just running standardrb itself? Eh, it's different.
