### PR TITLE
Add option to turn off geocode in `:event` factory

### DIFF
--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,6 +1,9 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 FactoryBot.define do
   factory :event do
+    transient do
+      perform_geocode { false }
+    end
     name { "The event of Wonders" }
     start_datetime { DateTime.new(2025, 5, 11, 4, 5, 6) }
     end_datetime { DateTime.new(2025, 5, 11, 5, 1, 7) }
@@ -10,6 +13,10 @@ FactoryBot.define do
     slug { "event-of-wonders" }
     nonprofit
     profile
+
+    before(:create) do |event, context|
+      allow(event).to receive(:geocode).and_return(nil) unless context.perform_geocode
+    end
   end
 
   factory :event_base, class: "Event" do


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

This sets the `:event` factory to skip geocoding unless intentionally overridden, just like `:event_base` does. Based upon the issues with #1229
