### PR TITLE
Disable keep alives

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -72,3 +72,6 @@ end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+# disable keep alives since that's an issue with Heroku Router 2.0 and puma 6 - https://www.heroku.com/blog/pumas-routers-keepalives-ohmy/
+enable_keep_alives false


### PR DESCRIPTION
Heroku Router 2.0 and Puma before 7 have a weird interaction around keep alives: Puma doesn't handle them properly. Until the new Puma is out, let's just turn off the keep alives as recommended at: https://www.heroku.com/blog/pumas-routers-keepalives-ohmy/

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
