### PR TITLE
Fix stripe logging

### DIFF
--- a/app/models/stripe_account.rb
+++ b/app/models/stripe_account.rb
@@ -81,7 +81,7 @@ class StripeAccount < ApplicationRecord
     when Stripe::Account
       self[:object] = input.to_hash
       object_json = object
-      puts object
+      Rails.logger.info object
     when String
       self[:object] = input
       object_json = object


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Using `puts` here outputs the Stripe account hash into std out and pollutes the rspec output. Using the Rails logger is better form.