### PR TITLE
Update Heroku version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Houdini is designed and tested to run with the following:
 * Ruby 3.0
 * Node 16
 * PostgreSQL 16
-* run on Heroku-20
+* run on Heroku-24
 
 ## Dev Setup
 


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We run on Heroku 24 but forgot to update the README to reflect that.