### PR TITLE
Remove unused references to browserify_rails

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -68,8 +68,6 @@ module Commitchange
 
     # Add trailing slashes to all routes
     # config.action_controller.default_url_options = {:trailing_slash => true}
-    #
-    # config.browserify_rails.commandline_options = "-t [ babelify --presets es2015 ]"
 
     # Require `belongs_to` associations by default. Previous versions had false.
     # it's a bunch of work to verify everything that should be marked optional actually is.

--- a/config/environments/ci.rb
+++ b/config/environments/ci.rb
@@ -40,8 +40,6 @@ Rails.application.configure do
   config.log_level = :debug
 
   config.dependency_loading = true if $rails_rake_task
-  # Turn this on if you want to mess with code inside /node_modules
-  # config.browserify_rails.evaluate_node_modules = true
 
   config.middleware.use I18n::JS::Middleware
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -111,8 +111,6 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.dependency_loading = true if $rails_rake_task
-  # Turn this on if you want to mess with code inside /node_modules
-  # config.browserify_rails.evaluate_node_modules = true
 
   config.middleware.use I18n::JS::Middleware
 


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We don't use browserify_rails. I don't remember if we ever did when I've worked on the application. Let's remove the comments related to it.
