### PR TITLE
Update puma to 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "rabl"
 
 gem "jbuilder"
 
-gem "puma", "~> 5.6"
+gem "puma", "~> 6.0"
 
 gem "kaminari"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,7 +407,7 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (5.6.9)
+    puma (6.6.1)
       nio4r (~> 2.0)
     rabl (0.17.0)
       activesupport (>= 2.3.14)
@@ -686,7 +686,7 @@ DEPENDENCIES
   protected_attributes_continued
   pry
   pry-byebug
-  puma (~> 5.6)
+  puma (~> 6.0)
   qx!
   rabl
   rack (~> 2.2.15)


### PR DESCRIPTION
The `enable_keep_alives` config isn't in Puma 5 and we hadn't updated to Puma 6. So prod crashed. This updates it.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
