### PR TITLE
Fix bug when `InsertSupporter.with_tags_and_supporters` is passed an `ActionController::Parameters`

### DIFF
--- a/app/legacy_lib/insert_supporter.rb
+++ b/app/legacy_lib/insert_supporter.rb
@@ -42,6 +42,7 @@ module InsertSupporter
   # The above will create a supporter with name/email, one tag with name 'xy',
   # and one field with name 'xy' and value 420
   def self.with_tags_and_fields(np_id, data)
+    data = data.to_deprecated_h
     tags = data.select { |key, val| key.match(/^tag_/) }.map { |key, val| key.gsub("tag_", "") }
     fields = data.select { |key, val| key.match(/^field_/) }.map { |key, val| [key.gsub("field_", ""), val] }
     supp_cols = data.select { |key, val| !key.match(/^field_/) && !key.match(/^tag_/) }


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

If `InsertSupporter.with_tags_and_supporters` is passed an `ActionController::Parameters`, it will crash. This is due to the change in Rails 5.1 where `ActionController::Parameters` no longer inherited from `Hash`. This fixes that bug.
