### PR TITLE
Fix bug where removing all tags from a supporter or supporters failed

### DIFF
--- a/app/controllers/nonprofits/tag_joins_controller.rb
+++ b/app/controllers/nonprofits/tag_joins_controller.rb
@@ -34,7 +34,7 @@ module Nonprofits
     end
 
     def tag_modify_params
-      modify_params.require(:tags)
+      modify_params[:tags]
     end
   end
 end

--- a/spec/controllers/nonprofits/tag_joins_spec.rb
+++ b/spec/controllers/nonprofits/tag_joins_spec.rb
@@ -41,6 +41,11 @@ describe Nonprofits::TagJoinsController, type: :controller do
           expect(supporter.tag_joins.count).to eq 1
         end
 
+        it "succeeds when tags are empty" do
+          post :modify, params: params.merge(tags: [])
+          expect(supporter.tag_joins).to be_empty
+        end
+
         # The line below raises the following error. I suspect it is due to the oldness of our Rails and Ruby.
         # We can turn this back on in newer versions and see if it works
         #     1) Nonprofits::TagJoinsController authorization modify permitting is expected to (for POST #modify) restrict parameters on :tags to :tag_master_id


### PR DESCRIPTION
If someone tried to remove all of the tags for a Supporter or group of supporters via `POST /nonprofits/:nonprofit_id/tag_joins/modify`, the call would fail with the following error: `ActionController::ParameterMissing: param is missing or the value is empty: tags`. This was because we were using strong parameters to get the `:tags` parameter via `require`. This was unneeded because the we were using this `require` on the result of the `permit` call, i.e. we'd already done the necessary parameter filtering.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
