### PR TITLE
Lock minitest < 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@ updates:
       - dependency-name: sprockets # Sprockets 4.0 stops allowing us to add a proc to the config.assets.precompile array, which we currently use
         versions:
           - ">=4"
+      - dependency-name: minitest # minitest 6 has incompatibilities with Rails, especially old ones. We need to lock that below 6.
+        versions:
+          - ">= 6"
     groups:
       development-dependencies-minor:
         dependency-type: development

--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,8 @@ gem "csv" # needed on Ruby 3.4
 
 gem "maintenance_tasks" # for running useful maintenance scripts that aren't part of a migration
 
+gem "minitest", "< 6" # minitest 6 has some incompatibilities with Rails especially old ones. Let's lock to under 6
+
 group :development, :ci, :test do
   gem "dumpcar"
   gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -680,6 +680,7 @@ DEPENDENCIES
   lograge
   maintenance_tasks
   mini_magick
+  minitest (< 6)
   param_validation!
   pg (~> 1.5.9)
   premailer-rails


### PR DESCRIPTION
**NOTE: DO NOT discuss internal CommitChange information in your PR; this PR will be public.
Link back to the issue in the Tix repo when you need to do that.**

Minitest 6 has some incompatibilities with Rails, especially older rails. This locks us to Minitest 5 so we don't have those issues.
