### PR TITLE
Remove unused format-number npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "flyd-zip": "0.0.1",
     "focus-group": "^0.3.1",
     "form-serialize": "0.7.0",
-    "format-number": "2.0.2",
     "hoist-non-react-statics": "^3.3.0",
     "i18n-js": "^3.0.3",
     "iban": "0.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4631,11 +4631,6 @@ form-serialize@^0.7.1:
   resolved "https://registry.yarnpkg.com/form-serialize/-/form-serialize-0.7.2.tgz#b0a2ff0c22026fb6d3d15c9d33f6de6a432e4732"
   integrity sha512-ohEA4Crzd/+hSREjGf4kSsy73WhAtQ7H+blGEz2DVd+JCi0TV5nZBSn9PaPlvrl9m29fa6xclAfpRkqZ57b1bw==
 
-format-number@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/format-number/-/format-number-2.0.2.tgz#8be2aa6fa6ef5ec43830892b1daee72705f9b462"
-  integrity sha512-ibyz0JpwyGjdb/7iOAzo6YeZuA5Z6vYFGGiw+5a11qduwHG669BrNIXm6BDqe5SideoPAi9PRXqGTcderFjNxQ==
-
 formidable@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.0.1.tgz#4310bc7965d185536f9565184dee74fbb75557ff"


### PR DESCRIPTION
I don't see any place that this is used. Let's remove it!


**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
