### PR TITLE
Remove unused rest-client gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,8 +72,6 @@ gem "airbrake"
 # http://www.rubygeocoder.com/
 gem "geocoder" # for adding latitude and longitude to location-based tables
 
-gem "rest-client" # recommended for fullcontact
-
 # https://github.com/fphilipe/premailer-rails
 # for stylizing emails
 gem "premailer-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,8 +178,6 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (3.1.8)
     dotenv-rails (3.1.8)
       dotenv (= 3.1.8)
@@ -246,9 +244,6 @@ GEM
     hashie (4.0.0)
     hiredis (0.6.3)
     htmlentities (4.3.4)
-    http-accept (1.7.0)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -308,9 +303,6 @@ GEM
       net-smtp
     marcel (1.0.4)
     method_source (1.1.0)
-    mime-types (3.4.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0408)
     mini_magick (5.2.0)
       benchmark
       logger
@@ -331,7 +323,6 @@ GEM
       timeout
     net-smtp (0.5.1)
       net-protocol
-    netrc (0.11.0)
     nio4r (2.7.0)
     nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
@@ -437,11 +428,6 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.4.1)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
@@ -557,9 +543,6 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (4.2.1)
       execjs (>= 0.3.0, < 3)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.7)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -649,7 +632,6 @@ DEPENDENCIES
   recaptcha (~> 5.8.1)
   redis (>= 3.2.0)
   redis-actionpack
-  rest-client
   rexml
   rspec (~> 3)
   rspec-json_expectations


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

The rest-client gem was used by the Fullcontact integration. The integration no longer exists so it shouldn't either.