### PR TITLE
Add csv to Gemfile as recommended by deprecation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ gem "i18n-js", "~> 3.8" # i18n-js 4 is very different and doesn't work without s
 gem "countries"
 
 gem "rexml" # needed on Ruby 3
+gem "csv" # needed on Ruby 3.4
 
 group :development, :ci, :test do
   gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
     crass (1.0.6)
     css_parser (1.21.1)
       addressable
+    csv (3.3.4)
     dalli (3.2.3)
     dante (0.2.0)
     database_cleaner (2.1.0)
@@ -603,6 +604,7 @@ DEPENDENCIES
   config (~> 2.0)
   connection_pool
   countries
+  csv
   dalli
   database_cleaner
   delayed_job_active_record


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Ruby 3.3 provides a deprecation that let's us know that the included csv library will be moved to separate Gem in 3.4. The best way to prepare is to add it to our Gemfile. So I did.
