### PR TITLE
Ability to hide main_image from nonprofit profile page

### DIFF
--- a/app/assets/stylesheets/common/utils.scss
+++ b/app/assets/stylesheets/common/utils.scss
@@ -55,7 +55,7 @@
   background-size: cover;
   background-position: center;
 }
- 
+
 .u-overflow--hidden {
   overflow: hidden !important;
 }
@@ -411,6 +411,21 @@
     padding-top:1px;
   }
 }
+
+.u-flex {
+  display: flex;
+}
+.u-justify-center {
+  justify-content: center;
+  align-items: center;
+}
+
+.u-gap-1 { gap: 0.5rem; }
+.u-gap-2 { gap: 1rem; }
+.u-gap-3 { gap: 2rem; }
+.u-gap-4 { gap: 3rem; }
+.u-gap-5 { gap: 4rem; }
+.u-grow { flex: 1 };
 
 @media screen and (max-width: 600px) {
   .u-hideIf--600 {display: none;}

--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -42,6 +42,7 @@ class Nonprofit < ApplicationRecord
     :brand_font, # string (lowercase key eg. 'helvetica')
     :brand_color, # string (hex color value)
     :hide_activity_feed, # bool
+    :hide_main_image, # bool
     :tracking_script,
     :facebook, # string (url)
     :twitter, # string (url)

--- a/app/views/components/_todos.html.erb
+++ b/app/views/components/_todos.html.erb
@@ -5,7 +5,7 @@
 			<!--= if (not todos.loading) (add_class 'show') -->
 
 		<p class='strong'>
-			Your <%= title %> is 
+			Your <%= title %> is
 			<!--= put todos.percent_done -->% complete.
 		</p>
 

--- a/app/views/components/_upload_background_image.html.erb
+++ b/app/views/components/_upload_background_image.html.erb
@@ -13,8 +13,7 @@
         </div>
         <p class='u-color--red'>
           <!--= show_if (length image_upload.error) -->
-          <small>
-            <!--= put image_upload.error --></small>
+          <small><!--= put image_upload.error --></small>
         </p>
         <div class='u-width--250 u-margin--auto'>
           <button type='submit' class='button--small u-width--full u-marginTop--20' data-loading='Uploading...'>

--- a/app/views/nonprofits/_overview_media.html.erb
+++ b/app/views/nonprofits/_overview_media.html.erb
@@ -1,10 +1,12 @@
 <%- # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later -%>
 <!-- partial start: nonprofits/_overview_media -->
-<% if @nonprofit.main_image.file %>
+<% if @nonprofit.main_image.file && !@nonprofit.hide_main_image %>
 <div class='overview-media'>
-  <div style='overflow: hidden; height: initial;'>
-    <%= image_tag @nonprofit.main_image_url(:nonprofit_carousel).to_s %>
-  </div>
+    <div>
+			<div style='overflow: hidden; height: initial;'>
+        <%= image_tag @nonprofit.main_image_url(:nonprofit_carousel).to_s %>
+			</div>
+		</div>
 </div>
 <% end %>
 <!-- partial end: nonprofits/_overview_media -->

--- a/app/views/nonprofits/_settings_modals.html.erb
+++ b/app/views/nonprofits/_settings_modals.html.erb
@@ -28,7 +28,23 @@
 					<input type='file' name='nonprofit[main_image]'>
 				</div>
 			</div>
-      <hr>
+
+      <hr />
+
+      <div class='u-flex u-gap-1 u-justify-center'>
+        <div class="u-paddingY--10">
+          <input type="hidden" name="nonprofit[hide_main_image]" value="false">
+          <input id="hide_main_image" class="u-block" type="checkbox" name="nonprofit[hide_main_image]"
+                 <%= @nonprofit.hide_main_image? ? 'checked=checked' : '' %>>
+        </div>
+        <label for="hide_main_image">
+          Hide this image on the main profile page?
+        </label>
+      </div>
+      <p class="u-small"><strong>Note:</strong> It is a good practice to set a Main Image because it is also used in social sharing and other places.</p>
+
+      <hr />
+
 			<button type='submit' class='button u-marginTop--10 ' data-loading='Uploading...'>Upload</button>
 		</form>
 	</div>

--- a/app/views/nonprofits/show.html.erb
+++ b/app/views/nonprofits/show.html.erb
@@ -89,6 +89,7 @@
 	<section class='box-r'>
 		<!--= add_class_if (eq todos.percent_done 100) 'u-padding--0' -->
 		<%= render 'components/todos', title: 'profile' if current_nonprofit_user? %>
+
 		<div class='hideWhenCollapsed'>
 			<%= render 'actions' %>
 		</div>

--- a/db/migrate/20250612221922_add_hide_main_image_to_nonprofit.rb
+++ b/db/migrate/20250612221922_add_hide_main_image_to_nonprofit.rb
@@ -1,0 +1,5 @@
+class AddHideMainImageToNonprofit < ActiveRecord::Migration[7.1]
+  def change
+    add_column :nonprofits, :hide_main_image, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_29_192209) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_12_221922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -727,6 +727,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_29_192209) do
     t.string "houid"
     t.jsonb "achievements"
     t.jsonb "categories"
+    t.boolean "hide_main_image", default: false, null: false
   end
 
   create_table "object_events", id: :serial, force: :cascade do |t|

--- a/spec/models/nonprofit_spec.rb
+++ b/spec/models/nonprofit_spec.rb
@@ -5,25 +5,18 @@ RSpec.describe Nonprofit, type: :model do
   it_behaves_like "an houidable entity", :np
 
   it { is_expected.to validate_presence_of(:name) }
-
   it { is_expected.to validate_presence_of(:city) }
   it { is_expected.to validate_presence_of(:state_code) }
-
   it { is_expected.to validate_presence_of(:slug) }
 
   it { expect(create(:nonprofit)).to validate_uniqueness_of(:slug).scoped_to(:city_slug, :state_code_slug) }
 
   it { is_expected.to have_one(:billing_plan).through(:billing_subscription) }
-
   it { is_expected.to have_many(:supporter_cards).class_name("Card").through(:supporters).source(:cards) }
-
   it { is_expected.to have_many(:disputes).through(:charges) }
-
   it { is_expected.to have_many(:email_lists) }
   it { is_expected.to have_one(:nonprofit_key) }
-
   it { is_expected.to have_many(:email_customizations) }
-
   it { is_expected.to have_many(:associated_object_events).class_name("ObjectEvent") }
 
   describe "with cards" do


### PR DESCRIPTION
Adds boolean "hide_main_image" to nonprofit table. If the user selects this checkbox, we hide the main image on the profile page.

### Showing the checkbox placement and hint text
![2025-06-12 at 6 33 PM](https://github.com/user-attachments/assets/3211b619-609b-42fb-948a-05029f5e5588)

### Selecting the checkbox and submitting ... 
![2025-06-12 at 6 34 PM](https://github.com/user-attachments/assets/df256c78-9e4c-462b-ac00-cafa74583b56)
