### PR TITLE
move nonprofit id and supporter id into refund

### DIFF
--- a/app/legacy_lib/insert_refunds.rb
+++ b/app/legacy_lib/insert_refunds.rb
@@ -33,7 +33,9 @@ module InsertRefunds
         comment: h["comment"],
         reason: h["reason"],
         stripe_refund_id: results[:stripe_refund].id,
-        charge_id: charge["id"]})
+        charge_id: charge["id"],
+        nonprofit_id: charge["nonprofit_id"],
+        supporter_id: charge["supporter_id"]})
 
       refund.create_misc_refund_info(is_modern: true, stripe_application_fee_refund_id: results[:stripe_app_fee_refund]&.id)
 

--- a/app/legacy_lib/merge_supporters.rb
+++ b/app/legacy_lib/merge_supporters.rb
@@ -5,7 +5,7 @@ module MergeSupporters
     new_supporter_id = new_supporter.id
     old_supporter_ids = old_supporters.map { |i| i.id }
     # The new supporter needs to have the following tables from the merged supporters:
-    associations = [:activities, :donations, :recurring_donations, :offsite_payments, :payments, :tickets, :supporter_notes, :supporter_emails, :full_contact_infos]
+    associations = [:activities, :donations, :recurring_donations, :offsite_payments, :payments, :tickets, :supporter_notes, :supporter_emails, :full_contact_infos, :refunds]
 
     associations.each do |table_name|
       Qx.update(table_name)

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -2,17 +2,6 @@
 class Refund < ApplicationRecord
   Reasons = [:duplicate, :fraudulent, :requested_by_customer]
 
-  attr_accessible \
-    :amount, # int
-    :comment, # text
-    :reason, # str ('duplicate', 'fraudulent', or 'requested_by_customer')
-    :stripe_refund_id,
-    :disbursed, # boolean (whether this refund has been counted in a payout)
-    :failure_message, # str (accessor for storing the Stripe error message)
-    :user_id, :user, # user who made this refund
-    :payment_id, :payment, # negative payment that records this refund
-    :charge_id, :charge
-
   attr_accessor :failure_message
 
   belongs_to :charge

--- a/app/tasks/maintenance/migrate_add_supporter_and_nonprofit_to_refund_task.rb
+++ b/app/tasks/maintenance/migrate_add_supporter_and_nonprofit_to_refund_task.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class MigrateAddSupporterAndNonprofitToRefundTask < MaintenanceTasks::Task
+    def collection
+      # Collection to be iterated over
+      # Must be Active Record Relation or Array
+      Refund.where(supporter_id: nil).or(Refund.where(nonprofit_id: nil))
+    end
+
+    def process(element)
+      # The work to be done in a single iteration of the task.
+      # This should be idempotent, as the same element may be processed more
+      # than once if the task is interrupted and resumed.
+      charge = element.charge
+      if charge&.nonprofit_id || charge&.supporter_id
+        element.update(nonprofit_id: charge.nonprofit_id, supporter_id: charge.supporter_id)
+      end
+    end
+
+    def count
+      # Optionally, define the number of rows that will be iterated over
+      # This is used to track the task's progress
+    end
+  end
+end

--- a/db/migrate/20250718224932_add_nonprofit_id_and_supporter_id_to_refund.rb
+++ b/db/migrate/20250718224932_add_nonprofit_id_and_supporter_id_to_refund.rb
@@ -1,0 +1,6 @@
+class AddNonprofitIdAndSupporterIdToRefund < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :refunds, :nonprofit
+    add_reference :refunds, :supporter
+  end
+end

--- a/db/migrate/20250718232728_create_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20250718232728_create_maintenance_tasks_runs.maintenance_tasks.rb
@@ -18,7 +18,7 @@ class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
       t.text(:backtrace)
       t.timestamps
       t.index(:task_name)
-      t.index([:task_name, :created_at], order: { created_at: :desc })
+      t.index([:task_name, :created_at], order: {created_at: :desc})
     end
   end
 

--- a/db/migrate/20250718232732_add_lock_version_to_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20250718232732_add_lock_version_to_maintenance_tasks_runs.maintenance_tasks.rb
@@ -8,7 +8,7 @@ class AddLockVersionToMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
       :lock_version,
       :integer,
       default: 0,
-      null: false,
+      null: false
     )
   end
 end

--- a/db/migrate/20250718232734_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20250718232734_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
@@ -6,15 +6,15 @@ class AddIndexOnTaskNameAndStatusToRuns < ActiveRecord::Migration[6.0]
     remove_index(
       :maintenance_tasks_runs,
       column: [:task_name, :created_at],
-      order: { created_at: :desc },
-      name: :index_maintenance_tasks_runs_on_task_name_and_created_at,
+      order: {created_at: :desc},
+      name: :index_maintenance_tasks_runs_on_task_name_and_created_at
     )
 
     add_index(
       :maintenance_tasks_runs,
       [:task_name, :status, :created_at],
       name: :index_maintenance_tasks_runs,
-      order: { created_at: :desc },
+      order: {created_at: :desc}
     )
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -773,6 +773,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_18_232735) do
     t.index ["supporter_id"], name: "index_offsite_payments_on_supporter_id"
   end
 
+  create_table "payment_dupe_statuses", id: :serial, force: :cascade do |t|
+    t.integer "payment_id"
+    t.boolean "matched", default: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.integer "matched_with_offline", default: [], array: true
+    t.index ["payment_id"], name: "index_payment_dupe_statuses_on_payment_id"
+  end
+
   create_table "payment_imports", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "nonprofit_id"

--- a/spec/lib/insert/insert_refunds_spec.rb
+++ b/spec/lib/insert/insert_refunds_spec.rb
@@ -117,6 +117,12 @@ describe InsertRefunds do
                   expect(refund.reason).to eq reason
                 end
 
+                it "has the correct supporter_id and nonprofit_id on Refund" do
+                  original_payment.reload
+                  expect(refund.supporter_id).to eq original_payment.supporter.id
+                  expect(refund.nonprofit_id).to eq original_payment.nonprofit.id
+                end
+
                 it "has an accurate misc_refund_info" do
                   expect(misc_refund_info.is_modern).to eq true
                   if amount_of_fees_to_refund > 0

--- a/spec/models/refund_spec.rb
+++ b/spec/models/refund_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Refund, type: :model do
   it { is_expected.to have_one(:nonprofit).through(:charge) }
   it { is_expected.to have_one(:supporter).through(:charge) }
   it { is_expected.to have_many(:manual_balance_adjustments) }
+  it { is_expected.to have_db_column(:supporter_id) }
+  it { is_expected.to have_db_column(:nonprofit_id) }
 
   describe "#from_donation?" do
     it "is true when refund is associated with a donation" do

--- a/spec/requests/maintenance_tasks_spec.rb
+++ b/spec/requests/maintenance_tasks_spec.rb
@@ -3,23 +3,23 @@ require "rails_helper"
 describe "MaintenanceTasks", type: :request do
   it "allows a super user to visit" do
     sign_in create(:user_as_super_admin)
-    get '/maintenance_tasks/'
+    get "/maintenance_tasks/"
 
     expect(response).to have_http_status(:success)
   end
 
   [:user_as_nonprofit_associate, :user_as_nonprofit_admin, :automated_user, :user].each do |factory|
-    it "prevents a #{factory.to_s} from visiting" do
+    it "prevents a #{factory} from visiting" do
       sign_in create(factory)
-      get '/maintenance_tasks/'
+      get "/maintenance_tasks/"
 
-      expect(response).to redirect_to( '/')
+      expect(response).to redirect_to("/")
     end
   end
 
   it "prevents an unknown user from visiting" do
-    get '/maintenance_tasks/'
+    get "/maintenance_tasks/"
 
-    expect(response).to redirect_to( '/users/sign_in' )
+    expect(response).to redirect_to("/users/sign_in")
   end
 end

--- a/spec/tasks/maintenance/migrate_add_supporter_and_nonprofit_to_refund_task_spec.rb
+++ b/spec/tasks/maintenance/migrate_add_supporter_and_nonprofit_to_refund_task_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe MigrateAddSupporterAndNonprofitToRefundTask do
+    let!(:refund_with_supporter_id) { create(:refund, supporter_id: 1, nonprofit_id: nil, charge: create(:charge_base)) }
+    let!(:refund_with_nonprofit_id) { create(:refund, supporter_id: nil, nonprofit_id: 1, charge: create(:charge_base)) }
+    let!(:refund_with_both) { create(:refund, supporter_id: 1, nonprofit_id: 1, charge: create(:charge_base)) }
+    let!(:refund_with_neither) { create(:refund, supporter_id: nil, nonprofit_id: nil, charge: create(:charge_base)) }
+
+    let(:refund_with_no_charge) { create(:refund, supporter_id: nil, nonprofit_id: nil) }
+    describe "#process" do
+      subject(:process) { described_class.process(element) }
+      context "Refund has a charge set " do
+        let(:element) { refund_with_neither }
+        it "sets the nonprofit_id and supporter_id" do
+          process
+          expect(element).to have_attributes(
+            nonprofit_id: refund_with_neither.charge.nonprofit_id,
+            supporter_id: refund_with_neither.charge.supporter_id
+          )
+        end
+      end
+
+      context "Refund has no charge set " do
+        let(:element) { refund_with_no_charge }
+        it "doesn't set nonprofit_id and supporter_id" do
+          process
+          expect(element).to have_attributes(
+            nonprofit_id: nil,
+            supporter_id: nil
+          )
+        end
+      end
+    end
+
+    describe "#collection" do
+      let(:expected_refunds) { [refund_with_nonprofit_id, refund_with_supporter_id, refund_with_neither] }
+
+      it "returns refunds with supporter_id or nonprofit_id set but nothing else" do
+        expect(described_class.collection).to match_array(expected_refunds)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- **Remove db migrations before 2024**
- **Add the nonprofit_id and supporter_id fields to Refunds**
- **Remove unneeded mass assignment protection on Refund**
- **Verify that InsertRefund sets nonprofit_id and supporter_id**

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
