### PR TITLE
docs: donation embed & redirect-to-thank-you-page documentation

### DIFF
--- a/docs/donation-iframe-embed.md
+++ b/docs/donation-iframe-embed.md
@@ -1,0 +1,139 @@
+# Donation Embed Parameters (Engineering Reference)
+
+This is the engineering source-of-truth for the parameters supported by the
+donation form when it is embedded on an external site — either as a **donate
+button** (`<a class="commitchange-donate">`) or as a **custom iframe**.
+
+The customer-facing version of the redirect/thank-you-page workflow lives in
+Help Scout (see `docs/help-center/redirecting-donors-to-a-custom-thank-you-page.md`
+for the source content).
+
+## Two embed methods
+
+### 1. Donate button (recommended)
+
+The widget loader script (`client/js/widget/donate-button.v2.js`) finds every
+`.commitchange-donate` element, reads its `data-*` attributes, and assembles the
+donation URL for you. The base it builds is:
+
+```
+{host}/nonprofits/{npo_id}/donate?offsite=t&<params from data-attrs and page UTMs>
+```
+
+Note it **always appends `offsite=t`** (line ~121). If the element also has
+`data-embedded`, the loader appends `&mode=embedded` and renders an inline
+iframe; otherwise it renders a modal popup.
+
+Because the loader does the URL assembly and encoding, this method avoids the
+encoding pitfalls of the hand-written iframe below.
+
+### 2. Custom iframe
+
+A hand-written iframe pointing directly at the donate URL. You are responsible
+for assembling the query string correctly (single `?`, `&`-joined params,
+encoding). Example:
+
+```html
+<iframe frameborder="0" class="commitchange-iframe-embedded" width="100%" height="600"
+  src="https://us.commitchange.com/nonprofits/3728/donate?campaign_id=6090&amp;mode=embedded&amp;custom_amounts=25%2C50%2C100%2C250%2C700%2C1000%2C1500&amp;redirect=https://www.example.org/thank-you&amp;skipFinish=t"></iframe>
+```
+
+## Parameter reference
+
+Params are parsed on the donate page via `url.parse(href, true).query`
+(`client/js/nonprofits/donate/wizard/utils/parseDonateParams.ts`). The
+`data-*` column shows the equivalent attribute on a donate button, where one
+exists.
+
+| Query param | Button `data-*` | Type | Purpose |
+|---|---|---|---|
+| `campaign_id` | `data-campaign-id` | id | Attribute the gift to a campaign |
+| `gift_option_id` | `data-gift-option-id` | id | Pre-select a gift option (with `campaign_id`) |
+| `amount` | `data-amount` | number | Pre-fill a donation amount |
+| `type` | `data-type` | `one-time`/`recurring` | Default donation type |
+| `custom_amounts` | `data-custom-amounts` / `data-amounts` | string | Amount buttons. Comma/semicolon/underscore-separated numbers (`25,50,100`) or JSON5 with `{amount, highlight}`. Default `[25,50,100,250,500,1000,1500]`. |
+| `custom_fields` | `data-custom-fields` | string | Extra form fields |
+| `designation` | `data-designation` | string | Pre-select a designation |
+| `multiple_designations` | `data-multiple-designations` | string | Allow multiple designations |
+| `designations_prompt` | `data-designations-prompt` | string | Prompt text for designations |
+| `designation_desc` | `data-designation-desc` / `data-description` | string | Designation description |
+| `single_amount` | `data-single-amount` | number | Lock to a single amount |
+| `hide_dedication` | `data-hide-dedication` | bool | Hide dedication fields |
+| `manual_cover_fees` | `data-manual-cover-fees` | bool | Manual fee-coverage handling |
+| `hide_cover_fees_option` | `data-hide-cover-fees-option` | bool | Hide the "cover fees" UI |
+| `hide_anonymous` | `data-hide-anonymous` | bool | Hide the anonymous option |
+| `minimal` | `data-minimal` | bool | Minimal UI |
+| `weekly` | `data-weekly` | bool | Offer weekly recurring |
+| `default` | `data-default` | string | Default recurring interval |
+| `locale` | `data-locale` | string | Locale |
+| `tags` | `data-tags` | string | Tag the donation |
+| `utm_source` `utm_campaign` `utm_medium` `utm_content` | `data-utm_source` etc. | string | Analytics tags (also auto-read from the host page URL by the loader) |
+| `first_name` `last_name` `country` `postal_code` `address` `city` | `data-first_name` etc. | string | Donor prefill |
+| `redirect` | `data-redirect` | url | Where to send the donor after the gift completes |
+| `skipFinish` | — (iframe/query only) | truthy | Auto-complete without the Finish button (see below) |
+| `mode=embedded` | `data-embedded` (presence) | flag | Inline embed vs modal: hides close button, no auto-close |
+| `offsite` | added automatically by loader | flag | Marks an external embed; gates the Finish button (see below) |
+| `modal` | — | flag | Modal context |
+| `fixed` | `data-fixed` | flag | Fixed/floating button variant |
+
+## redirect / skipFinish / offsite interaction
+
+This is the part most likely to cause confusion, so it is spelled out here.
+
+- **`redirect`** (`client/js/nonprofits/donate/wizard/utils/handleWizardFinished.ts`):
+  when the wizard finishes, if a `redirect` value is set and we're inside an
+  iframe, the form posts `commitchange:redirect:{url}` to the parent; otherwise
+  it sets `window.location` directly.
+
+- **`skipFinish`** (`client/js/nonprofits/donate/wizard.js`): when the charge
+  completes, if `skipFinish` is truthy the form calls `handleWizardFinished`
+  immediately — skipping the Finish button. Truthy check, so any non-empty
+  value (e.g. `t`) works. **There is no `data-skip-finish` attribute — this is
+  reachable only via the iframe/query-string method.**
+
+- **`offsite`** (`client/js/nonprofits/donate/followup-step.js` lines 37-38):
+  the Finish button only renders when `offsite` is true **and** (`redirect` or
+  `modal`) is set. The donate-button loader always sets `offsite=t`.
+
+Resulting behavior:
+
+| Method | offsite | skipFinish | Result |
+|---|---|---|---|
+| Donate button (`data-redirect`) | `t` (auto) | n/a | Finish button shows → donor clicks → redirect |
+| Iframe + `redirect` + `skipFinish=t` | not required | yes | Auto-redirect on completion (no Finish button) |
+| Iframe + `redirect`, no `skipFinish` | **required** | no | Needs `offsite=t` or there's no Finish button and no redirect ever fires |
+
+**Practical rule:** if you want an automatic/immediate redirect (skip the Finish
+screen), use the iframe method with `skipFinish=t`. If a Finish-button step is
+acceptable, the donate button (`data-redirect`) is simpler and adds `offsite=t`
+for you.
+
+## URL construction rules (hand-written iframe)
+
+1. **One `?` only.** It goes after `/donate`. Everything after is joined with
+   `&` (`&amp;` in HTML). A second `?` becomes a literal character and silently
+   swallows the following params into the previous value — the classic cause of
+   a redirect that "doesn't work."
+
+2. **`&amp;` is HTML encoding, not URL encoding.** Inside an iframe `src` it's
+   the correct way to write `&`; the browser decodes it. Don't convert it to a
+   plain `&` or to `%26`, and never paste `&amp;` into a browser address bar
+   (WAFs such as GoDaddy's flag it as an evasion attempt).
+
+3. **Encode the `redirect` value only when the destination has its own query
+   string.** A clean path like `https://example.org/thank-you` needs no
+   encoding. But the moment you add the destination's own params (UTMs, etc.),
+   URL-encode the entire `redirect` value so its `?`/`&`/`=` don't collide with
+   the donate form's params. The form URL-decodes the value automatically.
+
+   Destination: `https://example.org/thank-you?utm_campaign=spring-appeal`
+   Encoded for `redirect=`: `https%3A%2F%2Fexample.org%2Fthank-you%3Futm_campaign%3Dspring-appeal`
+
+## Key source files
+
+- `client/js/widget/donate-button.v2.js` — button loader; reads `data-*`, builds the URL, renders modal/inline iframe.
+- `client/js/nonprofits/donate/wizard/utils/parseDonateParams.ts` — query-string parsing.
+- `client/js/nonprofits/donate/wizard/utils/handleWizardFinished.ts` — redirect + close behavior, `mode=embedded` handling.
+- `client/js/nonprofits/donate/wizard.js` — `skipFinish` trigger, close-button visibility.
+- `client/js/nonprofits/donate/followup-step.js` — Finish-button gating on `offsite`.
+- `client/js/nonprofits/donate/parseFields/customAmounts/index.ts` — `custom_amounts` parsing.

--- a/docs/donation-iframe-embed.md
+++ b/docs/donation-iframe-embed.md
@@ -108,6 +108,68 @@ screen), use the iframe method with `skipFinish=t`. If a Finish-button step is
 acceptable, the donate button (`data-redirect`) is simpler and adds `offsite=t`
 for you.
 
+## ⚠️ A hand-written iframe cannot redirect on its own — the host page needs the loader script
+
+This is the single most common reason a redirect "doesn't work."
+
+When the form runs inside an iframe, it **cannot navigate the parent page
+directly** (the iframe is on `*.commitchange.com`, the host page is the
+nonprofit's own domain — cross-origin navigation is blocked by the browser).
+So instead, on completion the form **posts a message** to the parent window:
+
+```
+commitchange:redirect:{url}
+```
+
+(`handleWizardFinished.ts` → `WidgetWindowWrapper.notifyParentOfRedirect`.)
+
+Something on the host page has to **listen** for that message and perform the
+navigation. The only thing that does this is the **CommitChange loader script**
+(`donate-button.v2.js`), which installs:
+
+```js
+window.addEventListener('message', (e) => {
+  if (typeof e.data === 'string' && e.data.startsWith('commitchange:redirect')) {
+    const m = e.data.match(/^commitchange:redirect:(.+)$/)
+    if (m.length === 2) window.location.href = m[1]
+  }
+})
+```
+
+If the host page has only a bare `<iframe>` and **not** the loader script, the
+redirect message is posted into the void and nothing happens. The donate button
+method doesn't hit this because the loader script is required for it anyway.
+
+**Fix for a hand-written iframe:** add the loader script to the host page (it
+installs the listener; with no `.commitchange-donate` element it builds no
+buttons):
+
+```html
+<script id='commitchange-donation-script' data-npo-id='{NPO_ID}'
+        src='https://commitchange.com/js/donate-button.v2.js'></script>
+```
+
+### Side effect: the loader injects a stylesheet that resizes the embed
+
+On load, the loader also appends
+`<link href="https://us.commitchange.com/css/donate-button.v2.css">` to the
+host page `<head>`. All of its rules are scoped to `.commitchange-*` classes
+(no global/element selectors), so it won't affect the rest of the page — **but**
+it includes:
+
+```css
+.commitchange-iframe-embedded { width: 390px; height: 450px; max-width: 100%; border: 0; }
+```
+
+Because CSS overrides HTML `width`/`height` attributes, a hand-written
+`<iframe class="commitchange-iframe-embedded" width="100%" height="600">` will
+be resized to 390×450 once the script loads. To keep a custom size, override it
+after the script:
+
+```html
+<style>.commitchange-iframe-embedded { width: 100% !important; height: 600px !important; }</style>
+```
+
 ## URL construction rules (hand-written iframe)
 
 1. **One `?` only.** It goes after `/donate`. Everything after is joined with
@@ -131,7 +193,7 @@ for you.
 
 ## Key source files
 
-- `client/js/widget/donate-button.v2.js` — button loader; reads `data-*`, builds the URL, renders modal/inline iframe.
+- `client/js/widget/donate-button.v2.js` — button loader; reads `data-*`, builds the URL, renders modal/inline iframe, injects the widget stylesheet, **and installs the parent-window `message` listener that performs iframe redirects** (lines ~190-201).
 - `client/js/nonprofits/donate/wizard/utils/parseDonateParams.ts` — query-string parsing.
 - `client/js/nonprofits/donate/wizard/utils/handleWizardFinished.ts` — redirect + close behavior, `mode=embedded` handling.
 - `client/js/nonprofits/donate/wizard.js` — `skipFinish` trigger, close-button visibility.

--- a/docs/help-center/README.md
+++ b/docs/help-center/README.md
@@ -1,0 +1,29 @@
+# Help Center (Help Scout) article sources
+
+This folder holds the **source content** for customer-facing Help Scout articles
+(`help.commitchange.com`). These markdown files are the version-controlled
+master copy; the live articles are maintained in Help Scout.
+
+## Workflow
+
+1. Draft/update the article as markdown here and merge it.
+2. CSR (Carson) copies the content into Help Scout, sets the title and category,
+   and links the related articles noted at the bottom of each file.
+3. If an article changes in Help Scout, update the markdown here to keep the
+   source in sync.
+
+## Articles
+
+| File | Suggested title | Status |
+|---|---|---|
+| `redirecting-donors-to-a-custom-thank-you-page.md` | Redirecting donors to a custom thank-you page | New — needs to be created in Help Scout |
+
+## Handoff notes for the thank-you-page article
+
+- **Suggested category:** alongside the existing donate-button articles
+  (e.g. "Creating a campaign-specific donate button", article 81).
+- **Related articles to link** (already listed at the bottom of the markdown):
+  campaign-specific donate button, basic donate button, floating donate button,
+  "why isn't my donate button working?".
+- **Engineering reference:** the full parameter list and behavior is documented
+  in `../donation-iframe-embed.md` if deeper detail is needed.

--- a/docs/help-center/redirecting-donors-to-a-custom-thank-you-page.md
+++ b/docs/help-center/redirecting-donors-to-a-custom-thank-you-page.md
@@ -27,12 +27,31 @@ With this method, the donor completes their gift, clicks **Finish**, and is then
 
 ## Option 2 — Custom iframe embed
 
-If you embed the donation form with an iframe, add `redirect` and `skipFinish` as query parameters in the iframe's `src`.
+If you embed the donation form with an iframe, you need **two** things on the page: a small CommitChange helper script, and the iframe itself.
+
+### Step 1 — Add the helper script (required for the redirect to work)
+
+This is the step that's easy to miss. When a donation finishes inside an iframe, the form sends a "go to the thank-you page now" signal out to your website. Your page needs the CommitChange helper script to catch that signal and actually make the jump. **Without it, the donation completes but nothing redirects.**
+
+Add this line to the page, just above the iframe (replace `3728` with your nonprofit ID):
+
+```html
+<script id='commitchange-donation-script' data-npo-id='3728' src='https://commitchange.com/js/donate-button.v2.js'></script>
+```
+
+### Step 2 — Add the iframe
+
+Add `redirect` and `skipFinish` as query parameters in the iframe's `src`.
 
 ```html
 <iframe frameborder="0" class="commitchange-iframe-embedded" width="100%" height="600"
   src="https://us.commitchange.com/nonprofits/3728/donate?campaign_id=6090&amp;mode=embedded&amp;redirect=https://www.example.org/thank-you&amp;skipFinish=t"></iframe>
 ```
+
+> **Heads-up — the form may resize.** The helper script loads CommitChange's styling, which sets the embedded form to about 390px wide by 450px tall. If you want a different size, add this *after* the script:
+> ```html
+> <style>.commitchange-iframe-embedded { width: 100% !important; height: 600px !important; }</style>
+> ```
 
 ### The rules (this is where most mistakes happen)
 
@@ -69,6 +88,7 @@ You can use any free "URL encoder" tool online to do this conversion. Keep UTM v
 
 ## Troubleshooting
 
+- **The redirect doesn't happen (iframe method).** The most common cause is the missing helper script — confirm the `<script ... donate-button.v2.js>` line from Step 1 is on the page, above the iframe. Without it, the donation completes but nothing redirects.
 - **The redirect doesn't happen.** Check that there's only one `?` in your URL and that everything else uses `&` (or `&amp;` in an iframe).
 - **You land on a blank or error page.** Open your thank-you page address directly in a browser first to confirm it loads. If the page itself is broken or blocked, fix that on your website before adding it to the redirect.
 - **Tracking isn't showing up.** Confirm Google Analytics is installed on the thank-you page, and that you URL-encoded the redirect once you added UTM tags.

--- a/docs/help-center/redirecting-donors-to-a-custom-thank-you-page.md
+++ b/docs/help-center/redirecting-donors-to-a-custom-thank-you-page.md
@@ -1,0 +1,83 @@
+# Redirecting donors to a custom thank-you page
+
+After a donation completes, you can send donors to your own custom thank-you page (for example, a page with a special video, a survey, or conversion tracking). This is done with two settings: **redirect** and **skipFinish**.
+
+**Which method should I use?**
+
+- If it's okay for donors to click a **"Finish" button** before being sent to your page, use the **donate button** (Option 1) — it's the easiest and there's nothing to encode.
+- If you want donors sent to your page **automatically and immediately** when their gift completes (skipping the Finish screen), you must use the **custom iframe embed** (Option 2). This is the only method that supports the automatic skip.
+
+---
+
+## Option 1 — Donate button (redirect after "Finish")
+
+If you're using a CommitChange donate button, just add the `data-redirect` attribute. CommitChange handles all the URL formatting for you, so there's nothing to encode.
+
+```html
+<a class='commitchange-donate'
+   data-campaign-id='786'
+   data-redirect='https://www.example.org/thank-you'></a>
+```
+
+- **data-redirect** — the full URL of your thank-you page
+
+With this method, the donor completes their gift, clicks **Finish**, and is then sent to your thank-you page. (The donate button does not support skipping the Finish screen — for that, use Option 2.)
+
+---
+
+## Option 2 — Custom iframe embed
+
+If you embed the donation form with an iframe, add `redirect` and `skipFinish` as query parameters in the iframe's `src`.
+
+```html
+<iframe frameborder="0" class="commitchange-iframe-embedded" width="100%" height="600"
+  src="https://us.commitchange.com/nonprofits/3728/donate?campaign_id=6090&amp;mode=embedded&amp;redirect=https://www.example.org/thank-you&amp;skipFinish=t"></iframe>
+```
+
+### The rules (this is where most mistakes happen)
+
+1. **Use only ONE `?` in the whole URL.** It goes right after `/donate`. Everything after it is joined with `&` (written as `&amp;` inside HTML). A second `?` will break the redirect silently.
+
+   ❌ Wrong: `...custom_amounts=25,50,100?redirect=https://...`
+   ✅ Right: `...custom_amounts=25,50,100&amp;redirect=https://...`
+
+2. **Keep `&amp;` as-is.** Inside an iframe, `&amp;` is the correct way to write `&` — your browser converts it automatically. Don't change it to a plain `&` or anything else, and never type `&amp;` directly into a browser address bar (security firewalls will block it).
+
+3. **`skipFinish` is a CommitChange setting, not part of your thank-you page address.** It stays in the iframe URL; it is not added onto your thank-you page.
+
+---
+
+## Adding tracking (UTM tags) to your thank-you page
+
+If your thank-you page uses Google Analytics, you can tag the redirect so you can see which campaign drove the donation. Use the standard `utm_campaign` tag (plus `utm_source` and `utm_medium` if you like).
+
+**Important:** Once your thank-you page address has its *own* `?` (like a UTM tag), the entire redirect address must be URL-encoded so it doesn't conflict with the donation form's settings.
+
+Your desired thank-you page:
+```
+https://www.example.org/thank-you?utm_source=commitchange&utm_medium=donation&utm_campaign=spring-appeal
+```
+
+URL-encoded for the redirect (this is what goes in the iframe):
+```
+https%3A%2F%2Fwww.example.org%2Fthank-you%3Futm_source%3Dcommitchange%26utm_medium%3Ddonation%26utm_campaign%3Dspring-appeal
+```
+
+You can use any free "URL encoder" tool online to do this conversion. Keep UTM values lowercase with no spaces (Google Analytics treats `Spring` and `spring` as different campaigns).
+
+---
+
+## Troubleshooting
+
+- **The redirect doesn't happen.** Check that there's only one `?` in your URL and that everything else uses `&` (or `&amp;` in an iframe).
+- **You land on a blank or error page.** Open your thank-you page address directly in a browser first to confirm it loads. If the page itself is broken or blocked, fix that on your website before adding it to the redirect.
+- **Tracking isn't showing up.** Confirm Google Analytics is installed on the thank-you page, and that you URL-encoded the redirect once you added UTM tags.
+
+---
+
+### Related articles
+
+- Creating a campaign-specific donate button
+- Basic donate button implementation
+- Floating donate button
+- Why isn't my donate button working?


### PR DESCRIPTION
## What

Adds documentation for the donation form's embed parameters, prompted by a client (Warrior Foundation) hitting the common pitfalls when hand-writing a redirect iframe. None of this was documented anywhere (not the Help Scout KB, not the repo, not the tix/houdini wikis).

### Files
- **`docs/donation-iframe-embed.md`** — engineering source-of-truth. Full table of every embed query param and its `data-*` button equivalent, plus the `redirect` / `skipFinish` / `offsite` interaction and URL-construction rules. Verified against the widget/donate source (file refs included in the doc).
- **`docs/help-center/redirecting-donors-to-a-custom-thank-you-page.md`** — customer-facing Help Scout article source (nonprofit-friendly).
- **`docs/help-center/README.md`** — explains the help-center source folder and contains the CSR handoff notes.

## Key facts documented (verified in code)
- A URL has only **one `?`** — a second `?` silently swallows `redirect` into the previous param (the bug the client hit).
- `&amp;` is HTML encoding, correct inside an iframe `src`; never typed in an address bar, never `%26`-encoded.
- `skipFinish` is **iframe/query-only** — there is no `data-skip-finish` on the donate button.
- The Finish button is gated on `offsite=t` (`followup-step.js`), which is why the button method redirects after "Finish" and the iframe+`skipFinish` redirects automatically.
- The `redirect` value only needs URL-encoding once its destination has its own query string (e.g. UTMs).

## Handoff
- **CSR (Carson):** the Help Scout article is ready to load — see `docs/help-center/README.md` for title/category/related-links.
- Draft PR — docs only, no code changes.
