### PR TITLE
Remove unused config for spring

### DIFF
--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,6 +1,0 @@
-%w[
-  .ruby-version
-  .rbenv-vars
-  tmp/restart.txt
-  tmp/caching-dev.txt
-].each { |path| Spring.watch(path) }


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Previously, I removed spring (I can't find the specific PR). Apparently the config was accidentally left even though it wasn't being used. This deletes it.
