### PR TITLE
Remove unused tunemygc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,10 +128,6 @@ gem "terser"
 gem "config", "~> 2.0"
 gem "dry-validation" # used only for config validation
 
-group :production do
-  gem "tunemygc"
-end
-
 group :production, :staging do
   gem "hiredis", "~> 0.6.0"
   gem "redis", ">= 3.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -599,7 +599,6 @@ GEM
     tilt (2.0.10)
     timecop (0.9.10)
     timeout (0.4.3)
-    tunemygc (1.0.71)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -713,7 +712,6 @@ DEPENDENCIES
   terser
   test-unit
   timecop
-  tunemygc
   webmock
   yaaf
   yard


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

We were using an Heroku add-on at one point called "TuneMyGC". It consisted of the Heroku add-on and the associated gem. The Add-on was discontinued a while ago but we never removed the gem. This PR does that.
