### PR TITLE
Add setting to require 2fa for nonprofit

### DIFF
--- a/app/controllers/nonprofits_controller.rb
+++ b/app/controllers/nonprofits_controller.rb
@@ -55,10 +55,18 @@ class NonprofitsController < ApplicationController
   end
 
   def update
-    flash[:notice] = "Update successful!"
-    current_nonprofit.update_attributes params[:nonprofit].except(:verification_status)
-    current_nonprofit.clear_cache
-    json_saved current_nonprofit
+    @form = NonprofitSettingsForm.new(
+      nonprofit: current_nonprofit,
+      attributes: params[:nonprofit].except(:verification_status)
+    )
+
+    if @form.save
+      flash[:notice] = "Update successful!"
+      current_nonprofit.clear_cache
+      json_saved current_nonprofit
+    else
+      json_saved current_nonprofit, 500
+    end
   end
 
   def destroy

--- a/app/controllers/nonprofits_controller.rb
+++ b/app/controllers/nonprofits_controller.rb
@@ -55,6 +55,8 @@ class NonprofitsController < ApplicationController
   end
 
   def update
+    return render json: ["Not authorized"], status: 403 unless current_role?([:nonprofit_admin, :super_admin])
+
     @form = NonprofitSettingsForm.new(
       nonprofit: current_nonprofit,
       attributes: params[:nonprofit].except(:verification_status)
@@ -63,9 +65,9 @@ class NonprofitsController < ApplicationController
     if @form.save
       flash[:notice] = "Update successful!"
       current_nonprofit.clear_cache
-      json_saved current_nonprofit
+      render json: current_nonprofit, status: 200
     else
-      json_saved current_nonprofit, 500
+      render json: @form.errors.full_messages, status: 500
     end
   end
 

--- a/app/controllers/nonprofits_controller.rb
+++ b/app/controllers/nonprofits_controller.rb
@@ -55,11 +55,9 @@ class NonprofitsController < ApplicationController
   end
 
   def update
-    return render json: ["Not authorized"], status: 403 unless current_role?([:nonprofit_admin, :super_admin])
-
     @form = NonprofitSettingsForm.new(
       nonprofit: current_nonprofit,
-      attributes: params[:nonprofit].except(:verification_status)
+      attributes: update_params
     )
 
     if @form.save
@@ -134,6 +132,12 @@ class NonprofitsController < ApplicationController
   end
 
   private
+
+  def update_params
+    excluded = [:verification_status]
+    excluded << :require_two_factor unless current_role?([:nonprofit_admin, :super_admin])
+    params[:nonprofit].except(*excluded)
+  end
 
   def countries_list(locale)
     all_countries = ISO3166::Country.translations(locale)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -84,6 +84,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def handle_two_factor_changes
+    return if current_user.two_factor_required_by_nonprofit?
+
     otp_param = params[:user][:otp_required_for_login]
     return if otp_param.blank?
 

--- a/app/forms/nonprofit_settings_form.rb
+++ b/app/forms/nonprofit_settings_form.rb
@@ -1,0 +1,33 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+class NonprofitSettingsForm
+  include ActiveModel::Model
+
+  attr_accessor :nonprofit, :attributes
+
+  def save
+    return false unless valid?
+
+    nonprofit.transaction do
+      nonprofit.update!(attributes)
+
+      if nonprofit.previous_changes["require_two_factor"] == [false, true]
+        enforce_two_factor_for_all_users
+      end
+    end
+
+    true
+  rescue ActiveRecord::RecordInvalid => e
+    errors.add(:base, e.message)
+    false
+  end
+
+  private
+
+  def enforce_two_factor_for_all_users
+    nonprofit.users.where(otp_required_for_login: false).find_each do |user|
+      user.otp_required_for_login = true
+      user.otp_secret = User.generate_otp_secret
+      user.save(validate: false)
+    end
+  end
+end

--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -51,7 +51,8 @@ class Nonprofit < ApplicationRecord
     :blog, # string (url)
     :card_failure_message_top, # text
     :card_failure_message_bottom, # text
-    :autocomplete_supporter_address # boolean
+    :autocomplete_supporter_address, # boolean
+    :require_two_factor # boolean
 
   has_many :payouts
   has_many :charges

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -41,7 +41,7 @@ class Role < ApplicationRecord
   end
 
   def self.create_for_nonprofit(role_name, email, nonprofit)
-    user = User.find_or_create_with_email(email)
+    user = User.find_or_create_with_email(email, nonprofit.require_two_factor?)
     role = Role.create(user: user, name: role_name, host: nonprofit)
     return role unless role.valid?
 

--- a/app/views/settings/_org_two_factor_auth.html.erb
+++ b/app/views/settings/_org_two_factor_auth.html.erb
@@ -1,0 +1,26 @@
+<%- # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later -%>
+<header class='pane-header'>
+	<h3>Organization Two Factor Authentication</h3>
+</header>
+
+<div class='pane-inner'>
+    <form autosubmit method='put' action='<%= nonprofit_path(@nonprofit) %>' data-reload>
+      <p class='pastelBox--yellow u-padding--10 u-marginBottom--20'>Two factor authentication adds an extra layer of security to users' accounts by requiring a one-time password when they log in. To enable, check the option below. Unchecking will not disable it for users that have it enabled, it will just stop requring it to be enabled.</p>
+      <div class='field'>
+        <input type='hidden' name='nonprofit[require_two_factor]' value='false'>
+        <input
+            type='checkbox'
+            name='nonprofit[require_two_factor]'
+            value='true'
+            <%= 'checked=checked' if @nonprofit.require_two_factor? %>
+            <%= 'disabled' unless current_role?([:nonprofit_admin,:super_admin]) %>
+            id='users-two-factor-input'>
+        <label class='two-factor-label' for='users-two-factor-input'>Require two factor authentication for all users.</label>
+      </div>
+
+      <p class='error'></p>
+      <% if current_role?([:nonprofit_admin,:super_admin]) %>
+          <button type='submit' class='button u-marginTop--5' data-loading='Updating user settings...'>Save Settings</button>
+      <% end %>
+    </form>
+</div>

--- a/app/views/settings/_two_factor_auth.html.erb
+++ b/app/views/settings/_two_factor_auth.html.erb
@@ -3,22 +3,26 @@
   <h3>Two Factor Authentication</h3>
 </header>
 <div class='pane-inner'>
-  <form autosubmit method='put' action='<%= registration_path(@user) %>' data-reload>
-    <p class='pastelBox--yellow u-padding--10 u-marginBottom--20'>Two factor authentication adds an extra layer of security to your account by requiring a one-time password when you log in. To enable, check the option below.</p>
+  <% if @user.two_factor_required_by_nonprofit? %>
+    <p class='pastelBox--yellow u-padding--10 u-marginBottom--20'>Two factor authentication is required by your organization. It adds an extra layer of security to your account by requiring a one-time password when you log in.</p>
+  <% else %>
+    <form autosubmit method='put' action='<%= registration_path(@user) %>' data-reload>
+      <p class='pastelBox--yellow u-padding--10 u-marginBottom--20'>Two factor authentication adds an extra layer of security to your account by requiring a one-time password when you log in. To enable, check the option below.</p>
 
-    <div class='field'>
-      <input type='hidden' name='user[otp_required_for_login]' value='false'>
-      <input type='checkbox' name='user[otp_required_for_login]' value='true' <%= 'checked=checked' if @user.otp_required_for_login? %> id='two-factor-input'>
-      <label class='two-factor-label' for='two-factor-input'>Enable two factor authentication on my account.</label>
-    </div>
+      <div class='field'>
+        <input type='hidden' name='user[otp_required_for_login]' value='false'>
+        <input type='checkbox' name='user[otp_required_for_login]' value='true' <%= 'checked=checked' if @user.otp_required_for_login? %> id='two-factor-input'>
+        <label class='two-factor-label' for='two-factor-input'>Enable two factor authentication on my account.</label>
+      </div>
 
-    <% if !@user.pending_password %>
-    <div class='field'>
-      <label>Type your current password below to confirm your changes</label>
-      <input class='input--300 u-block' name='user[current_password]' type='password'>
-    </div>
-    <% end %>
-    <p class='error'></p>
-    <button type='submit' class='button u-marginTop--5' data-loading='Updating security settings...'>Update Security Settings</button>
-  </form>
+      <% if !@user.pending_password %>
+      <div class='field'>
+        <label>Type your current password below to confirm your changes</label>
+        <input class='input--300 u-block' name='user[current_password]' type='password'>
+      </div>
+      <% end %>
+      <p class='error'></p>
+      <button type='submit' class='button u-marginTop--5' data-loading='Updating security settings...'>Update Security Settings</button>
+    </form>
+  <% end %>
 </div>

--- a/app/views/settings/_users.html.erb
+++ b/app/views/settings/_users.html.erb
@@ -55,32 +55,6 @@
 	</div>
 </div>
 
-<header class='pane-header'>
-	<h3>Require Two Factor Authentication</h3>
-</header>
-
-<div class='pane-inner'>
-    <form autosubmit method='put' action='<%= nonprofit_path(@nonprofit) %>' data-reload>
-      <p class='pastelBox--yellow u-padding--10 u-marginBottom--20'>Two factor authentication adds an extra layer of security to users' accounts by requiring a one-time password when they log in. To enable, check the option below. Unchecking will not disable it for users that have it enabled, it will just stop requring it to be enabled.</p>
-      <div class='field'>
-        <input type='hidden' name='nonprofit[require_two_factor]' value='false'>
-        <input
-            type='checkbox'
-            name='nonprofit[require_two_factor]'
-            value='true'
-            <%= 'checked=checked' if @nonprofit.require_two_factor? %>
-            <%= 'disabled' unless current_role?([:nonprofit_admin,:super_admin]) %>
-            id='users-two-factor-input'>
-        <label class='two-factor-label' for='users-two-factor-input'>Require two factor authentication for all users.</label>
-      </div>
-
-      <p class='error'></p>
-      <% if current_role?([:nonprofit_admin,:super_admin]) %>
-          <button type='submit' class='button u-marginTop--5' data-loading='Updating user settings...'>Save Settings</button>
-      <% end %>
-    </form>
-</div>
-
 <div class='modal' id='roleInfoModal'>
 	<%= render 'common/modal_header', title: "What's the difference between an Associate and an Admin?" %>
 	<div class='modal-body'>

--- a/app/views/settings/_users.html.erb
+++ b/app/views/settings/_users.html.erb
@@ -55,6 +55,32 @@
 	</div>
 </div>
 
+<header class='pane-header'>
+	<h3>Require Two Factor Authentication</h3>
+</header>
+
+<div class='pane-inner'>
+    <form autosubmit method='put' action='<%= nonprofit_path(@nonprofit) %>' data-reload>
+      <p class='pastelBox--yellow u-padding--10 u-marginBottom--20'>Two factor authentication adds an extra layer of security to users' accounts by requiring a one-time password when they log in. To enable, check the option below. Unchecking will not disable it for users that have it enabled, it will just stop requring it to be enabled.</p>
+      <div class='field'>
+        <input type='hidden' name='nonprofit[require_two_factor]' value='false'>
+        <input
+            type='checkbox'
+            name='nonprofit[require_two_factor]'
+            value='true'
+            <%= 'checked=checked' if @nonprofit.require_two_factor? %>
+            <%= 'disabled' unless current_role?([:nonprofit_admin,:super_admin]) %>
+            id='users-two-factor-input'>
+        <label class='two-factor-label' for='users-two-factor-input'>Require two factor authentication for all users.</label>
+      </div>
+
+      <p class='error'></p>
+      <% if current_role?([:nonprofit_admin,:super_admin]) %>
+          <button type='submit' class='button u-marginTop--5' data-loading='Updating user settings...'>Save Settings</button>
+      <% end %>
+    </form>
+</div>
+
 <div class='modal' id='roleInfoModal'>
 	<%= render 'common/modal_header', title: "What's the difference between an Associate and an Admin?" %>
 	<div class='modal-body'>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -40,6 +40,7 @@
 					<li class='active' swap-class='settings-pane' swap-in='pricing'>Pricing Plan</li>
 					<li swap-class='settings-pane' swap-in='timezone'>Timezone</li>
 					<li swap-class='settings-pane' swap-in='users'>Users</li>
+          <li swap-class='settings-pane' swap-in='org-two-factor-auth'>Two Factor Authentication</li>
 					<li swap-class='settings-pane' swap-in='payouts'>Payouts</li>
 					<li swap-class='settings-pane' swap-in='email-content'>Customize Email Content</li>
 					<li swap-class='settings-pane' swap-in='anons'>Anonymous Donations</li>
@@ -62,7 +63,6 @@
 							Email
 				</li>
 				<li swap-class='settings-pane' swap-in='pass'>Password</li>
-				<li swap-class='settings-pane' swap-in='two-factor-auth'>Two Factor Authentication</li>
 				<li swap-class='settings-pane' swap-in='privacy-settings'>Privacy</li>
 			</ul>
 		</nav>
@@ -86,6 +86,10 @@
 
 			<section class='settings-pane nonprofit-settings users hide'>
 				<%= render 'users' %>
+			</section>
+
+			<section class='settings-pane nonprofit-settings org-two-factor-auth hide'>
+				<%= render 'org_two_factor_auth' %>
 			</section>
 
 			<section class='settings-pane nonprofit-settings email-content hide'>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -40,7 +40,7 @@
 					<li class='active' swap-class='settings-pane' swap-in='pricing'>Pricing Plan</li>
 					<li swap-class='settings-pane' swap-in='timezone'>Timezone</li>
 					<li swap-class='settings-pane' swap-in='users'>Users</li>
-          <li swap-class='settings-pane' swap-in='org-two-factor-auth'>Two Factor Authentication</li>
+                    <li swap-class='settings-pane' swap-in='org-two-factor-auth'>Two Factor Authentication</li>
 					<li swap-class='settings-pane' swap-in='payouts'>Payouts</li>
 					<li swap-class='settings-pane' swap-in='email-content'>Customize Email Content</li>
 					<li swap-class='settings-pane' swap-in='anons'>Anonymous Donations</li>
@@ -63,6 +63,7 @@
 							Email
 				</li>
 				<li swap-class='settings-pane' swap-in='pass'>Password</li>
+				<li swap-class='settings-pane' swap-in='two-factor-auth'>Two Factor Authentication</li>
 				<li swap-class='settings-pane' swap-in='privacy-settings'>Privacy</li>
 			</ul>
 		</nav>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,7 +2,7 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 
-# Set expiration for OTP in seconds
+# Set expiration for OTP
 Devise.otp_allowed_drift = 15.minutes
 
 Devise.setup do |config|

--- a/db/migrate/20250623214715_add_require_two_factor_to_nonprofits.rb
+++ b/db/migrate/20250623214715_add_require_two_factor_to_nonprofits.rb
@@ -1,0 +1,5 @@
+class AddRequireTwoFactorToNonprofits < ActiveRecord::Migration[7.1]
+  def change
+    add_column :nonprofits, :require_two_factor, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_13_195800) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_23_214715) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -728,6 +728,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_13_195800) do
     t.jsonb "achievements"
     t.jsonb "categories"
     t.boolean "hide_main_image", default: false, null: false
+    t.boolean "require_two_factor", default: false, null: false
   end
 
   create_table "object_events", id: :serial, force: :cascade do |t|
@@ -1389,10 +1390,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_13_195800) do
   create_trigger :update_donations_fts, sql_definition: <<-SQL
       CREATE TRIGGER update_donations_fts BEFORE INSERT OR UPDATE ON public.donations FOR EACH ROW EXECUTE FUNCTION update_fts_on_donations()
   SQL
-  create_trigger :update_supporters_fts, sql_definition: <<-SQL
-      CREATE TRIGGER update_supporters_fts BEFORE INSERT OR UPDATE ON public.supporters FOR EACH ROW EXECUTE FUNCTION update_fts_on_supporters()
-  SQL
   create_trigger :update_supporters_phone_index, sql_definition: <<-SQL
       CREATE TRIGGER update_supporters_phone_index BEFORE INSERT OR UPDATE ON public.supporters FOR EACH ROW EXECUTE FUNCTION update_phone_index_on_supporters()
+  SQL
+  create_trigger :update_supporters_fts, sql_definition: <<-SQL
+      CREATE TRIGGER update_supporters_fts BEFORE INSERT OR UPDATE ON public.supporters FOR EACH ROW EXECUTE FUNCTION update_fts_on_supporters()
   SQL
 end

--- a/spec/forms/nonprofit_settings_form_spec.rb
+++ b/spec/forms/nonprofit_settings_form_spec.rb
@@ -1,0 +1,118 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require "rails_helper"
+
+RSpec.describe NonprofitSettingsForm do
+  let(:nonprofit) { create(:nonprofit_base, require_two_factor: false) }
+  let(:form) { described_class.new(nonprofit: nonprofit, attributes: attributes) }
+
+  describe "#save" do
+    context "when updating general attributes" do
+      let(:attributes) { {"name" => "New Organization Name"} }
+
+      it "updates the nonprofit" do
+        expect { form.save }.to change { nonprofit.reload.name }.to("New Organization Name")
+      end
+
+      it "returns true" do
+        expect(form.save).to be true
+      end
+    end
+
+    context "when enabling two-factor authentication" do
+      let(:attributes) { {"require_two_factor" => true} }
+
+      let!(:user_with_2fa) do
+        create(:user_as_nonprofit_admin,
+          nonprofit: nonprofit,
+          otp_required_for_login: true)
+      end
+
+      let!(:user_without_2fa) do
+        create(:user_as_nonprofit_associate,
+          nonprofit: nonprofit,
+          otp_required_for_login: false)
+      end
+
+      before do
+        allow(User).to receive(:generate_otp_secret).and_return("SECRET123")
+      end
+
+      it "enables two-factor for the nonprofit" do
+        expect { form.save }.to change { nonprofit.reload.require_two_factor? }.from(false).to(true)
+      end
+
+      it "enables two-factor for users without it" do
+        expect { form.save }.to change { user_without_2fa.reload.otp_required_for_login }.from(false).to(true)
+      end
+
+      it "generates OTP secrets for users without two-factor" do
+        form.save
+        expect(user_without_2fa.reload.otp_secret).to eq("SECRET123")
+      end
+
+      it "does not modify users who already have two-factor" do
+        expect { form.save }.not_to change { user_with_2fa.reload.otp_secret }
+      end
+    end
+
+    context "when disabling two-factor authentication" do
+      let(:nonprofit) { create(:nonprofit_base, require_two_factor: true) }
+      let(:attributes) { {"require_two_factor" => false} }
+      let!(:user) { create(:user_as_nonprofit_admin, nonprofit: nonprofit, otp_required_for_login: true) }
+
+      it "disables the requirement for the nonprofit" do
+        expect { form.save }.to change { nonprofit.reload.require_two_factor? }.from(true).to(false)
+      end
+
+      it "does not modify existing user settings" do
+        expect { form.save }.not_to change { user.reload.otp_required_for_login }
+      end
+    end
+
+    context "when two-factor is already enabled" do
+      let(:nonprofit) { create(:nonprofit_base, require_two_factor: true) }
+      let(:attributes) { {"require_two_factor" => true} }
+      let!(:user) { create(:user_as_nonprofit_associate, nonprofit: nonprofit, otp_required_for_login: false) }
+
+      it "does not enforce two-factor on users" do
+        expect { form.save }.not_to change { user.reload.otp_required_for_login }
+      end
+    end
+
+    context "with invalid data" do
+      let(:attributes) { {"name" => ""} }
+
+      before do
+        allow(nonprofit).to receive(:update!).and_raise(
+          ActiveRecord::RecordInvalid.new(nonprofit)
+        )
+      end
+
+      it "returns false" do
+        expect(form.save).to be false
+      end
+
+      it "adds errors" do
+        form.save
+        expect(form.errors[:base]).to be_present
+      end
+    end
+
+    context "when transaction rollback is needed" do
+      let(:attributes) { {"require_two_factor" => true} }
+      let!(:user) { create(:user_as_nonprofit_admin, nonprofit: nonprofit, otp_required_for_login: false) }
+
+      before do
+        allow(form).to receive(:enforce_two_factor_for_all_users).and_raise(ActiveRecord::RecordInvalid.new(user))
+      end
+
+      it "rolls back the nonprofit change" do
+        expect { form.save }.not_to change { nonprofit.reload.require_two_factor? }
+      end
+
+      it "returns false" do
+        expect(form.save).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/api/nonprofits_spec.rb
+++ b/spec/requests/api/nonprofits_spec.rb
@@ -133,7 +133,7 @@ describe Api::NonprofitsController, type: :request do
       expect(response.code).to eq "201"
       expect(MailchimpNonprofitUserAddJob).to have_been_enqueued
 
-      our_np = Nonprofit.all[1]
+      our_np = Nonprofit.all.order(:created_at)[1]
       expected_np = {
         name: "n",
         state_code: "WI",


### PR DESCRIPTION
Enabling 2FA-for-all sets 2FA to enabled for all users, and prevents them from changing it to disabled. Disabling it does not change any user's 2fa settings; it just no longer prevents them from disabling it.

Organization Users pane in settings for admin below. The checkbox still shows if not an admin, but you can't change it.
![Screenshot 2025-06-24 at 3 36 20 PM](https://github.com/user-attachments/assets/a77d1e16-749c-480a-aa93-b99c7f20774b)

User Account 2FA settings pane if the user's org has 2FA required. Checkbox is hidden completely. Even for admins.
![Screenshot 2025-06-24 at 3 37 02 PM](https://github.com/user-attachments/assets/6e6d2757-9fd6-450c-9af1-ea41c5df1c2d)

Closes https://github.com/CommitChange/tix/issues/4566

