### PR TITLE
Switch Intel Mac runner to Macos 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
-          os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-latest] # macos-13 is the last Intel mac version
+          os: [ubuntu-22.04, ubuntu-24.04, macos-15-intel, macos-latest] # macos-15-intel is the last Intel mac version
           node: [16]
           ruby: ['3.3.8']
           postgres: ['16']


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Github [says](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) they're removing the old Macos 13 runner for intel chips. Instead we can use their new `macOS-15-intel` runner.
