### PR TITLE
Add method for getting associated Stripe::Payout from the Payout object

### DIFF
--- a/spec/factories/nonprofits.rb
+++ b/spec/factories/nonprofits.rb
@@ -131,5 +131,9 @@ FactoryBot.define do
           billing_plan: create(:billing_plan_base, :with_associated_stripe_plan, amount: 133333, percentage_fee: 0.33, name: "fake plan")
       }
     end
+
+    trait :with_stripe_account do
+      stripe_account
+    end
   end
 end

--- a/spec/factories/payouts.rb
+++ b/spec/factories/payouts.rb
@@ -1,8 +1,13 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 FactoryBot.define do
   factory :payout do
-    stripe_transfer_id { "tr_xxxxxxxxx" }
+    stripe_transfer_id { "po_xxxxxxxxx" }
     email { Faker::Internet.email }
     net_amount { Faker::Number.number(digits: 5) }
+    nonprofit
+
+    trait :old_transfer_type do
+      stripe_transfer_id { "tr_xxxxxxx" }
+    end
   end
 end


### PR DESCRIPTION
There wasn't a method for getting the Stripe::Payout (or Stripe::Transfer) object from the Payout itself. This adds such a mechanism.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
