### PR TITLE
Remove no longer needed `Format::Date.us_timezones`

### DIFF
--- a/app/legacy_lib/format/date.rb
+++ b/app/legacy_lib/format/date.rb
@@ -41,13 +41,5 @@ module Format
       datetime = datetime.in_time_zone(timezone) if timezone
       datetime.strftime("%l:%M%P")
     end
-
-    def self.us_timezones
-      # zones=ActiveSupport::TimeZone.us_zones
-      zones = ActiveSupport::TimeZone.all
-      names = zones.map(&:name)
-      vals = zones.map { |t| t.tzinfo.name }
-      names.zip(vals).sort_by { |name, val| name }
-    end
   end
 end


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

#1274 removed the last usage of `Format::Date.us_timezones` (which didn't actually do what the method was named). This removes it.
