### PR TITLE
Security fix 2 - insecure direct object access on donation

### DIFF
--- a/app/controllers/nonprofits/donations_controller.rb
+++ b/app/controllers/nonprofits/donations_controller.rb
@@ -49,7 +49,8 @@ module Nonprofits
     end
 
     def update
-      render_json { UpdateDonation.update_payment(params[:id], params[:donation]) }
+      donation = current_nonprofit.donations.find(params[:id])
+      render_json { UpdateDonation.update_payment(donation.id, params[:donation]) }
     end
 
     # put /nonprofits/:nonprofit_id/donations/:id

--- a/spec/controllers/nonprofits/donations_spec.rb
+++ b/spec/controllers/nonprofits/donations_spec.rb
@@ -26,6 +26,40 @@ describe Nonprofits::DonationsController, type: :controller do
     include_context :shared_user_context
     include_context :open_to_np_associate, :put, :followup, nonprofit_id: :__our_np, id: "1"
   end
+
+  describe "insecure direct object reference protection" do
+    include_context :shared_user_context
+
+    let(:other_np_supporter) { create(:supporter, nonprofit: other_nonprofit) }
+    let(:other_np_donation) {
+      create(:donation,
+        supporter: other_np_supporter,
+        nonprofit: other_nonprofit,
+        amount: 1000)
+    }
+
+    describe "update" do
+      it "prevents admin from updating donation belonging to another nonprofit" do
+        sign_in user_as_np_admin
+        expect do
+          put :update, params: {nonprofit_id: nonprofit.id,
+                                id: other_np_donation.id,
+                                donation: {designation: "broken"}}
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe "followup" do
+      it "prevents admin from updating donation belonging to another nonprofit" do
+        sign_in user_as_np_admin
+        expect do
+          put :followup, params: {nonprofit_id: nonprofit.id,
+                                  id: other_np_donation.id,
+                                  donation: {designation: "broken"}}
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end
 
 describe "Nonprofits::DonationsController::create_offsite", type: :request do


### PR DESCRIPTION

Fixes cross-donation update security issue.

**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**
