### PR TITLE
Show full password error message in registrations

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -39,7 +39,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       errs = current_user.errors.full_messages
     else
       success = false
-      errs = {password: :incorrect}
+      errs = {password: [:incorrect]}
     end
 
     if success


### PR DESCRIPTION
Fixes a bug where the desired message "password incorrect" on registration update was instead displaying as "password i". The issue was that the `print_error` utility function expects the errors to be an object with the values as arrays, but we just had a string, so in the util function `json.errors[key][0]` was getting just "i" instead of the full "incorrect": https://github.com/Commitchange/houdini/blob/953d2165fe46d4f2a6f28e74ea729b49ca1aea56/client/js/common/utilities.js#L29