### PR TITLE
Update recaptcha gem to 5.19.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,7 +137,7 @@ group :production, :staging do
   gem "redis-actionpack"
 end
 
-gem "recaptcha", "~> 5.8.1"
+gem "recaptcha", "~> 5.19"
 
 gem "hashie"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,8 +450,7 @@ GEM
     rdoc (6.14.0)
       erb
       psych (>= 4.0.0)
-    recaptcha (5.8.1)
-      json
+    recaptcha (5.19.0)
     redis (4.2.5)
     redis-actionpack (5.5.0)
       actionpack (>= 5)
@@ -673,7 +672,7 @@ DEPENDENCIES
   rails-autoscale-web
   rails-i18n
   rake
-  recaptcha (~> 5.8.1)
+  recaptcha (~> 5.19)
   redis (>= 3.2.0)
   redis-actionpack
   rexml


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Google Enterprise Recaptcha has deprecating their `v1beta1` version now that `v1` is out. Fortunately, the updated recaptcha gem handles that seemlessly.

I've tested this locally but, since it involves transactions, we should test on staging before deploying to prod.
