### PR TITLE
Chore: delegate timezone

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -126,6 +126,8 @@ class Campaign < ApplicationRecord
 
   after_update :send_campaign_updated
 
+  delegate :timezone, to: :nonprofit, prefix: true, allow_nil: true
+
   def set_defaults
     self.total_supporters = 1
     self.published = false if published.nil?

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -8,13 +8,6 @@ class Charge < ApplicationRecord
     :stripe_charge_id,
     :status
 
-  has_one :campaign, through: :donation
-  has_one :recurring_donation, through: :donation
-  has_one :stripe_dispute, primary_key: :stripe_charge_id, foreign_key: :stripe_charge_id
-  has_many :tickets
-  has_many :events, through: :tickets
-  has_many :refunds
-  has_many :disputes
   belongs_to :supporter
   belongs_to :card
   belongs_to :direct_debit_detail
@@ -22,6 +15,14 @@ class Charge < ApplicationRecord
   belongs_to :donation
   belongs_to :payment
   belongs_to :stripe_charge_object, primary_key: "stripe_charge_id", foreign_key: "stripe_charge_id", class_name: "StripeCharge"
+  has_one :campaign, through: :donation
+  has_one :recurring_donation, through: :donation
+  has_one :stripe_dispute, primary_key: :stripe_charge_id, foreign_key: :stripe_charge_id
+  has_many :tickets
+  has_many :events, through: :tickets
+  has_many :refunds
+  has_many :disputes
+
 
   scope :paid, -> { where(status: ["available", "pending", "disbursed"]) }
   scope :not_paid, -> { where(status: [nil, "failed"]) }
@@ -30,6 +31,8 @@ class Charge < ApplicationRecord
   scope :disbursed, -> { where(status: "disbursed") }
 
   has_many :manual_balance_adjustments, as: :entity
+
+  delegate :timezone, to: :nonprofit, prefix: true, allow_nil: true
 
   def paid?
     status.in?(%w[available pending disbursed])

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -31,6 +31,14 @@ class Donation < ApplicationRecord
   validates_associated :charges
   validates :payment_provider, inclusion: {in: ["credit_card", "sepa"]}, allow_blank: true
 
+  belongs_to :supporter
+  belongs_to :card
+  belongs_to :direct_debit_detail
+  belongs_to :profile
+  belongs_to :nonprofit
+  belongs_to :campaign
+  belongs_to :event
+
   has_many :charges
   has_many :campaign_gifts, dependent: :destroy
   has_many :campaign_gift_options, through: :campaign_gifts
@@ -41,13 +49,8 @@ class Donation < ApplicationRecord
   has_one :offsite_payment
   has_one :tracking
   has_many :modern_donations
-  belongs_to :supporter
-  belongs_to :card
-  belongs_to :direct_debit_detail
-  belongs_to :profile
-  belongs_to :nonprofit
-  belongs_to :campaign
-  belongs_to :event
+
+  delegate :timezone, to: :nonprofit, prefix: true, allow_nil: true
 
   scope :anonymous, -> { where(anonymous: true) }
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -61,6 +61,8 @@ class Payment < ApplicationRecord
     each.map(&:from_donation?)
   end
 
+  delegate :timezone, to: :nonprofit, prefix: true, allow_nil: true
+
   def from_donation?
     if kind == "Refund"
       !!refund&.from_donation?

--- a/app/views/campaigns/_campaigns_table.html.erb
+++ b/app/views/campaigns/_campaigns_table.html.erb
@@ -10,7 +10,7 @@
       <td class='u-padding--10'>
         <% if campaign.end_datetime %>
           <p class='u-marginBottom--0'>
-            <small><strong>Until: <%= Format::Date.full(campaign.end_datetime, campaign.nonprofit.timezone) %> </strong></small>
+            <small><strong>Until: <%= Format::Date.full(campaign.end_datetime, campaign.nonprofit_timezone) %> </strong></small>
           </p>
         <% end %>
         <h6 class='u-marginTop--0 u-marginBottom--5'>

--- a/app/views/campaigns/_settings_modal.html.erb
+++ b/app/views/campaigns/_settings_modal.html.erb
@@ -4,7 +4,7 @@
 
 	<%= render 'common/modal_header', title: 'Campaign Settings' %>
 
-  <form class='form--flatFields' autosubmit action='/nonprofits/<%=@nonprofit.id%>/campaigns/<%=@campaign.id%>' method='put' data-reload-with-slug parsley-validate>
+  <form class='form--flatFields' autosubmit action='<%= campaigns_path(@campaign.nonprofit, @campaign) %>' method='put' data-reload-with-slug parsley-validate>
 
     <% if @campaign.child_campaign? %>
       <div class='modal-body'>
@@ -48,7 +48,7 @@
         <fieldset>
           <label>End Date & Time</label>
           <div pikaday-timepicker='MM/DD/YYYY hh:mm a'>
-            <input class='u-width--200 u-bold u-inlineBlock' type='text' name='campaign[end_datetime]' required parsley-trigger='change' placeholder='MM/DD/YYYY HH:MM' value='<%= Format::Date.full(@campaign.end_datetime, @nonprofit.timezone) %>'>
+            <input class='u-width--200 u-bold u-inlineBlock' type='text' name='campaign[end_datetime]' required parsley-trigger='change' placeholder='MM/DD/YYYY HH:MM' value='<%= Format::Date.full(@campaign.end_datetime, @campaign.nonprofit_timezone) %>'>
             <a class='button edit u-inlineBlock'>Set</a>
           </div>
         </fieldset>

--- a/app/views/charge_mailer/_payment_receipt.html.erb
+++ b/app/views/charge_mailer/_payment_receipt.html.erb
@@ -22,7 +22,7 @@
 
 		<tr>
 			<td><strong>Transaction Date</strong></td>
-			<td><%= Format::Date.full(charge.created_at, charge.nonprofit.timezone) %></td>
+			<td><%= Format::Date.full(charge.created_at, charge.nonprofit_timezone) %></td>
 		</tr>
 		<tr>
 			<td><strong>Transaction ID</strong></td>

--- a/app/views/donation_mailer/_donation_payment_table.html.erb
+++ b/app/views/donation_mailer/_donation_payment_table.html.erb
@@ -22,7 +22,7 @@
 		</tr>
 		<tr>
 			<td><strong><%= t('donation.date') %></strong></td>
-			<td><%= date_and_time(@payment&.charge.try(:created_at) || donation.created_at, donation.nonprofit.timezone) %></td>
+			<td><%= date_and_time(@payment&.charge.try(:created_at) || donation.created_at, donation.nonprofit_timezone) %></td>
 		</tr>
 
 		<% if donation.campaign && donation.campaign.published %>

--- a/app/views/nonprofit_mailer/invoice_payment_notification.html.erb
+++ b/app/views/nonprofit_mailer/invoice_payment_notification.html.erb
@@ -24,7 +24,7 @@ Your invoice for the month of <%= @month_name %> has been paid and the receipt i
   </tr>
   <tr>
     <td><strong>Transaction Date</strong></td>
-    <td><%= date_and_time(@payment.date, @nonprofit.timezone) %></td>
+    <td><%= date_and_time(@payment.date, @payment.nonprofit_timezone) %></td>
   </tr>
 
   <tr>

--- a/app/views/tax_mailer/_dispute_payment_table.html.erb
+++ b/app/views/tax_mailer/_dispute_payment_table.html.erb
@@ -7,7 +7,7 @@
 		</tr>
 		<tr>
 			<td><strong>Dispute Date</strong></td>
-			<td><%= date_and_time(payment.date, payment.nonprofit.timezone) %></td>
+			<td><%= date_and_time(payment.date, payment.nonprofit_timezone) %></td>
 		</tr>
 
 		<tr>

--- a/app/views/tax_mailer/_dispute_reversal_payment_table.html.erb
+++ b/app/views/tax_mailer/_dispute_reversal_payment_table.html.erb
@@ -8,7 +8,7 @@
 		</tr>
 		<tr>
 			<td><strong>Dispute Reversal Date</strong></td>
-			<td><%= date_and_time(payment.date, payment.nonprofit.timezone) %></td>
+			<td><%= date_and_time(payment.date, payment.nonprofit_timezone) %></td>
 		</tr>
 
 		<tr>

--- a/app/views/tax_mailer/_donation_payment_table.html.erb
+++ b/app/views/tax_mailer/_donation_payment_table.html.erb
@@ -16,7 +16,7 @@
 		</tr>
 		<tr>
 			<td><strong><%= t('donation.date') %></strong></td>
-			<td><%= date_and_time(payment.date, payment.nonprofit.timezone) %></td>
+			<td><%= date_and_time(payment.date, payment.nonprofit_timezone) %></td>
 		</tr>
 
 		<% if payment.donation.campaign %>

--- a/app/views/tax_mailer/_refund_payment_table.html.erb
+++ b/app/views/tax_mailer/_refund_payment_table.html.erb
@@ -7,7 +7,7 @@
 		</tr>
 		<tr>
 			<td><strong>Refund Date</strong></td>
-			<td><%= date_and_time(payment.date, payment.nonprofit.timezone) %></td>
+			<td><%= date_and_time(payment.date, payment.nonprofit_timezone) %></td>
 		</tr>
 
 		<tr>

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Campaign, type: :model do
 
   it { is_expected.to belong_to :widget_description }
 
+  it { is_expected.to delegate_method(:timezone).to(:nonprofit).with_prefix.allow_nil }
+
   describe "goal_amount" do
     before(:each) do
       @nonprofit = create(:nonprofit)

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -3,8 +3,30 @@ require "rails_helper"
 
 RSpec.describe Charge, type: :model do
   it { is_expected.to belong_to(:card) }
+  it { is_expected.to belong_to(:supporter) }
+  it { is_expected.to belong_to(:direct_debit_detail) }
+  it { is_expected.to belong_to(:nonprofit) }
+  it { is_expected.to belong_to(:donation) }
+  it { is_expected.to belong_to(:payment) }
 
+  it { is_expected.to have_one(:campaign).through(:donation) }
+  it { is_expected.to have_one(:recurring_donation).through(:donation) }
+  it do
+    is_expected.to have_one(:stripe_dispute).with_primary_key(:stripe_charge_id)
+                                            .with_foreign_key(:stripe_charge_id)
+  end
+  it { is_expected.to have_many(:tickets) }
+  it { is_expected.to have_many(:events).through(:tickets) }
+  it { is_expected.to have_many(:refunds) }
+  it { is_expected.to have_many(:disputes) }
+  it do
+    is_expected.to belong_to(:stripe_charge_object).with_primary_key(:stripe_charge_id)
+                                                   .with_foreign_key(:stripe_charge_id)
+                                                   .class_name("StripeCharge")
+  end
   it { is_expected.to have_many(:manual_balance_adjustments) }
+
+  it { is_expected.to delegate_method(:timezone).to(:nonprofit).with_prefix.allow_nil }
 
   describe ".charge" do
     include_context :disputes_context

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -2,9 +2,26 @@
 require "rails_helper"
 
 RSpec.describe Donation, type: :model do
-  it {
-    is_expected.to have_many(:modern_donations)
-  }
+  it { is_expected.to belong_to(:supporter) }
+  it { is_expected.to belong_to(:card) }
+  it { is_expected.to belong_to(:direct_debit_detail) }
+  it { is_expected.to belong_to(:profile) }
+  it { is_expected.to belong_to(:nonprofit) }
+  it { is_expected.to belong_to(:campaign) }
+  it { is_expected.to belong_to(:event) }
+
+  it { is_expected.to have_one(:recurring_donation) }
+  it { is_expected.to have_one(:payment) }
+  it { is_expected.to have_one(:offsite_payment) }
+  it { is_expected.to have_one(:tracking) }
+  it { is_expected.to have_many(:modern_donations) }
+  it { is_expected.to have_many(:charges) }
+  it { is_expected.to have_many(:campaign_gifts) }
+  it { is_expected.to have_many(:campaign_gift_options).through(:campaign_gifts) }
+  it { is_expected.to have_many(:activities) }
+  it { is_expected.to have_many(:payments) }
+
+  it { is_expected.to delegate_method(:timezone).to(:nonprofit).with_prefix.allow_nil }
 
   describe "#campaign_gift_purchase?" do
     it "is false without any campaign_gifts" do

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Payment, type: :model do
 
   it { is_expected.to have_many(:campaign_gifts).through(:donation) }
 
+  it { is_expected.to delegate_method(:timezone).to(:nonprofit).with_prefix.allow_nil }
+
   describe "#staff_comment" do
     it "is nil if manual_balance_adjustment is unset" do
       payment = build(:payment)


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Found several more cases where timezone could be delegated. It may make sense to move the delegation and any helper/convenience methods into a Concern later but at the moment the only common piece of code between the 5 models is the delegation itself. 

* Delegated timezone to nonprofit in Payment, Campaign, Charge, and Donation.
* Convert to using delegated timezone calls.
* Added spec coverage to models that were modified. Spec failures suggested reordering associations. Associations referenced by another association as a `through` should be defined first. For example, on `Charge`, `belongs_to :donation` should come before `has_one :campaign, through: :donation` because the campaign association references donation in its through designation.