### PR TITLE
Remove now unused Rails autoscale gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,7 +129,6 @@ gem "config", "~> 2.0"
 gem "dry-validation" # used only for config validation
 
 group :production do
-  gem "rails-autoscale-web"
   gem "tunemygc"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,10 +295,6 @@ GEM
     js-routes (2.2.7)
       railties (>= 4)
     json (2.12.2)
-    judoscale-rails (1.11.1)
-      judoscale-ruby (= 1.11.1)
-      railties
-    judoscale-ruby (1.11.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -439,8 +435,6 @@ GEM
       activesupport (= 7.1.5.2)
       bundler (>= 1.15.0)
       railties (= 7.1.5.2)
-    rails-autoscale-web (1.11.1)
-      judoscale-rails (= 1.11.1)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -696,7 +690,6 @@ DEPENDENCIES
   rack-cors
   rack-timeout
   rails (~> 7.1.5.1)
-  rails-autoscale-web
   rails-i18n
   rake
   recaptcha (~> 5.19)


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
